### PR TITLE
Add README.agda; code checks with agda 2.5.2 and 2.5.3

### DIFF
--- a/MLTT-and-setoids/README.agda
+++ b/MLTT-and-setoids/README.agda
@@ -1,0 +1,63 @@
+-- Erik Palmgren, September 1, 2019
+-- Andreas Abel, November 20, 2020: converted to .agda file, determined Agda version
+
+-- This development requires Agda ≥ 2.5.2, 600 MB free main memory
+-- Tested successfully with the following versions (2020-11-20, contemporary macBook):
+--
+--   - 2.5.2: checks in 2min 15sec
+--   - 2.5.3: checks in 2min 30sec
+--
+-- Unclear status with these versions:
+--
+--   - 2.5.4.2: killed after 90min (stuck on V-model-pt6)
+--   - 2.6.0:   killed after  7min (stuck on V-model-pt6)
+--   - 2.6.1:
+--
+-- Fails with: 2.4.2.x, 2.5.1.1 (and likely with older versions as well)
+
+module README where
+
+-- The following files are relevant for the setoid model
+-- of extensional Martin-Löf type theory
+
+-- general type and setoid constructions
+
+import basic-types
+import basic-setoids
+import dependent-setoids
+import subsetoids
+
+-- Aczel's model of CZF
+
+import iterative-sets
+import iterative-sets-pt2
+import iterative-sets-pt3
+import iterative-sets-pt4
+import iterative-sets-pt5
+import iterative-sets-pt6
+import iterative-sets-pt7
+import iterative-sets-pt8
+
+-- The model
+
+import V-model-pt1
+import V-model-pt2
+import V-model-pt3
+import V-model-pt4
+import V-model-pt5  -- Takes some minutes to check
+import V-model-pt6  -- Takes some minutes to check
+import V-model-pt7
+import V-model-pt8
+import V-model-pt9
+import V-model-pt10
+import V-model-pt13
+import V-model-pt11
+import V-model-pt15
+
+-- top module : all rules interpreted
+
+import V-model-all-rules
+
+-- Unfinished parts
+
+import V-model-pt16    -- Quotient sets

--- a/MLTT-and-setoids/V-model-all-rules.agda
+++ b/MLTT-and-setoids/V-model-all-rules.agda
@@ -10,26 +10,26 @@
 module V-model-all-rules where
 
 open import basic-types
-open import basic-setoids       
-open import dependent-setoids   
-open import subsetoids          
-open import iterative-sets      
-open import iterative-sets-pt2  
-open import iterative-sets-pt3  
+open import basic-setoids
+open import dependent-setoids
+open import subsetoids
+open import iterative-sets
+open import iterative-sets-pt2
+open import iterative-sets-pt3
 open import iterative-sets-pt4
-open import iterative-sets-pt5 
+open import iterative-sets-pt5
 open import iterative-sets-pt6
 open import iterative-sets-pt8
 open import V-model-pt0
-open import V-model-pt1         
-open import V-model-pt2         
-open import V-model-pt3         
-open import V-model-pt4         
-open import V-model-pt5         
-open import V-model-pt6         
-open import V-model-pt7         
-open import V-model-pt8         
-open import V-model-pt9         
+open import V-model-pt1
+open import V-model-pt2
+open import V-model-pt3
+open import V-model-pt4
+open import V-model-pt5
+open import V-model-pt6
+open import V-model-pt7
+open import V-model-pt8
+open import V-model-pt9
 open import V-model-pt10
 open import V-model-pt13
 open import V-model-pt11
@@ -37,51 +37,51 @@ open import V-model-pt15
 
 -- Summary of interpreted rules
 
-E1-tyrefl :  {Γ : ctx} 
+E1-tyrefl :  {Γ : ctx}
 --
-         -> (A : ty Γ) 
+         -> (A : ty Γ)
 -- ------------------------
          -> Γ ==> A == A
 --
 E1-tyrefl =  tyrefl
 
-E2-tysym :  {Γ : ctx} -> {A B : ty Γ} 
+E2-tysym :  {Γ : ctx} -> {A B : ty Γ}
 --
-         -> Γ ==> A == B 
---   -------------------------- 
+         -> Γ ==> A == B
+--   --------------------------
          -> Γ ==> B == A
 --
-E2-tysym = tysym 
+E2-tysym = tysym
 
 
-E3-tytra :  {Γ : ctx} -> {A B C : ty Γ} 
+E3-tytra :  {Γ : ctx} -> {A B C : ty Γ}
 --
-         -> Γ ==> A == B  -> Γ ==> B == C 
+         -> Γ ==> A == B  -> Γ ==> B == C
 --  -------------------------------------
                 -> Γ ==> A == C
 --
-E3-tytra = tytra 
+E3-tytra = tytra
 
 E4-tmrefl :  {Γ : ctx} -> {A : ty Γ}-> {a : raw Γ}
 --
-         -> Γ ==> a :: A  
+         -> Γ ==> a :: A
 --    ------------------------
          -> Γ ==> a == a :: A
 --
-E4-tmrefl = tmrefl 
+E4-tmrefl = tmrefl
 
-E5-tmsym :  {Γ : ctx} -> (A : ty Γ) -> (a b : raw Γ) 
+E5-tmsym :  {Γ : ctx} -> (A : ty Γ) -> (a b : raw Γ)
 --
-         -> Γ ==> a == b :: A 
+         -> Γ ==> a == b :: A
 --    ------------------------
          -> Γ ==> b == a :: A
 --
-E5-tmsym = tmsym 
+E5-tmsym = tmsym
 
 
-E6-tmtra :  {Γ : ctx} -> (A : ty Γ) -> (a b c : raw Γ) 
+E6-tmtra :  {Γ : ctx} -> (A : ty Γ) -> (a b c : raw Γ)
 --
-         -> Γ ==> a == b :: A   -> Γ ==> b == c :: A 
+         -> Γ ==> a == b :: A   -> Γ ==> b == c :: A
 --  --------------------------------------------------
          -> Γ ==> a == c :: A
 --
@@ -94,17 +94,17 @@ E6-tmtra = tmtra
 
 
 
-E10-elttyeq :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ} 
+E10-elttyeq :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ}
 --
-      -> Γ ==> a :: A     -> Γ ==> A == B 
+      -> Γ ==> a :: A     -> Γ ==> A == B
 --  --------------------------------------------
               -> Γ ==> a :: B
 --
-E10-elttyeq =  elttyeq 
+E10-elttyeq =  elttyeq
 
-E11-elteqtyeq :  {Γ : ctx} ->  (a b : raw Γ)  -> (A B : ty Γ) 
+E11-elteqtyeq :  {Γ : ctx} ->  (a b : raw Γ)  -> (A B : ty Γ)
 --
-      -> Γ ==>  a == b :: A    -> Γ ==> A == B 
+      -> Γ ==>  a == b :: A    -> Γ ==> A == B
 --  ---------------------------------------------
               -> Γ ==>  a == b :: B
 --
@@ -117,22 +117,22 @@ E12-subj-red : {Γ : ctx} -> {A : ty Γ} ->  (a b : raw Γ)
 --   -------------------------
      -> Γ ==> b :: A
 --
-E12-subj-red  = subj-red 
+E12-subj-red  = subj-red
 
 
-S1-sub-id-prop : {Γ : ctx}  
+S1-sub-id-prop : {Γ : ctx}
 --
-         -> (a : raw Γ) 
+         -> (a : raw Γ)
 --    ---------------------------------
-      ->  << Raw Γ >> a [ ids ] ~ a  
--- 
+      ->  << Raw Γ >> a [ ids ] ~ a
+--
 S1-sub-id-prop = sub-id-prop
 
 
-S2-sub-comp-prop : {Θ Δ Γ : ctx}  
+S2-sub-comp-prop : {Θ Δ Γ : ctx}
 --
-       -> (a : raw Γ) 
-       -> (f : subst Δ Γ) -> (g : subst Θ Δ) 
+       -> (a : raw Γ)
+       -> (f : subst Δ Γ) -> (g : subst Θ Δ)
 -- --------------------------------------------------
       -> << Raw Θ >>  a [ f ⌢ g ]  ~ (a [ f ] [ g ])
 --
@@ -140,33 +140,33 @@ S2-sub-comp-prop = sub-comp-prop
 
 -- substitution of ctx-trp in to a
 
-S3-subst-trp : {Γ Δ : ctx} 
+S3-subst-trp : {Γ Δ : ctx}
 --
-     ->  (p : << Ctx >> Γ ~ Δ) 
+     ->  (p : << Ctx >> Γ ~ Δ)
 -- -------------------------------
      -> subst Γ Δ
 S3-subst-trp = subst-trp
 
-S4-sub-trp-prop : {Γ : ctx}  
+S4-sub-trp-prop : {Γ : ctx}
 --
-    -> (a : raw Γ)   ->  (p : << Ctx >> Γ ~ Γ) 
+    -> (a : raw Γ)   ->  (p : << Ctx >> Γ ~ Γ)
 -- ---------------------------------------------
     -> << Raw Γ >> a [ subst-trp p ]  ~ a
 --
 S4-sub-trp-prop = sub-trp-prop
 
 
-S5-Sub-id-prop : {Γ : ctx}  
+S5-Sub-id-prop : {Γ : ctx}
 --
         -> (A : ty Γ)
 -- -----------------------------------
-      ->  << Ty Γ >> A [[ ids ]] ~ A   
+      ->  << Ty Γ >> A [[ ids ]] ~ A
 --
 S5-Sub-id-prop  = Sub-id-prop
 
-S6-Sub-comp-prop : {Θ Δ Γ : ctx}  
+S6-Sub-comp-prop : {Θ Δ Γ : ctx}
 --
-       -> (A : ty Γ) 
+       -> (A : ty Γ)
        ->  (f : subst Δ Γ) -> (g : subst Θ Δ) ->
 -- -------------------------------------------------------
        << Ty Θ >>  A [[ f ⌢ g ]]  ~ (A [[ f ]] [[ g ]])
@@ -174,26 +174,26 @@ S6-Sub-comp-prop : {Θ Δ Γ : ctx}
 S6-Sub-comp-prop = Sub-comp-prop
 
 
-S7-tyeq-subst :  {Δ Γ : ctx} -> {A B : ty Γ} -> (f : subst Δ Γ) 
+S7-tyeq-subst :  {Δ Γ : ctx} -> {A B : ty Γ} -> (f : subst Δ Γ)
 --
-                  -> Γ ==> A == B 
---      -------------------------------------------------- 
+                  -> Γ ==> A == B
+--      --------------------------------------------------
          -> Δ ==> A [[ f ]] ==  B [[ f ]]
 --
 S7-tyeq-subst = tyeq-subst
 
-S8-elt-subst :  {Δ Γ : ctx} -> {a : raw Γ} -> {A : ty Γ} -> (f : subst Δ Γ) 
+S8-elt-subst :  {Δ Γ : ctx} -> {a : raw Γ} -> {A : ty Γ} -> (f : subst Δ Γ)
 --
-          -> Γ ==> a :: A 
---   -------------------------------------------------------- 
+          -> Γ ==> a :: A
+--   --------------------------------------------------------
          -> Δ ==> a [ f ] ::  A [[ f ]]
 --
 S8-elt-subst = elt-subst
 
 
-S9-elteq-subst :  {Δ Γ : ctx} -> {a b : raw Γ} -> {A : ty Γ} 
+S9-elteq-subst :  {Δ Γ : ctx} -> {a b : raw Γ} -> {A : ty Γ}
 --
-          -> (f : subst Δ Γ)   -> Γ ==> a == b :: A 
+          -> (f : subst Δ Γ)   -> Γ ==> a == b :: A
 --   --------------------------------------------------------------------------
          -> Δ ==> a [ f ] == b [ f ] :: A [[ f ]]
 --
@@ -203,12 +203,12 @@ S9-elteq-subst = elteq-subst
 S10-tyeq-subst2 :  {Δ Γ : ctx}
 --
         -> (A : ty Γ)   -> (f g : subst Δ Γ)    -> < Subst Δ Γ > f ~ g
---      -------------------------------------------------- 
+--      --------------------------------------------------
          -> Δ ==> A [[ f ]] ==  A [[ g ]]
 --
 S10-tyeq-subst2 = tyeq-subst2
 
-S9b-elteq-subst2 :  {Δ Γ : ctx} -> {a  : raw Γ} -> {A : ty Γ} -> (f  g : subst Δ Γ) 
+S9b-elteq-subst2 :  {Δ Γ : ctx} -> {a  : raw Γ} -> {A : ty Γ} -> (f  g : subst Δ Γ)
 --
            -> Γ ==> a :: A
            -> < Subst Δ Γ > f ~ g
@@ -219,11 +219,11 @@ S9b-elteq-subst2 = elteq-subst2
 
 S11-tysubst-id : {Γ : ctx}
 --
-        -> (A  : ty Γ) 
+        -> (A  : ty Γ)
 --   -------------------------
      -> Γ ==> (A [[ ids ]]) == A
 --
-S11-tysubst-id = tysubst-id 
+S11-tysubst-id = tysubst-id
 
 S12-tysubst-com : {Θ Δ Γ : ctx}
 --
@@ -256,25 +256,25 @@ S14-eltsubst-com : {Θ Δ Γ : ctx}
 S14-eltsubst-com = eltsubst-com
 
 
-S15-subst-trp-id :  {Γ : ctx} 
+S15-subst-trp-id :  {Γ : ctx}
 --
-       ->  (p : << Ctx >> Γ ~ Γ) 
+       ->  (p : << Ctx >> Γ ~ Γ)
 -- -------------------------------------------
       -> < Subst Γ Γ > subst-trp p ~ ids {Γ}
 --
 S15-subst-trp-id = subst-trp-id
 
 S16-subst-trp-irr :  {Γ Δ : ctx}
--- 
-      ->  (p q : << Ctx >> Γ ~ Δ) 
+--
+      ->  (p q : << Ctx >> Γ ~ Δ)
 -- ----------------------------------------------
       -> < Subst Γ Δ > subst-trp p ~ subst-trp q
 --
-S16-subst-trp-irr  = subst-trp-irr 
+S16-subst-trp-irr  = subst-trp-irr
 
-S17-subst-trp-fun :  {Γ Δ  Θ : ctx} 
--- 
-    ->  (p : << Ctx >> Γ ~ Δ)   ->  (q : << Ctx >> Δ ~ Θ) 
+S17-subst-trp-fun :  {Γ Δ  Θ : ctx}
+--
+    ->  (p : << Ctx >> Γ ~ Δ)   ->  (q : << Ctx >> Δ ~ Θ)
     ->  (r : << Ctx >> Γ ~ Θ)
 -- ----------------------------------------------------------------
     -> < Subst Γ Θ > ((subst-trp q) ⌢ (subst-trp p)) ~ subst-trp r
@@ -283,9 +283,9 @@ S17-subst-trp-fun = subst-trp-fun
 
 
 
-C1-↓ : {Γ : ctx} 
--- 
-      -> (A : ty Γ) 
+C1-↓ : {Γ : ctx}
+--
+      -> (A : ty Γ)
 -- ---------------------
      -> subst (Γ ▷ A) Γ
 --
@@ -293,66 +293,66 @@ C1-↓ = ↓
 
 C2-asm : {Γ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
 --   --------------------------------------------------------
       -> Γ ▷ A ==> vv A :: A [[ ↓ A ]]
 --
 C2-asm = asm
 
-C3-ext : {Δ Γ : ctx} 
+C3-ext : {Δ Γ : ctx}
 --
-      -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+      -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> Δ ==> a :: A [[ f ]]
 -- ------------------------------------
       -> subst Δ (Γ ▷ A)
 --
 C3-ext = ext
 
-C4-ext-irr : {Δ Γ : ctx} 
+C4-ext-irr : {Δ Γ : ctx}
 --
-      -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+      -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (q : Δ ==> a :: A [[ f ]])
 -- ----------------------------------------
-      -> < Subst Δ (Γ ▷ A) >  (ext A f a p) ~  (ext A f a q) 
+      -> < Subst Δ (Γ ▷ A) >  (ext A f a p) ~  (ext A f a q)
 --
 C4-ext-irr = ext-irr
 
-C5-ext-prop1 : {Δ Γ : ctx} 
+C5-ext-prop1 : {Δ Γ : ctx}
 --
-      -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+      -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
 -- ----------------------------------------------------
       -> < Subst Δ Γ >  ((↓ A) ⌢ (ext A f a p)) ~ f
 --
 C5-ext-prop1 = ext-prop1
 
-C6-ext-prop2 : {Δ Γ : ctx} 
+C6-ext-prop2 : {Δ Γ : ctx}
 --
-      -> (A : ty Γ) 
-      ->  (f : subst Δ Γ) -> (a : raw Δ) 
+      -> (A : ty Γ)
+      ->  (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
 -- ----------------------------------------------------
       -> << Raw Δ >>  (vv A) [ ext A f a p ] ~ a
 C6-ext-prop2 = ext-prop2
 
 
-C7-ext-prop3 : {Γ : ctx} 
+C7-ext-prop3 : {Γ : ctx}
 --
-       -> (A : ty Γ) 
+       -> (A : ty Γ)
 -- -----------------------------------------------------------------------------
      ->   < Subst (Γ ▷ A) (Γ ▷ A) >  (ext A (↓ A) (vv A) (asm A)) ~ ids {Γ ▷ A}
 --
 C7-ext-prop3 = ext-prop3
 
 
-C9-ext-prop4 : {Θ Δ Γ : ctx} 
+C9-ext-prop4 : {Θ Δ Γ : ctx}
 --
-      -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+      -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (h : subst Θ Δ)
 --  --------------------------
@@ -362,20 +362,20 @@ C9-ext-prop4 : {Θ Δ Γ : ctx}
 C9-ext-prop4 = ext-prop4
 
 
-C10-ext-prop4-gen : {Θ Δ Γ : ctx} -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+C10-ext-prop4-gen : {Θ Δ Γ : ctx} -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (h : subst Θ Δ)
       -> (q : Θ ==> a [ h ] :: A [[ f ⌢ h ]])
 --    --------------------------------------------
       -> < Subst Θ (Γ ▷ A) > ((ext A f a p) ⌢ h) ~ (ext A (f ⌢ h) (a [ h ]) q)
 --
-C10-ext-prop4-gen = ext-prop4-lm2 
+C10-ext-prop4-gen = ext-prop4-lm2
 
 
 C10-ext-eq : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (Γ ==> A == A')
 -- --------------------------
       -> (Γ ▷ A) ≐ (Γ ▷ A')
@@ -384,10 +384,10 @@ C10-ext-eq = ext-eq
 
 
 
-C11-els  :  
-       {Γ : ctx} 
+C11-els  :
+       {Γ : ctx}
 --
-    -> {A : ty Γ}   
+    -> {A : ty Γ}
     -> {a : raw Γ}
     -> (Γ ==> a :: A)
 -- -------------------------
@@ -396,24 +396,24 @@ C11-els  :
 C11-els = els
 
 
-C12-↑ :  {Δ Γ : ctx}  
+C12-↑ :  {Δ Γ : ctx}
 --
-    -> (A : ty Γ)    -> (h : subst Δ Γ) 
+    -> (A : ty Γ)    -> (h : subst Δ Γ)
 -- -------------------------------------
      -> subst (Δ ▷ (A [[ h ]])) (Γ ▷ A)
 --
-C12-↑ = ↑ 
+C12-↑ = ↑
 
 
-P1-Π-f :  {Γ : ctx} 
+P1-Π-f :  {Γ : ctx}
 --
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
 --     ---------------------------------------
        -> ty Γ
--- 
+--
 P1-Π-f = Π-f
 
-P2-Π-f-rcong :  {Γ : ctx} 
+P2-Π-f-rcong :  {Γ : ctx}
 --
        -> (A : ty Γ)   -> (B B' : ty (Γ ▷ A))
        -> (Γ ▷ A ==> B == B')
@@ -421,29 +421,29 @@ P2-Π-f-rcong :  {Γ : ctx}
        -> (Γ  ==>  Π-f A B == Π-f A B')
 P2-Π-f-rcong = Π-f-rcong
 
-P3-Π-i  :  {Γ : ctx} 
+P3-Π-i  :  {Γ : ctx}
 --
        -> (A : ty Γ)   -> {B : ty (Γ ▷ A)}
        -> {b : raw (Γ ▷ A)}
        -> Γ ▷ A ==> b :: B
 --  -----------------------------------------
         -> Γ ==> lambda A B b :: Π-f A B
--- 
+--
 P3-Π-i = Π-i
 
 
-P4-Π-xi  :  {Γ : ctx} 
+P4-Π-xi  :  {Γ : ctx}
        -> (A : ty Γ)   -> {B : ty (Γ ▷ A)}
        -> {b : raw (Γ ▷ A)}
        -> {b' : raw (Γ ▷ A)}
        -> (r : Γ ▷ A ==> b == b' :: B)
 --  -----------------------------------------
         -> Γ ==> lambda A B b ==  lambda A B b' :: Π-f A B
--- 
+--
 P4-Π-xi = Π-xi
 
 
-P5-Π-e :  {Γ : ctx} 
+P5-Π-e :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -452,9 +452,9 @@ P5-Π-e :  {Γ : ctx}
 --  -----------------------------------------
     ->  Γ ==> app A B c p a q :: B [[ els q ]]
 --
-P5-Π-e = Π-e 
+P5-Π-e = Π-e
 
-P6-Π-e-cong :  {Γ : ctx} 
+P6-Π-e-cong :  {Γ : ctx}
 --
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c c' : raw Γ)
@@ -468,9 +468,9 @@ P6-Π-e-cong :  {Γ : ctx}
 --  -----------------------------------------
     ->  Γ ==> app A B c p a q == app A B c' p' a' q'  :: B [[ els q ]]
 --
-P6-Π-e-cong = Π-e-cong 
+P6-Π-e-cong = Π-e-cong
 
-P7-Π-beta :  {Γ : ctx} 
+P7-Π-beta :  {Γ : ctx}
 --
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
@@ -478,12 +478,12 @@ P7-Π-beta :  {Γ : ctx}
        -> (a : raw Γ)
        -> (q : Γ ==> a :: A)
 --  -----------------------------------------
-       ->  Γ ==> app A B (lambda A B b) (Π-i A p) a q  
+       ->  Γ ==> app A B (lambda A B b) (Π-i A p) a q
              ==  b [ els q ] :: B [[ els q ]]
 --
 P7-Π-beta = Π-beta
 
-P8-Π-beta-gen :  {Γ : ctx} 
+P8-Π-beta-gen :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
        -> (p : Γ ▷ A ==> b :: B)
@@ -491,7 +491,7 @@ P8-Π-beta-gen :  {Γ : ctx}
        -> (a : raw Γ)
        -> (q : Γ ==> a :: A)
 --  -----------------------------------------
-       ->  Γ ==> app A B (lambda A B b) r a q  
+       ->  Γ ==> app A B (lambda A B b) r a q
              ==  b [ els q ] :: B [[ els q ]]
 --
 P8-Π-beta-gen = Π-beta-gen
@@ -499,15 +499,15 @@ P8-Π-beta-gen = Π-beta-gen
 
 
 
-P9-Π-f-sub :  {Δ Γ : ctx} 
+P9-Π-f-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ) 
+       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ)
 --     ---------------------------------------
-       -> Δ ==>  (Π-f A B) [[ h ]] ==  Π-f (A [[ h ]]) (B [[ ↑ A h ]]) 
+       -> Δ ==>  (Π-f A B) [[ h ]] ==  Π-f (A [[ h ]]) (B [[ ↑ A h ]])
 --
-P9-Π-f-sub = Π-f-sub 
+P9-Π-f-sub = Π-f-sub
 
-P10-lambda-sub  :  {Δ Γ : ctx} 
+P10-lambda-sub  :  {Δ Γ : ctx}
 --
        -> (A : ty Γ)   -> {B : ty (Γ ▷ A)}
        -> {b : raw (Γ ▷ A)}
@@ -521,7 +521,7 @@ P10-lambda-sub = lambda-sub
 
 
 
-P11-Π-eta-left2 :  {Γ : ctx}  
+P11-Π-eta-left2 :  {Γ : ctx}
 --
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
@@ -531,55 +531,55 @@ P11-Π-eta-left2 :  {Γ : ctx}
 --
 P11-Π-eta-left2 = Π-eta-left2
 
-P12-Π-eta-left3 :  {Γ : ctx}  
+P12-Π-eta-left3 :  {Γ : ctx}
 --
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
 -- --------------------------------------------------------------------------------
-    -> (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]))  
---  
-P12-Π-eta-left3 = Π-eta-left3 
+    -> (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]))
+--
+P12-Π-eta-left3 = Π-eta-left3
 
 
-P13-Π-eta-eq :  {Γ : ctx}  
+P13-Π-eta-eq :  {Γ : ctx}
 --
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
 -- ------------------------------------------------------
-    -> Γ ==> lambda A B (app (A [[ ↓ A ]]) 
+    -> Γ ==> lambda A B (app (A [[ ↓ A ]])
                              (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             (Π-eta-left3 {Γ} A B c p)  
-                             (vv A) 
-                             (Π-eta-left2 {Γ} A B c p))  
+                             (Π-eta-left3 {Γ} A B c p)
+                             (vv A)
+                             (Π-eta-left2 {Γ} A B c p))
              == c ::  Π-f {Γ} A B
 --
 P13-Π-eta-eq = Π-eta-eq
 
 -- More general rule where RHS doesn't depend on Π-eta-left{3,2}:
 
-P14-Π-eta-eq-gen :  {Γ : ctx}  
+P14-Π-eta-eq-gen :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
 
     -> (q1 : (Γ ▷ A) ==> vv A ::  A [[ ↓ A ]])
-    -> (q2 : (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])))     
-    -> Γ ==> lambda A B (app (A [[ ↓ A ]]) 
+    -> (q2 : (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])))
+    -> Γ ==> lambda A B (app (A [[ ↓ A ]])
                              (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             q2  
-                             (vv A) 
-                             q1)  
+                             q2
+                             (vv A)
+                             q1)
              == c ::  Π-f {Γ} A B
 P14-Π-eta-eq-gen = Π-eta-eq-gen
 
 
 P15-Π-f-cong : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (p : Γ ==> A == A')
       -> (B : ty (Γ ▷ A))
       -> (B' : ty (Γ ▷ A'))
@@ -595,12 +595,12 @@ P15-Π-f-cong = Π-f-cong
 
 I1-ID : {Γ : ctx}
 --
-     -> (A : ty Γ) 
+     -> (A : ty Γ)
      -> (a : raw Γ)
      -> (p : Γ ==> a :: A)
      -> (b : raw Γ)
-     -> (q : Γ ==> b :: A)   
--- ----------------------------- 
+     -> (q : Γ ==> b :: A)
+-- -----------------------------
      -> ty Γ
 
 I1-ID = ID
@@ -616,7 +616,7 @@ I2-ID-i : {Γ : ctx}
 I2-ID-i = ID-i
 
 I3-ID-e : {Γ : ctx}
--- 
+--
      -> (A : ty Γ)
      -> (a b t : raw Γ)
      -> (p : Γ ==> a :: A)
@@ -628,7 +628,7 @@ I3-ID-e : {Γ : ctx}
 I3-ID-e = ID-e
 
 I4-ID-uip : {Γ : ctx}
--- 
+--
      -> (A : ty Γ)
      -> (a b t : raw Γ)
      -> (p : Γ ==> a :: A)
@@ -644,7 +644,7 @@ I5-rr-sub :  {Δ Γ : ctx}
 --
      -> (h : subst Δ Γ)
      -> (A : ty Γ)
-     -> (a : raw Γ)    
+     -> (a : raw Γ)
      -> (p : Γ ==> a :: A)
 -- ---------------------------------------------
      -> Δ ==> (rr a) [ h ] == rr (a [ h ]) ::  (ID A a p a p) [[ h ]]
@@ -656,11 +656,11 @@ I5-rr-sub = rr-sub
 I6-rr-cong :  {Γ : ctx}
 --
      -> (A : ty Γ)
-     -> (a  b : raw Γ) 
+     -> (a  b : raw Γ)
      -> (p : Γ ==> a :: A)
      -> (Γ ==> a == b :: A)
 -- --------------------------------
-     -> Γ ==> (rr a) == (rr b) ::  (ID A a p a p) 
+     -> Γ ==> (rr a) == (rr b) ::  (ID A a p a p)
 --
 I6-rr-cong = rr-cong
 
@@ -668,14 +668,14 @@ I7-ID-sub :  {Δ Γ : ctx}
 --
      -> (h : subst Δ Γ)
      -> (A : ty Γ)
-     -> (a : raw Γ) 
-     -> (pa : Γ ==> a :: A) 
-     -> (b : raw Γ) 
-     -> (pb : Γ ==> b :: A) 
+     -> (a : raw Γ)
+     -> (pa : Γ ==> a :: A)
+     -> (b : raw Γ)
+     -> (pb : Γ ==> b :: A)
 -- --------------------------------------------------------------------------
      -> << Ty Δ >> (ID A a pa b pb) [[ h ]] ~
            (ID (A [[ h ]]) (a [ h ]) (elt-subst h pa) (b [ h ]) (elt-subst h pb))
--- 
+--
 I7-ID-sub = ID-sub
 
 -- More general rule where RHS doesn't depend on elt-subst:
@@ -686,10 +686,10 @@ I7-ID-sub = ID-sub
 I8-ID-sub-gen :  {Δ Γ : ctx}
      -> (h : subst Δ Γ)
      -> (A : ty Γ)
-     -> (a : raw Γ) 
-     -> (pa : Γ ==> a :: A) 
-     -> (b : raw Γ) 
-     -> (pb : Γ ==> b :: A) 
+     -> (a : raw Γ)
+     -> (pa : Γ ==> a :: A)
+     -> (b : raw Γ)
+     -> (pb : Γ ==> b :: A)
      -> (q : Δ ==> a [ h ] :: A [[ h ]])
      -> (r : Δ ==> b [ h ] :: A [[ h ]])
      -> Δ ==>  (ID A a pa b pb) [[ h ]] == (ID (A [[ h ]]) (a [ h ]) q (b [ h ]) r)
@@ -702,7 +702,7 @@ I8-ID-sub-gen =  ID-sub-gen
 I9-ID-cong :  {Γ : ctx}
 --
      -> (A A' : ty Γ)
-     -> (a b a' b' : raw Γ) 
+     -> (a b a' b' : raw Γ)
      -> (pa : Γ ==> a :: A)
      -> (pa' : Γ ==> a' :: A')
      -> (pb : Γ ==> b :: A)
@@ -716,7 +716,7 @@ I9-ID-cong = ID-cong
 
 
 
-Sg1-Σ-f :  {Γ : ctx} 
+Sg1-Σ-f :  {Γ : ctx}
 --
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
 -- -------------------------------------------
@@ -726,7 +726,7 @@ Sg1-Σ-f = Σ-f
 
 Sg2-Σ-f-cong : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (p : Γ ==> A == A')
       -> (B : ty (Γ ▷ A))
       -> (B' : ty (Γ ▷ A'))
@@ -740,9 +740,9 @@ Sg2-Σ-f-cong = Σ-f-cong
 
 Sg3-Σ-i : {Γ : ctx}
 --
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))
@@ -753,18 +753,18 @@ Sg3-Σ-i = Σ-i
 
 Sg4-Σ-e-1 : {Γ : ctx}
 --
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
 -- -------------------------------------------
       -> Γ ==> pr1 A B c p :: A
 --
-Sg4-Σ-e-1  = Σ-e-1 
+Sg4-Σ-e-1  = Σ-e-1
 
 Sg5-Σ-e-2 : {Γ : ctx}
 --
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -772,13 +772,13 @@ Sg5-Σ-e-2 : {Γ : ctx}
 -- --------------------------------------------
       -> Γ ==> pr2 A B c p :: B [[ els q ]]
 --
-Sg5-Σ-e-2 = Σ-e-2 
+Sg5-Σ-e-2 = Σ-e-2
 
 Sg6-Σ-c-1 : {Γ : ctx}
 --
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))
@@ -790,9 +790,9 @@ Sg6-Σ-c-1 = Σ-c-1
 
 Sg7-Σ-c-2 : {Γ : ctx}
 --
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))
@@ -803,8 +803,8 @@ Sg7-Σ-c-2 : {Γ : ctx}
 Sg7-Σ-c-2 = Σ-c-2
 
 Sg8-Σ-c-eta : {Γ : ctx}
--- 
-      -> (A  : ty Γ) 
+--
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -814,34 +814,34 @@ Sg8-Σ-c-eta : {Γ : ctx}
 Sg8-Σ-c-eta = Σ-c-eta
 
 
-Sg8-Σ-f-sub :  {Δ Γ : ctx} 
+Sg8-Σ-f-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ) 
+       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ)
 --     ---------------------------------------
-       -> Δ ==>  (Σ-f A B) [[ h ]] ==  Σ-f (A [[ h ]]) (B [[ ↑ A h ]]) 
+       -> Δ ==>  (Σ-f A B) [[ h ]] ==  Σ-f (A [[ h ]]) (B [[ ↑ A h ]])
 --
 Sg8-Σ-f-sub = Σ-f-sub
 
 -- Natural numbers
 
 
-N1-Nat-i-O : (Γ : ctx) -> 
+N1-Nat-i-O : (Γ : ctx) ->
 --  -------------------------------------------
           Γ ==> zero Γ :: Nat Γ
 --
-N1-Nat-i-O =  Nat-i-O 
+N1-Nat-i-O =  Nat-i-O
 
 
 
-N2-Nat-i-s : (Γ : ctx) 
+N2-Nat-i-s : (Γ : ctx)
         -> (a : raw Γ)
-        -> (Γ ==> a :: Nat Γ)      
+        -> (Γ ==> a :: Nat Γ)
 --  -------------------------------------------
        ->  Γ ==> succ Γ a :: Nat Γ
 --
 N2-Nat-i-s = Nat-i-s
 
-N3-Nat-e : {Γ : ctx} 
+N3-Nat-e : {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (d : raw Γ)
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
@@ -850,10 +850,10 @@ N3-Nat-e : {Γ : ctx}
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> Γ ==> Rec C d p e q c r :: C [[ els r ]]
-N3-Nat-e = Nat-e 
+N3-Nat-e = Nat-e
 
 
-N4-Nat-c-O : {Γ : ctx} 
+N4-Nat-c-O : {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (d : raw Γ)
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
@@ -862,7 +862,7 @@ N4-Nat-c-O : {Γ : ctx}
       -> Γ ==> Rec C d p e q (zero Γ) (Nat-i-O Γ) == d :: C [[ els (Nat-i-O Γ)]]
 N4-Nat-c-O = Nat-c-O
 
-N5-Nat-c-s : {Γ : ctx} 
+N5-Nat-c-s : {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (d : raw Γ)
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
@@ -870,10 +870,10 @@ N5-Nat-c-s : {Γ : ctx}
       -> (q : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]])
       -> (a : raw Γ)
       -> (r : Γ ==> a :: Nat Γ)
-      -> Γ ==> Rec C d p e q (succ Γ a) (Nat-i-s Γ a r) 
-           == e [  ext C (els r) (Rec C d p e q a r) (Nat-e {Γ} C d p e q a r) ] 
+      -> Γ ==> Rec C d p e q (succ Γ a) (Nat-i-s Γ a r)
+           == e [  ext C (els r) (Rec C d p e q a r) (Nat-e {Γ} C d p e q a r) ]
                  :: C [[ els (Nat-i-s Γ a r)]]
-N5-Nat-c-s = Nat-c-s 
+N5-Nat-c-s = Nat-c-s
 
 N6-Rec-cong : {Γ : ctx}
       -> (C C' : ty (Γ ▷ Nat Γ))
@@ -892,7 +892,7 @@ N6-Rec-cong : {Γ : ctx}
       -> << Raw ((Γ ▷ Nat Γ) ▷ C) >> e ~ (e' [ subst-trp (ext-eq' {Γ ▷ Nat Γ} C C' Cq) ])
       -> << Raw Γ >> c ~ c'
       -> << Raw Γ >>  Rec {Γ} C d p e q c r ~ Rec {Γ} C' d' p' e' q' c' r'
-N6-Rec-cong  =   Rec-cong' 
+N6-Rec-cong  =   Rec-cong'
 
 N7-Nat-sub :  (Δ Γ : ctx) -> (f : subst Δ Γ)
     -> Δ ==> (Nat Γ) [[ f ]] == (Nat Δ)
@@ -915,15 +915,15 @@ N10-Rec-sub : {Δ Γ : ctx}
       -> (p' : Δ ==> (d [ f ]) :: C [[  N-sub f  ]] [[ els (Nat-i-O Δ) ]])
       -> (e : raw ((Γ ▷ Nat Γ) ▷ C))
       -> (q  : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]])
-      -> (q' : (Δ ▷ Nat Δ ) ▷ (C [[ N-sub f ]])  ==> e [ C-sub f C ] ::  
+      -> (q' : (Δ ▷ Nat Δ ) ▷ (C [[ N-sub f ]])  ==> e [ C-sub f C ] ::
            C [[  N-sub f  ]] [[ step-sub Δ ]] [[ ↓ ( C [[  N-sub f  ]]) ]])
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> (r' : Δ ==> (c [ f ]) :: (Nat Γ) [[ f ]])
       -> << Raw Δ >> ((Rec {Γ} C d p e q c r) [ f ])
-                   ~ (Rec {Δ} (C [[  N-sub f  ]]) 
+                   ~ (Rec {Δ} (C [[  N-sub f  ]])
                               (d [ f ]) p' (e [ C-sub f C ])  q' (c [ f ]) r')
-N10-Rec-sub  = Rec-sub' 
+N10-Rec-sub  = Rec-sub'
 
 
 
@@ -932,7 +932,7 @@ Empty1-N0-sub :  (Δ Γ : ctx) -> (f : subst Δ Γ)
     -> Δ ==> (N0 Γ) [[ f ]] == (N0 Δ)
 Empty1-N0-sub = N0-sub
 
-Empty2-N0-e : {Γ : ctx} 
+Empty2-N0-e : {Γ : ctx}
       -> (C : ty (Γ ▷ N0 Γ))
       -> (c : raw Γ)
       -> (r : Γ ==> c :: N0 Γ)
@@ -984,7 +984,7 @@ Sm3-Sum-sub : {Δ Γ : ctx}
    -> (A : ty Γ)
    -> (B : ty Γ)
 -- ----------------------------------------------------------
-   -> Δ ==> (Sum A B) [[ f ]] == Sum (A [[ f ]]) (B [[ f ]]) 
+   -> Δ ==> (Sum A B) [[ f ]] == Sum (A [[ f ]]) (B [[ f ]])
 --
 Sm3-Sum-sub  = Sum-sub
 
@@ -1007,7 +1007,7 @@ Sm5-rg-pf : {Γ : ctx}
    -> (p : Γ ==> b :: B)
 -- ---------------------------------
    -> Γ ==> rg A B b p :: Sum A B
--- 
+--
 Sm5-rg-pf = rg-pf
 
 
@@ -1021,7 +1021,7 @@ Sm6-lf-cong : {Γ : ctx}
    -> (r : Γ ==> B == B')
    -> (Γ ==> a == a' :: A)
 -- --------------------------------------------------------
-   -> Γ ==> lf {Γ} A B a p == lf {Γ} A' B' a' p' :: Sum A B 
+   -> Γ ==> lf {Γ} A B a p == lf {Γ} A' B' a' p' :: Sum A B
 --
 Sm6-lf-cong = lf-cong
 
@@ -1033,7 +1033,7 @@ Sm7-lf-sub : {Δ Γ : ctx}
    -> (p : Γ ==> a :: A)
    -> (p' : Δ ==> a [ h ] :: A [[ h ]])
    ->  Δ ==> (lf A B a p) [ h ] == lf (A [[ h ]])  (B [[ h ]]) (a [ h ]) p' :: (Sum A B) [[ h ]]
-Sm7-lf-sub = lf-sub 
+Sm7-lf-sub = lf-sub
 
 Sm8-rg-cong : {Γ : ctx}
 --
@@ -1045,7 +1045,7 @@ Sm8-rg-cong : {Γ : ctx}
    -> (r : Γ ==> B == B')
    -> (Γ ==> b == b' :: B)
 -- ---------------------------------------------------------
-   -> Γ ==> rg {Γ} A B b p == rg {Γ} A' B' b' p' :: Sum A B 
+   -> Γ ==> rg {Γ} A B b p == rg {Γ} A' B' b' p' :: Sum A B
 --
 Sm8-rg-cong = rg-cong
 
@@ -1062,8 +1062,8 @@ Sm9-rg-sub = rg-sub
 
 
 
-Sm10-Sum-e : {Γ : ctx} 
---  
+Sm10-Sum-e : {Γ : ctx}
+--
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -1079,7 +1079,7 @@ Sm10-Sum-e = Sum-e
 
 
 
-Sm11-Sum-c1 : {Γ : ctx}   
+Sm11-Sum-c1 : {Γ : ctx}
 --
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
@@ -1095,7 +1095,7 @@ Sm11-Sum-c1 : {Γ : ctx}
 --
 Sm11-Sum-c1 = Sum-c1
 
-Sm12-Sum-c2 : {Γ : ctx}   
+Sm12-Sum-c2 : {Γ : ctx}
 --
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
@@ -1111,8 +1111,8 @@ Sm12-Sum-c2 : {Γ : ctx}
 --
 Sm12-Sum-c2 =  Sum-c2
 
-Sm13-Sum-rec-cong : {Γ : ctx}   
--- 
+Sm13-Sum-rec-cong : {Γ : ctx}
+--
        -> (A B A' B' : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (C' : ty (Γ ▷ (Sum A' B')))
@@ -1131,9 +1131,9 @@ Sm13-Sum-rec-cong : {Γ : ctx}
        -> (Aq : Γ ==> A == A')
        -> (Bq : Γ ==> B == B')
        -> (Γ ▷ (Sum A B)  ==> C == C' [[  subst-trp (ext-eq' {Γ} (Sum A B) (Sum A' B') (Sum-cong A A' B B' Aq Bq)) ]])
-       -> ((Γ ▷ A) ==> d == (d' [ subst-trp (ext-eq' {Γ} A A' Aq) ]) :: C [[ Sum-sub-lf A B ]]) 
-       -> ((Γ ▷ B) ==> e == (e' [ subst-trp (ext-eq' {Γ} B B' Bq) ]) :: C [[ Sum-sub-rg A B ]]) 
-       -> (Γ ==> c == c' :: Sum A B) 
+       -> ((Γ ▷ A) ==> d == (d' [ subst-trp (ext-eq' {Γ} A A' Aq) ]) :: C [[ Sum-sub-lf A B ]])
+       -> ((Γ ▷ B) ==> e == (e' [ subst-trp (ext-eq' {Γ} B B' Bq) ]) :: C [[ Sum-sub-rg A B ]])
+       -> (Γ ==> c == c' :: Sum A B)
 -- --------------------------------------------------------------------------------------------
        -> Γ ==>  Sum-rec {Γ} A B C d p e q c r == Sum-rec {Γ} A' B' C' d' p' e' q' c' r' :: C [[ els r ]]
 Sm13-Sum-rec-cong = Sum-rec-cong
@@ -1141,7 +1141,7 @@ Sm13-Sum-rec-cong = Sum-rec-cong
 
 
 Sm14-Sum-rec-sub : {Δ Γ : ctx}
-       -> (h : subst Δ Γ)   
+       -> (h : subst Δ Γ)
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -1164,8 +1164,8 @@ Sm14-Sum-rec-sub : {Δ Γ : ctx}
                 (Sum-sub-rg {Δ} (_[[_]] {Δ} {Γ} A h) (_[[_]] {Δ} {Γ} B h)))
        -> (r' : Δ ==> c [ h ] :: Sum (A [[ h ]]) (B [[ h ]]))
        ->  Δ ==> ((Sum-rec {Γ} A B C d p e q c r) [ h ])
-                     ==  (Sum-rec {Δ} (A [[ h ]]) (B [[ h ]]) (C [[ ↑ {Δ} {Γ} (Sum A B) h ]]) 
-                                    (d [ ↑  A h ]) p' (e [ ↑ B h ]) q' (c [ h ]) r') 
+                     ==  (Sum-rec {Δ} (A [[ h ]]) (B [[ h ]]) (C [[ ↑ {Δ} {Γ} (Sum A B) h ]])
+                                    (d [ ↑  A h ]) p' (e [ ↑ B h ]) q' (c [ h ]) r')
                        ::  C [[ els r ]] [[ h ]]
 Sm14-Sum-rec-sub = Sum-rec-sub
 
@@ -1175,27 +1175,27 @@ Sm14-Sum-rec-sub = Sum-rec-sub
 
 -- Universe hierarchy à la Russell
 
-U1-T-eq- : (k : N) 
-     -> {Γ : ctx}  
+U1-T-eq- : (k : N)
+     -> {Γ : ctx}
      -> (A : raw Γ)
      -> (p : Γ ==> A :: U- k Γ)
 -- -------------------------------
      ->  Γ ==> T- k A p == A
 --
-U1-T-eq- = T-eq- 
+U1-T-eq- = T-eq-
 
 
-U2-U-nat- : (k : N) ->  (Γ : ctx) 
+U2-U-nat- : (k : N) ->  (Γ : ctx)
 -- -----------------------------------
     -> Γ ==> Nat Γ :: U- k Γ
 --
 U2-U-nat- = U-nat-
- 
 
 
-U3-U-sigma- :   (k : N) -> {Γ : ctx} 
+
+U3-U-sigma- :   (k : N) -> {Γ : ctx}
 --
-    ->  (A : ty Γ) 
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U- k Γ [[ ↓ A ]])
@@ -1206,9 +1206,9 @@ U3-U-sigma-  = U-sigma-
 
 
 
-U4-U-pi- : (k : N) -> {Γ : ctx} 
+U4-U-pi- : (k : N) -> {Γ : ctx}
 --
-    ->  (A : ty Γ) 
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U- k Γ [[ ↓ A ]])
@@ -1226,7 +1226,7 @@ U5-U-ID- :  (k : N) -> {Γ : ctx}
      -> (a : raw Γ)
      -> (qa : Γ ==> a :: A)
      -> (b : raw Γ)
-     -> (qb : Γ ==> b :: A)    
+     -> (qb : Γ ==> b :: A)
 -- ------------------------------------------
      -> Γ ==> ID A a qa b qb :: U- k Γ
 --
@@ -1241,9 +1241,9 @@ U6-U-N0-  = U-N0-
 
 
 
-U7-U-Sum- : (k : N) -> {Γ : ctx} 
+U7-U-Sum- : (k : N) -> {Γ : ctx}
 --
-    ->  (A B : ty Γ) 
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (q : Γ ==> B :: U- k Γ)
 -- ------------------------------
@@ -1254,7 +1254,7 @@ U7-U-Sum- = U-Sum-
 
 
 
-U8-U-sub- :  (k : N) ->  (Δ Γ : ctx) 
+U8-U-sub- :  (k : N) ->  (Δ Γ : ctx)
       -> (f : subst Δ Γ)
 -- --------------------------------------
      ->  Δ ==> (U- k Γ) [[ f ]] == U- k Δ
@@ -1262,7 +1262,7 @@ U8-U-sub- :  (k : N) ->  (Δ Γ : ctx)
 U8-U-sub- = U-sub-
 
 
-U9-Cu-1a  : (k : N) -> (Γ : ctx)  
+U9-Cu-1a  : (k : N) -> (Γ : ctx)
 -- ---------------------------------------
      -> (Γ ==> U- k Γ :: U- (s k) Γ)
 --
@@ -1280,55 +1280,55 @@ U10-Cu-1b  =  Cu-1b-
 
 
 
-B1-Br-intro :  {Γ : ctx} 
+B1-Br-intro :  {Γ : ctx}
 --
-    -> (A : ty Γ) 
+    -> (A : ty Γ)
     -> (a : raw Γ)
     -> Γ ==> a :: A
 -- -------------------------
     -> Γ ==> br a :: Br A
 B1-Br-intro  =  Br-intro
 
-B2-Br-e :  {Γ : ctx} 
+B2-Br-e :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
--- --------------------------------  
+-- --------------------------------
     -> Γ ==>  wh A B k b q r p :: B
 B2-Br-e = Br-e
 
-B3-Br-beta :  {Γ : ctx} 
+B3-Br-beta :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (a : raw Γ)
     -> (b  : raw (Γ ▷ A))
     -> (t : Γ ==> a :: A)
     -> (q : Γ ==> (br a) :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
--- --------------------------------  
+-- --------------------------------
     -> Γ ==>  (wh A B (br a) b q r p) == (b [ els t ]) :: B
 B3-Br-beta = Br-beta
 
-B4-Br-eta :  {Γ : ctx} 
+B4-Br-eta :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ Br A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ (Br A) ==> b :: B [[ ↓ (Br A) ]])
     -> (t :  Γ ▷ A ==> b [ br-sb A ] :: B [[ ↓ A ]])
--- --------------------------------  
+-- --------------------------------
     -> Γ ==>  wh A B k (b [ br-sb A ]) q t (br-sb-lm {Γ} A B b r) == (b [ els q ]) :: B
 B4-Br-eta = Br-eta
 
-B5-Br-eqty :  {Γ : ctx} 
+B5-Br-eqty :  {Γ : ctx}
 --
-    -> (A : ty Γ) 
+    -> (A : ty Γ)
     -> (a b : raw Γ)
     -> Γ ==> a :: Br A
     -> Γ ==> b :: Br A
@@ -1336,23 +1336,23 @@ B5-Br-eqty :  {Γ : ctx}
     ->  Γ ==> a == b :: Br A
 B5-Br-eqty = Br-eqty
 
-B6-Br-cong : {Γ : ctx} 
+B6-Br-cong : {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> Γ ==> A == B
 -- -------------------
     -> Γ ==> Br A == Br B
 B6-Br-cong = Br-cong
 
-B7-Br-e-cong :  {Γ : ctx} 
+B7-Br-e-cong :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
-    -> (A' B' : ty Γ) 
+    -> (A' B' : ty Γ)
     -> (k'  : raw Γ)
     -> (b' : raw (Γ ▷ A'))
     -> (q' : Γ ==> k' :: Br A')
@@ -1362,33 +1362,33 @@ B7-Br-e-cong :  {Γ : ctx}
     -> Γ ==> B == B'
     -> Γ ==> k ==  k' :: Br A
     -> Γ ▷ A ==> b == (b' [ subst-trp (ext-eq' {Γ} A A' Aq) ]) ::  B [[ ↓ A ]]
--- --------------------------------  
+-- --------------------------------
     -> Γ ==>  wh A B k b q r p ==  wh A' B' k' b' q' r' p' :: B
 B7-Br-e-cong = Br-e-cong
 
 
-B8-Br-sub : {Δ Γ : ctx} 
+B8-Br-sub : {Δ Γ : ctx}
 --
-    -> (A : ty Γ) 
-    -> (f : subst Δ Γ) 
--- --------------------------------    
+    -> (A : ty Γ)
+    -> (f : subst Δ Γ)
+-- --------------------------------
     ->  Δ ==> (Br A) [[ f ]] == (Br (A [[ f ]]))
 B8-Br-sub = Br-sub
 
-B9-br-sub : {Δ Γ : ctx} 
+B9-br-sub : {Δ Γ : ctx}
 --
-    -> (A : ty Γ) 
-    -> (f : subst Δ Γ) 
+    -> (A : ty Γ)
+    -> (f : subst Δ Γ)
     -> (a : raw Γ)
     -> Γ ==> a :: A
--- --------------------------------    
+-- --------------------------------
     ->  Δ ==> (br a) [ f ] == (br (a [ f ])) :: (Br A) [[ f ]]
 B9-br-sub = br-sub
 
-B10-Br-e-sub :  {Δ Γ : ctx} 
+B10-Br-e-sub :  {Δ Γ : ctx}
 --
     -> (h : subst Δ Γ)
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
@@ -1396,10 +1396,10 @@ B10-Br-e-sub :  {Δ Γ : ctx}
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
     -> (q' : Δ ==> k [ h ] :: Br (A [[ h ]]))
     -> (r' : Δ ▷ (A [[ h ]])  ==> (b [[ (↑ A  h) ]]) :: (B [[ h ]]) [[ ↓ (A [[ h ]]) ]])
-    -> (p' : Δ ▷ (A [[ h ]]) ▷ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) 
-             ==> (b [[ (↑ A h) ]]) [ pr-x (A [[ h ]])  ] ==  (b [[ (↑ A  h) ]]) [ pr-y (A [[ h ]]) ] 
+    -> (p' : Δ ▷ (A [[ h ]]) ▷ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]])
+             ==> (b [[ (↑ A h) ]]) [ pr-x (A [[ h ]])  ] ==  (b [[ (↑ A  h) ]]) [ pr-y (A [[ h ]]) ]
                   :: (B [[ h ]])  [[ ↓ (A [[ h ]]) ]] [[ ↓ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) ]])
 
--- --------------------------------  
+-- --------------------------------
     -> Δ ==>  (wh A B k b q r p) [ h ] == (wh (A [[ h ]]) (B [[ h ]]) (k [ h ]) (b [[ (↑ A h) ]]) q' r' p') :: B [[ h ]]
 B10-Br-e-sub = Br-e-sub

--- a/MLTT-and-setoids/V-model-epi-rules.agda
+++ b/MLTT-and-setoids/V-model-epi-rules.agda
@@ -10,41 +10,41 @@
 module V-model-epi-rules where
 
 open import basic-types
-open import basic-setoids       
-open import dependent-setoids   
-open import subsetoids          
-open import iterative-sets      
-open import iterative-sets-pt2  
-open import iterative-sets-pt3  
+open import basic-setoids
+open import dependent-setoids
+open import subsetoids
+open import iterative-sets
+open import iterative-sets-pt2
+open import iterative-sets-pt3
 open import iterative-sets-pt4
 open import iterative-sets-pt5-wop -- wop = use universe operator and W
 open import iterative-sets-pt6-wop
 open import V-model-pt0
-open import V-model-pt1         
-open import V-model-pt2         
-open import V-model-pt3         
-open import V-model-pt4         
-open import V-model-pt5         
-open import V-model-pt6         
-open import V-model-pt7         
-open import V-model-pt8         
-open import V-model-pt9         
+open import V-model-pt1
+open import V-model-pt2
+open import V-model-pt3
+open import V-model-pt4
+open import V-model-pt5
+open import V-model-pt6
+open import V-model-pt7
+open import V-model-pt8
+open import V-model-pt9
 open import V-model-pt10
 open import V-model-pt13-wop
 open import V-model-pt11-wop
 
 open import V-model-all-rules-wop
 
--- 
+--
 
--- ⊢ 
+-- ⊢
 
 
 ty-substr-lm-ref : {Γ : ctx}
   -> (A : ty Γ)
   -> (p : << Ctx >> Γ ~ Γ)
   -> Γ ==> A == A [[ subst-trp p ]]
-ty-substr-lm-ref {Γ} A p =  
+ty-substr-lm-ref {Γ} A p =
   let lm =  >><< (Sub-trp-prop {Γ} A p)
   in tysym (mk-eqty (>><< lm))
 
@@ -81,7 +81,7 @@ ty-substr-lm-tra : {Δ Γ H : ctx}
   -> (Δ ==> A == B [[ subst-trp p ]])
   -> (Γ ==> B == C [[ subst-trp q ]])
   -> Δ ==> A == C [[ subst-trp (tra' p q) ]]
-ty-substr-lm-tra {Δ} {Γ} {H} A B C p q eq1 eq2 = 
+ty-substr-lm-tra {Δ} {Γ} {H} A B C p q eq1 eq2 =
   let lm :  Δ ==> (B [[ subst-trp p ]]) == (C  [[ subst-trp q ]] [[ subst-trp p ]])
       lm = tyeq-subst (subst-trp p) eq2
       lm2 : Δ ==> A == (C  [[ subst-trp q ]] [[ subst-trp p ]])
@@ -93,7 +93,7 @@ ty-substr-lm-tra {Δ} {Γ} {H} A B C p q eq1 eq2 =
       lm5 :  < Subst Δ H > subst-trp q ⌢ subst-trp p ~ subst-trp (tra' p q)
       lm5 = subst-trp-fun p q (tra' p q)
       lm6 : Δ ==> (C [[ subst-trp q ]]) [[ subst-trp p ]] == C [[ subst-trp (tra' p q) ]]
-      lm6 = tytra lm3 (tyeq-subst2 C (subst-trp q ⌢ subst-trp p) (subst-trp (tra' p q)) lm5) 
+      lm6 = tytra lm3 (tyeq-subst2 C (subst-trp q ⌢ subst-trp p) (subst-trp (tra' p q)) lm5)
   in tytra lm2 lm6
 
 
@@ -110,9 +110,9 @@ ty-substr-lm-fun : {H Δ Γ : ctx}
   -> (p : << Ctx >> Δ ~ Γ)
   -> (q : << Ctx >> H ~ Δ)
   -> H ==> (A [[ subst-trp p ]]) [[ subst-trp q ]] == (A [[ subst-trp (tra' q p) ]])
-ty-substr-lm-fun {Δ} {Γ} A p q = 
-          tytra (tysym (tysubst-com A (subst-trp p) (subst-trp q))) 
-                (tyeq-subst2 A (subst-trp p ⌢ subst-trp q)  (subst-trp (tra' q p)) 
+ty-substr-lm-fun {Δ} {Γ} A p q =
+          tytra (tysym (tysubst-com A (subst-trp p) (subst-trp q)))
+                (tyeq-subst2 A (subst-trp p ⌢ subst-trp q)  (subst-trp (tra' q p))
                                (subst-trp-fun q p (tra' q p)))
 
 
@@ -129,10 +129,10 @@ ty-substr-lm-inv {Δ} {Γ} A p = tytra (ty-substr-lm-fun A p (sym' p)) (tysym (t
 
 
 data ty-in-ctx : Set1 where
-  _⊢_ : (ct : ctx) -> (ty ct) ->  ty-in-ctx 
+  _⊢_ : (ct : ctx) -> (ty ct) ->  ty-in-ctx
 
 data el-in-ctx : Set1 where
-  _⊢_ : (ct : ctx) -> (raw ct) ->  el-in-ctx 
+  _⊢_ : (ct : ctx) -> (raw ct) ->  el-in-ctx
 
 
  {--
@@ -147,23 +147,23 @@ data el-in-ctx : Set1 where
 
 
 ty-in-ctx-eq :  (u v : ty-in-ctx) -> Set
-ty-in-ctx-eq (Γ ⊢ A) (Γ' ⊢ A') = Σ (<< Ctx >> Γ ~ Γ') 
-                     (\p -> Γ ==> A ==  (A' [[ subst-trp p ]]) )  
+ty-in-ctx-eq (Γ ⊢ A) (Γ' ⊢ A') = Σ (<< Ctx >> Γ ~ Γ')
+                     (\p -> Γ ==> A ==  (A' [[ subst-trp p ]]) )
 
-rf-ty-in-ctx-eq :  (u : ty-in-ctx) 
+rf-ty-in-ctx-eq :  (u : ty-in-ctx)
       -> ty-in-ctx-eq u u
-rf-ty-in-ctx-eq (Γ ⊢ A) = (refl' Ctx _) , ty-substr-lm-ref {Γ} A (refl' Ctx Γ) 
+rf-ty-in-ctx-eq (Γ ⊢ A) = (refl' Ctx _) , ty-substr-lm-ref {Γ} A (refl' Ctx Γ)
 
-sy-ty-in-ctx-eq :  (u  v : ty-in-ctx) 
-      -> ty-in-ctx-eq u v 
+sy-ty-in-ctx-eq :  (u  v : ty-in-ctx)
+      -> ty-in-ctx-eq u v
       -> ty-in-ctx-eq v u
 sy-ty-in-ctx-eq (Γ ⊢ A) (Γ' ⊢ A') (p1 , p2) =
   let lm = ty-substr-lm-sym {Γ} {Γ'} A A' p1
   in
       (sym' p1) , lm p2
 
-tr-ty-in-ctx-eq :  (u v z : ty-in-ctx) 
-      -> ty-in-ctx-eq u v -> ty-in-ctx-eq v z 
+tr-ty-in-ctx-eq :  (u v z : ty-in-ctx)
+      -> ty-in-ctx-eq u v -> ty-in-ctx-eq v z
       -> ty-in-ctx-eq u z
 tr-ty-in-ctx-eq  (Γ ⊢ A) (Γ' ⊢ A') (Γ'' ⊢ A'')  (p1 , p2) (q1 , q2) =
   let lm = ty-substr-lm-tra {Γ} {Γ'}  {Γ''}  A A' A'' p1 q1
@@ -171,12 +171,12 @@ tr-ty-in-ctx-eq  (Γ ⊢ A) (Γ' ⊢ A') (Γ'' ⊢ A'')  (p1 , p2) (q1 , q2) =
       (tra' p1 q1) , lm p2 q2
 
 Ty-in-ctx : classoid
-Ty-in-ctx = record { object = ty-in-ctx 
-                   ; _∼_ = ty-in-ctx-eq 
-                   ; eqrel = record { rf' = rf-ty-in-ctx-eq 
-                                    ; sy' = sy-ty-in-ctx-eq 
-                                    ; tr' = tr-ty-in-ctx-eq 
-                                    } 
+Ty-in-ctx = record { object = ty-in-ctx
+                   ; _∼_ = ty-in-ctx-eq
+                   ; eqrel = record { rf' = rf-ty-in-ctx-eq
+                                    ; sy' = sy-ty-in-ctx-eq
+                                    ; tr' = tr-ty-in-ctx-eq
+                                    }
                    }
 
 
@@ -193,12 +193,12 @@ A ≈ B = (<< Ty-in-ctx >> A  ~  B)
 
 -- move this :
 
-raw-subst-ext1 : {Δ Γ : ctx} 
+raw-subst-ext1 : {Δ Γ : ctx}
      -> (a b : raw Γ)
-     -> (f : subst Δ Γ) 
+     -> (f : subst Δ Γ)
      -> << Raw Γ >> a ~ b
      -> << Raw Δ >> a [ f ] ~ (b [ f ])
-raw-subst-ext1 {Δ} {Γ} a  b f p = 
+raw-subst-ext1 {Δ} {Γ} a  b f p =
     <<>> (<<>> (λ x → let lm1 = >><< (>><< p) (aps f x)
                           lm :  << VV >> raw.rawterm (a [ f ]) • x ~  (raw.rawterm (b [ f ]) • x)
                           lm = <<>> (>><< lm1)
@@ -206,9 +206,9 @@ raw-subst-ext1 {Δ} {Γ} a  b f p =
          ))
 
 
-raw-subst-ext2 : {Δ Γ : ctx} 
+raw-subst-ext2 : {Δ Γ : ctx}
      -> (a : raw Γ)
-     -> (f g : subst Δ Γ) 
+     -> (f g : subst Δ Γ)
      -> < Subst Δ Γ > f ~ g
      -> << Raw Δ >> a [ f ] ~ (a [ g ])
 raw-subst-ext2 {Δ} {Γ} a f g p = <<>> (<<>> (λ x → extensionality1 (raw.rawterm a) (aps f x) (aps g x) (>< (>< p) x)))
@@ -229,7 +229,7 @@ raw-substr-lm-sym : {Δ Γ : ctx}
   -> (p : << Ctx >> Δ ~ Γ)
   -> (<< Raw Δ >> a ~ (b [ subst-trp p ]))
   -> << Raw Γ >> b ~ (a [ subst-trp (sym' p) ])
-raw-substr-lm-sym {Δ} {Γ} a b p eq = 
+raw-substr-lm-sym {Δ} {Γ} a b p eq =
    let lm : << Raw Γ >> a [ subst-trp (sym' p) ] ~ (b [ subst-trp p ]  [ subst-trp (sym' p) ])
        lm = raw-subst-ext1 a (b [ subst-trp p ]) (subst-trp (sym' p)) eq
        lm1 :  << Raw Γ >> b [  (subst-trp p) ⌢ (subst-trp (sym' p)) ]
@@ -240,12 +240,12 @@ raw-substr-lm-sym {Δ} {Γ} a b p eq =
        lm3 : < Subst Γ Γ >  subst-trp (tra' (sym' p) p)  ~  (subst-trp p ⌢ subst-trp (sym' p))
        lm3 = sym (subst-trp-fun (sym' p) p  (tra' (sym' p) p))
        lm4 :  << Raw Γ >> (b [ subst-trp p ]) [ subst-trp (sym' p) ] ~ b
-       lm4 = tra' (sym' 
-                  (tra' (raw-subst-ext2 b (subst-trp (tra' (sym' p) p)) ((subst-trp p ⌢ subst-trp (sym' p))) lm3) 
-                         lm1)) 
+       lm4 = tra' (sym'
+                  (tra' (raw-subst-ext2 b (subst-trp (tra' (sym' p) p)) ((subst-trp p ⌢ subst-trp (sym' p))) lm3)
+                         lm1))
                   lm2
    in sym' (tra' lm lm4)
- 
+
 
 
 raw-substr-lm-tra : {Δ Γ H : ctx}
@@ -257,61 +257,61 @@ raw-substr-lm-tra : {Δ Γ H : ctx}
   -> (<< Raw Δ >> a ~ (b [ subst-trp p ]))
   -> (<< Raw Γ >> b ~ (c [ subst-trp q ]))
   -> << Raw Δ >> a ~ (c [ subst-trp (tra' p q) ])
-raw-substr-lm-tra {Δ} {Γ} {H} a b c p q eq1 eq2 =  
+raw-substr-lm-tra {Δ} {Γ} {H} a b c p q eq1 eq2 =
    let
      lm1 :  << Raw Δ >> (b [ subst-trp p ]) ~ ((c [ subst-trp q ]) [ subst-trp p ])
      lm1 = raw-subst-ext1 b (c [ subst-trp q ]) (subst-trp p) eq2
      lm2 : << Raw Δ >> ((c [ subst-trp q ]) [ subst-trp p ]) ~ (c [ subst-trp (tra' p q) ])
-     lm2 = tra' (sym' (sub-comp-prop c (subst-trp q) (subst-trp p))) 
-                (raw-subst-ext2 c (subst-trp q ⌢ subst-trp p) (subst-trp (tra' p q)) 
-                     (subst-trp-fun p q (tra' p q))) 
+     lm2 = tra' (sym' (sub-comp-prop c (subst-trp q) (subst-trp p)))
+                (raw-subst-ext2 c (subst-trp q ⌢ subst-trp p) (subst-trp (tra' p q))
+                     (subst-trp-fun p q (tra' p q)))
 
    in tra' eq1 (tra' lm1 lm2)
- 
+
 
 raw-substr-lm-irr : {Δ Γ : ctx}
   -> (a : ty Γ)
   -> (p  q : << Ctx >> Δ ~ Γ)
   -> << Raw Δ >> a [ subst-trp p ] ~ (a [ subst-trp q ])
-raw-substr-lm-irr {Δ} {Γ} a p q = raw-subst-ext2 a (subst-trp p) (subst-trp q) (subst-trp-irr p q) 
+raw-substr-lm-irr {Δ} {Γ} a p q = raw-subst-ext2 a (subst-trp p) (subst-trp q) (subst-trp-irr p q)
 
 
 el-in-ctx-eq :  (u v : el-in-ctx) -> Set
-el-in-ctx-eq (Γ ⊢ a) (Γ' ⊢ a') = Σ (<< Ctx >> Γ ~ Γ') 
+el-in-ctx-eq (Γ ⊢ a) (Γ' ⊢ a') = Σ (<< Ctx >> Γ ~ Γ')
                      (\p -> << Raw Γ >> a ~ (a' [[ subst-trp p ]]) )
 
-rf-el-in-ctx-eq :  (u : el-in-ctx) 
+rf-el-in-ctx-eq :  (u : el-in-ctx)
       -> el-in-ctx-eq u u
-rf-el-in-ctx-eq (Γ ⊢ a) = 
+rf-el-in-ctx-eq (Γ ⊢ a) =
   let lm =  raw-substr-lm-ref {Γ} a  (refl' Ctx _)
   in  (refl' Ctx _) , lm
 
 
-sy-el-in-ctx-eq :  (u v : el-in-ctx) 
-      -> el-in-ctx-eq u v 
+sy-el-in-ctx-eq :  (u v : el-in-ctx)
+      -> el-in-ctx-eq u v
       -> el-in-ctx-eq v u
-sy-el-in-ctx-eq (Γ ⊢ a) (Γ' ⊢ a') (p1 , p2) =  
-  let lm =  raw-substr-lm-sym {Γ} {Γ'} a a' 
+sy-el-in-ctx-eq (Γ ⊢ a) (Γ' ⊢ a') (p1 , p2) =
+  let lm =  raw-substr-lm-sym {Γ} {Γ'} a a'
   in (sym' p1) , lm p1 p2
 
 
 
-tr-el-in-ctx-eq :  (u v z : el-in-ctx) 
-      -> el-in-ctx-eq u v -> el-in-ctx-eq v z 
+tr-el-in-ctx-eq :  (u v z : el-in-ctx)
+      -> el-in-ctx-eq u v -> el-in-ctx-eq v z
       -> el-in-ctx-eq u z
-tr-el-in-ctx-eq (Γ ⊢ a) (Γ' ⊢ a') (Γ'' ⊢ a'') (p1 , p2) (q1 , q2) = 
+tr-el-in-ctx-eq (Γ ⊢ a) (Γ' ⊢ a') (Γ'' ⊢ a'') (p1 , p2) (q1 , q2) =
   let lm =  raw-substr-lm-tra {Γ} {Γ'} {Γ''}
-                              a a' a'' 
+                              a a' a''
   in tra' p1 q1 , lm p1 q1 p2 q2
 
 
 El-in-ctx : classoid
-El-in-ctx = record { object = el-in-ctx 
-                   ; _∼_ = el-in-ctx-eq 
-                   ; eqrel = record { rf' = rf-el-in-ctx-eq 
-                                    ; sy' = sy-el-in-ctx-eq 
-                                    ; tr' = tr-el-in-ctx-eq 
-                                    } 
+El-in-ctx = record { object = el-in-ctx
+                   ; _∼_ = el-in-ctx-eq
+                   ; eqrel = record { rf' = rf-el-in-ctx-eq
+                                    ; sy' = sy-el-in-ctx-eq
+                                    ; tr' = tr-el-in-ctx-eq
+                                    }
                     }
 
 
@@ -323,23 +323,23 @@ A ≈≈ B = (<< El-in-ctx >> A  ~  B)
 
 
 _:::_ : el-in-ctx -> ty-in-ctx -> Set
-(Γ ⊢ a) ::: (Γ' ⊢ A) =  Σ (<< Ctx >> Γ ~ Γ') 
-                           (\p -> Γ ==> a :: (A [[ subst-trp p ]]) ) 
+(Γ ⊢ a) ::: (Γ' ⊢ A) =  Σ (<< Ctx >> Γ ~ Γ')
+                           (\p -> Γ ==> a :: (A [[ subst-trp p ]]) )
 
 
-::-::: : (Γ : ctx) -> (a : raw Γ) -> (A : ty Γ) -> 
+::-::: : (Γ : ctx) -> (a : raw Γ) -> (A : ty Γ) ->
            (Γ ==> a :: A) ->  (Γ ⊢ a) ::: (Γ ⊢ A)
 ::-::: Γ a A p = (refl' Ctx Γ) , elttyeq p (ty-substr-lm-ref A (refl' Ctx Γ))
 
 
-:::-:: : (Γ : ctx) -> (a : raw Γ) -> (A : ty Γ) -> 
-             (Γ ⊢ a) ::: (Γ ⊢ A) -> (Γ ==> a :: A) 
+:::-:: : (Γ : ctx) -> (a : raw Γ) -> (A : ty Γ) ->
+             (Γ ⊢ a) ::: (Γ ⊢ A) -> (Γ ==> a :: A)
 :::-:: Γ a A (p , q) = elttyeq q (tysym (ty-substr-lm-ref A p))
 
-=::-::: : (Γ : ctx) -> (a b : raw Γ) -> (A : ty Γ) 
-       ->  (Γ ==> a == b :: A) 
+=::-::: : (Γ : ctx) -> (a b : raw Γ) -> (A : ty Γ)
+       ->  (Γ ==> a == b :: A)
        -> (and ((Γ ⊢ a) ::: (Γ ⊢ A))  (and  ((Γ ⊢ b) ::: (Γ ⊢ A)) ((Γ ⊢ a) ≈≈ (Γ ⊢ b))))
-=::-::: Γ a b A (pair p1 (pair p2 p3)) = 
+=::-::: Γ a b A (pair p1 (pair p2 p3)) =
        let eq :  << Raw Γ >> b ~ (b [[ subst-trp (refl' Ctx Γ) ]])
            eq = sym' (sub-trp-prop b (refl' Ctx Γ))
            lm : (Γ ⊢ a) ≈≈ (Γ ⊢ b)
@@ -350,26 +350,26 @@ _:::_ : el-in-ctx -> ty-in-ctx -> Set
            lm2 = elttyeq p3  (ty-substr-lm-ref A  (refl' Ctx Γ))
        in  pair ((refl' Ctx Γ) , lm1) (pair (refl' Ctx Γ , lm2) lm)
 
-tyeq-new : 
+tyeq-new :
    {Γ Γ' Γ'' : ctx}
    -> (a : raw Γ)
-   -> (A  : ty Γ') 
-   -> (B  : ty Γ'') 
-   -> (Γ ⊢ a) ::: (Γ' ⊢ A) 
+   -> (A  : ty Γ')
+   -> (B  : ty Γ'')
+   -> (Γ ⊢ a) ::: (Γ' ⊢ A)
    -> (Γ' ⊢ A) ≈ (Γ'' ⊢ B)
-   -> (Γ ⊢ a) ::: (Γ'' ⊢ B) 
+   -> (Γ ⊢ a) ::: (Γ'' ⊢ B)
 tyeq-new {Γ} {Γ'} {Γ''} a A B p q =
    let p1 = pj1 p
        p2 = pj2 p
        q1 = pj1 (>><< q)
        q2 = pj2 (>><< q)
        lm : Γ ==> (A [[ subst-trp (pj1 p) ]]) == (B [[ subst-trp (pj1 (>><< q)) ]]) [[ subst-trp (pj1 p) ]]
-       lm = tyeq-subst (subst-trp (pj1 p)) q2 
+       lm = tyeq-subst (subst-trp (pj1 p)) q2
        lm2 :  Γ ==> (B [[ subst-trp (pj1 (>><< q)) ]]) [[ subst-trp (pj1 p) ]] == B [[ subst-trp (tra' (pj1 p) (pj1 (>><< q))) ]]
-       lm2 = tysym (tytra (tyeq-subst2 B 
-                              (subst-trp (tra' (pj1 p) (pj1 (>><< q)))) 
+       lm2 = tysym (tytra (tyeq-subst2 B
+                              (subst-trp (tra' (pj1 p) (pj1 (>><< q))))
                               ((subst-trp (pj1 (>><< q))) ⌢ ( subst-trp (pj1 p)))
-                               (sym (subst-trp-fun (pj1 p) (pj1 (>><< q)) (tra' (pj1 p) (pj1 (>><< q)))))) 
+                               (sym (subst-trp-fun (pj1 p) (pj1 (>><< q)) (tra' (pj1 p) (pj1 (>><< q))))))
                            (tysubst-com B (subst-trp (pj1 (>><< q))) (subst-trp (pj1 p))))
        lm3 :  Γ ==> (A [[ subst-trp (pj1 p) ]]) == B [[ subst-trp (tra' (pj1 p) (pj1 (>><< q))) ]]
        lm3 = tytra lm lm2
@@ -377,41 +377,41 @@ tyeq-new {Γ} {Γ'} {Γ''} a A B p q =
 
 
 
-tyeq2-new : 
+tyeq2-new :
    {Γ Γ' Γ'' : ctx}
    -> (a : raw Γ)
    -> (b : raw Γ')
-   -> (A : ty Γ'') 
-   -> (Γ' ⊢ b) ::: (Γ'' ⊢ A) 
+   -> (A : ty Γ'')
+   -> (Γ' ⊢ b) ::: (Γ'' ⊢ A)
    -> (Γ ⊢ a) ≈≈ (Γ' ⊢ b)
-   -> (Γ ⊢ a) ::: (Γ'' ⊢ A) 
-tyeq2-new {Γ} {Γ'} {Γ''} a b A p q = 
+   -> (Γ ⊢ a) ::: (Γ'' ⊢ A)
+tyeq2-new {Γ} {Γ'} {Γ''} a b A p q =
    let p1 = pj1 p
        p2 = pj2 p
        q1 = pj1 (>><< q)
        q2 = pj2 (>><< q)
        lm1 : Γ ==> b  [[ subst-trp (pj1 (>><< q)) ]] :: (A [[ subst-trp (pj1 p) ]]) [[ subst-trp (pj1 (>><< q)) ]]
        lm1 = elt-subst (subst-trp (pj1 (>><< q))) p2
-       lm2 : Γ ==> (A [[ subst-trp (pj1 p) ]]) [[ subst-trp (pj1 (>><< q)) ]] 
+       lm2 : Γ ==> (A [[ subst-trp (pj1 p) ]]) [[ subst-trp (pj1 (>><< q)) ]]
                       == A [[ subst-trp (tra' (pj1 (>><< q)) (pj1 p)) ]]
-       lm2 = ty-substr-lm-fun A (pj1 p) (pj1 (>><< q)) 
-       lm3 : Γ ==> a ::  (A [[ subst-trp (pj1 p) ]]) [[ subst-trp (pj1 (>><< q)) ]] 
+       lm2 = ty-substr-lm-fun A (pj1 p) (pj1 (>><< q))
+       lm3 : Γ ==> a ::  (A [[ subst-trp (pj1 p) ]]) [[ subst-trp (pj1 (>><< q)) ]]
        lm3 = subj-red  (b [[ subst-trp (pj1 (>><< q)) ]]) a lm1 (sym' q2)
        lm4 : Γ ==> a :: A [[ subst-trp (tra' (pj1 (>><< q)) (pj1 p)) ]]
        lm4 = elttyeq lm3 lm2
     in (tra' q1 p1) , lm4
 
 
-tyeq3-new : 
+tyeq3-new :
    {Δ Γ : ctx}
-   -> (A : ty Γ) 
+   -> (A : ty Γ)
    -> (p :  << Ctx >> Δ ~ Γ)
    -> (Γ ⊢ A) ≈ (Δ ⊢ (A [[ subst-trp p ]]))
 tyeq3-new {Δ} {Γ} A p = <<>> ((sym' p) , tysym (ty-substr-lm-inv A p))
 
-tyeq4-new : 
+tyeq4-new :
    {Δ Γ : ctx}
-   -> (a : raw Γ) 
+   -> (a : raw Γ)
    -> (p :  << Ctx >> Δ ~ Γ)
    -> (Γ ⊢ a) ≈≈ (Δ ⊢ (a [[ subst-trp p ]]))
 tyeq4-new {Δ} {Γ} a p = <<>> ((sym' p) , tra' (sym' (tra' (raw-subst-ext2 a (subst-trp p ⌢ subst-trp (sym' p))
@@ -424,16 +424,16 @@ tyeq4-new {Δ} {Γ} a p = <<>> ((sym' p) , tra' (sym' (tra' (raw-subst-ext2 a (s
 
 -- Some rules written with the new judgement forms.
 
--- to do: 
+-- to do:
 
 
 P15-Π-f-cong-new : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
-      -> (Γ ⊢ A) ≈ (Γ ⊢ A') 
+      -> (A  A' : ty Γ)
+      -> (Γ ⊢ A) ≈ (Γ ⊢ A')
       -> (B : ty (Γ ▷ A))
       -> (B' : ty (Γ ▷ A'))
-      -> ((Γ ▷ A) ⊢ B) ≈ ((Γ ▷ A') ⊢ B') 
+      -> ((Γ ▷ A) ⊢ B) ≈ ((Γ ▷ A') ⊢ B')
 -- ---------------------
       -> Γ ==> Π-f A B == Π-f A' B'
 P15-Π-f-cong-new {Γ} A A' p B B' q =
@@ -443,14 +443,14 @@ P15-Π-f-cong-new {Γ} A A' p B B' q =
         lm1 = tytra p2 (tysym (ty-substr-lm-ref A' (pj1 (>><< p))))
         q1 = pj1 (>><< q)
         q2 = pj2 (>><< q)
-        
 
-    in P15-Π-f-cong {Γ} A A' lm1 B B' 
-         (tytra q2  
-               (ty-substr-lm-irr B'  (pj1 (>><< q))  
+
+    in P15-Π-f-cong {Γ} A A' lm1 B B'
+         (tytra q2
+               (ty-substr-lm-irr B'  (pj1 (>><< q))
                                      (ext-eq' A A'
                                           (tytra (pj2 (>><< p))
-                                              (tysym (ty-substr-lm-ref A' (pj1 (>><< p))))))) ) 
+                                              (tysym (ty-substr-lm-ref A' (pj1 (>><< p))))))) )
 
 
 {--
@@ -463,7 +463,7 @@ ty-substr-lm-irr : {Δ Γ : ctx}
 
 P15-Π-f-cong : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (p : Γ ==> A == A')
       -> (B : ty (Γ ▷ A))
       -> (B' : ty (Γ ▷ A'))
@@ -479,11 +479,11 @@ P15-Π-f-cong = Π-f-cong
 
 Sg2-Σ-f-cong-new : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
-      -> (Γ ⊢ A) ≈ (Γ ⊢ A') 
+      -> (A  A' : ty Γ)
+      -> (Γ ⊢ A) ≈ (Γ ⊢ A')
       -> (B : ty (Γ ▷ A))
       -> (B' : ty (Γ ▷ A'))
-      -> ((Γ ▷ A) ⊢ B) ≈ ((Γ ▷ A') ⊢ B') 
+      -> ((Γ ▷ A) ⊢ B) ≈ ((Γ ▷ A') ⊢ B')
 -- ---------------------
       -> Γ ==> Σ-f A B == Σ-f A' B'
 Sg2-Σ-f-cong-new {Γ} A A' p B B' q =
@@ -492,20 +492,20 @@ Sg2-Σ-f-cong-new {Γ} A A' p B B' q =
         lm1 :  Γ ==> A == A'
         lm1 = tytra p2 (tysym (ty-substr-lm-ref A' (pj1 (>><< p))))
         q1 = pj1 (>><< q)
-        q2 = pj2 (>><< q)        
+        q2 = pj2 (>><< q)
 
-    in Sg2-Σ-f-cong {Γ} A A' lm1 B B' 
-         (tytra q2  
-               (ty-substr-lm-irr B'  (pj1 (>><< q))  
+    in Sg2-Σ-f-cong {Γ} A A' lm1 B B'
+         (tytra q2
+               (ty-substr-lm-irr B'  (pj1 (>><< q))
                                      (ext-eq' A A'
                                           (tytra (pj2 (>><< p))
-                                              (tysym (ty-substr-lm-ref A' (pj1 (>><< p))))))) ) 
+                                              (tysym (ty-substr-lm-ref A' (pj1 (>><< p))))))) )
 
 
 {--
 Sg2-Σ-f-cong : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (p : Γ ==> A == A')
       -> (B : ty (Γ ▷ A))
       -> (B' : ty (Γ ▷ A'))
@@ -515,5 +515,4 @@ Sg2-Σ-f-cong : {Γ : ctx}
 --
 Sg2-Σ-f-cong = Σ-f-cong
 --}
-
 

--- a/MLTT-and-setoids/V-model-pt0.agda
+++ b/MLTT-and-setoids/V-model-pt0.agda
@@ -33,10 +33,10 @@ ctx = V
 
 -- Every set a in V gives rise to a canonical setoid  κ a.
 -- See previous files.
--- The context maps are extensional functions between 
+-- The context maps are extensional functions between
 -- such canonical setoids.
 
-ctx-maps : (a b : ctx) -> setoid 
+ctx-maps : (a b : ctx) -> setoid
 ctx-maps a b = (κ a => κ b)
 
 ctx-trp :  {a b : ctx} -> (p : a ≐ b) -> || ctx-maps a b ||
@@ -55,8 +55,8 @@ record subst (a b : ctx ) : Set where
 Subst : (a b : ctx) -> setoid
 Subst a b = record {object = subst a b
                    ;  _∼_ = \f -> \g -> < ctx-maps a b > subst.cmap f ~ subst.cmap g
-                   ; eqrel = pair (λ f -> <> (\ x → refl (κ b) _)) 
-                                  (pair (λ f g p -> <> (\ x → sym {κ b} ((>< p) x))) 
+                   ; eqrel = pair (λ f -> <> (\ x → refl (κ b) _))
+                                  (pair (λ f g p -> <> (\ x → sym {κ b} ((>< p) x)))
                                         (λ f g h p q -> <> (\ x → tra {κ b} ((>< p) x) ((>< q) x))))
                    }
 
@@ -65,7 +65,7 @@ Subst a b = record {object = subst a b
 aps : {a b : ctx} -> (f : subst a b) -> (x : || κ a ||) -> || κ b ||
 aps f x = (ap (subst.cmap f) x)
 
-aps-ext : {a b : ctx} -> (f : subst a b) -> (x y : || κ a ||) 
+aps-ext : {a b : ctx} -> (f : subst a b) -> (x y : || κ a ||)
               -> < κ a > x ~ y -> < κ b > aps f x ~ aps f y
 aps-ext {a} {b} f x y p = extensionality (subst.cmap f) x y p
 
@@ -86,18 +86,18 @@ f ⌢ g = subst.sb (subst.cmap f ° subst.cmap g)
 
 
 
-subst-cong : {Θ Δ Γ : ctx} -> (f f' : subst Δ Γ) -> (g  g' : subst Θ Δ) 
-      -> < Subst Δ Γ > f ~ f' 
-      -> < Subst Θ Δ > g ~ g' 
-      -> < Subst Θ Γ > (f ⌢ g) ~ (f' ⌢ g') 
+subst-cong : {Θ Δ Γ : ctx} -> (f f' : subst Δ Γ) -> (g  g' : subst Θ Δ)
+      -> < Subst Δ Γ > f ~ f'
+      -> < Subst Θ Δ > g ~ g'
+      -> < Subst Θ Γ > (f ⌢ g) ~ (f' ⌢ g')
 subst-cong {Θ} {Δ} {Γ} f f' g g' p q =
-    <> (<> (λ x →  
+    <> (<> (λ x →
    let eq1 : < κ Γ > setoidmap.op (subst.cmap f ° subst.cmap g) x ~
-                     setoidmap.op (subst.cmap f ° subst.cmap g' ) x 
-       eq1 = extensionality (subst.cmap f) _ _ ((>< (>< q) x)) 
+                     setoidmap.op (subst.cmap f ° subst.cmap g' ) x
+       eq1 = extensionality (subst.cmap f) _ _ ((>< (>< q) x))
        eq2 : < κ Γ > setoidmap.op (subst.cmap f ° subst.cmap g' ) x ~
                     setoidmap.op (subst.cmap (f') ° subst.cmap (g')) x
-       eq2 = >< (>< p) ( aps g' x) 
+       eq2 = >< (>< p) ( aps g' x)
        eq : < κ Γ > setoidmap.op (subst.cmap f ° subst.cmap g) x ~
                     setoidmap.op (subst.cmap (f') ° subst.cmap (g')) x
        eq = tra eq1 eq2
@@ -121,10 +121,10 @@ apr {Γ} a x = (raw.rawterm a) • x
 Raw : (Γ : ctx) -> classoid
 Raw Γ = record {object = raw Γ
                ;  _∼_ = \a -> \b -> << setoidmaps1 (κ Γ) VV >> (raw.rawterm a) ~ (raw.rawterm b)
-               ; eqrel = record { rf' = λ x → <<>> (λ t → <<>> (refV _)) 
-                                ; sy' = λ x y p → <<>> (λ t → <<>> (symV (>><< (>><< p t))))  
-                                ; tr' =  λ x y z p q → <<>> (λ t → <<>> (traV ((>><< (>><< p t))) ((>><< (>><< q t))))) 
-                                } 
+               ; eqrel = record { rf' = λ x → <<>> (λ t → <<>> (refV _))
+                                ; sy' = λ x y p → <<>> (λ t → <<>> (symV (>><< (>><< p t))))
+                                ; tr' =  λ x y z p q → <<>> (λ t → <<>> (traV ((>><< (>><< p t))) ((>><< (>><< q t)))))
+                                }
                }
 
 
@@ -137,7 +137,7 @@ Raw Γ = record {object = raw Γ
 record ty (Γ : ctx) : Set1 where
   constructor tyy
   field
-    type : ||| setoidmaps1 (κ Γ) VV  ||| 
+    type : ||| setoidmaps1 (κ Γ) VV  |||
 --}
 
 {-- New version trying to making it synonymous (thanks to Guillaum Brunerie) :
@@ -170,10 +170,10 @@ apt {Γ} A x = (ty.type A) • x
 Ty : (Γ : ctx) -> classoid
 Ty Γ =  record {object = ty Γ
                ;  _∼_ = \A -> \B -> << setoidmaps1 (κ Γ) VV >> (ty.type A) ~ (ty.type B)
-               ; eqrel = record { rf' = λ x → <<>> (λ t → <<>> (refV _)) 
-                                ; sy' = λ x y p → <<>> (λ t → <<>> (symV (>><< (>><< p t))))   
-                                ; tr' = λ x y z p q → <<>> (λ t → <<>> (traV ((>><< (>><< p t))) ((>><< (>><< q t))))) 
-                                } 
+               ; eqrel = record { rf' = λ x → <<>> (λ t → <<>> (refV _))
+                                ; sy' = λ x y p → <<>> (λ t → <<>> (symV (>><< (>><< p t))))
+                                ; tr' = λ x y z p q → <<>> (λ t → <<>> (traV ((>><< (>><< p t))) ((>><< (>><< q t)))))
+                                }
                }
 
 
@@ -188,17 +188,17 @@ record tm (Γ : ctx) (A : ty Γ) : Set1 where
 
 -- Definition of interpretation of the type-theoretic judgements
 --  Γ context
---  Γ ==> A type  
+--  Γ ==> A type
 --  Γ ==> A == B
 --  Γ ==> a :: A
---  Γ ==> a == b :: A 
+--  Γ ==> a == b :: A
 
 -- (make all these into records just as subst to improve inference of hidden variables?)
 
---  Γ context 
+--  Γ context
 --  is just  Γ : ctx
 
---   Γ ==> A type 
+--   Γ ==> A type
 --  is just  A : ty Γ
 
 --  Γ ==> A == B
@@ -226,18 +226,18 @@ record _==>_::_ (Γ : ctx) (a : raw Γ) (A : ty Γ) : Set where
  field
    judge-elt : (x : || κ Γ ||) ->  (apr a x) ∈ (apt A x)
 
-apel :  {Γ : ctx} -> {a : raw Γ} -> {A : ty Γ} 
+apel :  {Γ : ctx} -> {a : raw Γ} -> {A : ty Γ}
         -> (p : Γ ==> a :: A) ->  (u : || κ Γ ||)
         ->  (apr a u) ∈ (apt A u)
 apel p u =  _==>_::_.judge-elt p u
 
---  Γ ==> a == b :: A 
+--  Γ ==> a == b :: A
 
 infix 10  _==>_==_::_
 
 _==>_==_::_ : (Γ : ctx) -> (a b : raw Γ) -> (A : ty Γ) -> Set
 Γ ==> a == b :: A = and ((x : || κ Γ ||) -> (apr a x) ≐ (apr b x)) -- should be raw equality, but size issues
-                        (and (Γ ==> a :: A) (Γ ==> b :: A)) 
+                        (and (Γ ==> a :: A) (Γ ==> b :: A))
 
 
 Raw-lm  : {Γ : ctx} -> {a b : raw Γ}
@@ -254,40 +254,40 @@ Raw-lm2 {Γ} {a} {b} p = <<>> (<<>> (λ x → <<>> (p x)))
 -- Verification of general rules for the type and element equality
 
 
-tyrefl :  {Γ : ctx} 
+tyrefl :  {Γ : ctx}
 --
-         -> (A : ty Γ) 
+         -> (A : ty Γ)
 -- ------------------------
          -> Γ ==> A == A
 --
-tyrefl A = mk-eqty (λ x → refl' _ _) 
+tyrefl A = mk-eqty (λ x → refl' _ _)
 
 
 
-tysym :  {Γ : ctx} -> {A B : ty Γ} 
+tysym :  {Γ : ctx} -> {A B : ty Γ}
 --
-         -> Γ ==> A == B 
---   -------------------------- 
+         -> Γ ==> A == B
+--   --------------------------
          -> Γ ==> B == A
 --
-tysym {A} {B} p = mk-eqty (λ x → sym'  (ape p x)) 
+tysym {A} {B} p = mk-eqty (λ x → sym'  (ape p x))
 
 
 
-tytra :  {Γ : ctx} -> {A B C : ty Γ} 
+tytra :  {Γ : ctx} -> {A B C : ty Γ}
 --
-         -> Γ ==> A == B  -> Γ ==> B == C 
+         -> Γ ==> A == B  -> Γ ==> B == C
 --  -------------------------------------
                 -> Γ ==> A == C
 --
-tytra {A} {B} {C} p q = mk-eqty (λ x → tra' (ape p x) (ape q x)) 
+tytra {A} {B} {C} p q = mk-eqty (λ x → tra' (ape p x) (ape q x))
 
 
 
 
 tmrefl :  {Γ : ctx} -> {A : ty Γ}-> {a : raw Γ}
 --
-         -> Γ ==> a :: A  
+         -> Γ ==> a :: A
 --    ------------------------
          -> Γ ==> a == a :: A
 --
@@ -295,17 +295,17 @@ tmrefl p = pair (λ x → refV _) (pair p p)
 
 
 
-tmsym :  {Γ : ctx} -> (A : ty Γ) -> (a b : raw Γ) 
+tmsym :  {Γ : ctx} -> (A : ty Γ) -> (a b : raw Γ)
 --
-         -> Γ ==> a == b :: A 
+         -> Γ ==> a == b :: A
 --    ------------------------
          -> Γ ==> b == a :: A
 --
 tmsym A a b p = pair (λ x → symV (prj1 p x)) (pair (prj2 (prj2 p)) (prj1 (prj2 p)))
 
-tmtra :  {Γ : ctx} -> (A : ty Γ) -> (a b c : raw Γ) 
+tmtra :  {Γ : ctx} -> (A : ty Γ) -> (a b c : raw Γ)
 --
-         -> Γ ==> a == b :: A   -> Γ ==> b == c :: A 
+         -> Γ ==> a == b :: A   -> Γ ==> b == c :: A
 --  --------------------------------------------------
          -> Γ ==> a == c :: A
 --
@@ -317,55 +317,55 @@ tmtra A a b c p q = pair (λ x → traV (prj1 p x) (prj1 q x)) (pair (prj1 (prj2
 
 -- The crucial type equality is verified
 
-elttyeq :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ} 
+elttyeq :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ}
 --
-      -> Γ ==> a :: A     -> Γ ==> A == B 
+      -> Γ ==> a :: A     -> Γ ==> A == B
 --  --------------------------------------------
               -> Γ ==> a :: B
 --
-elttyeq {Γ} {a} {A} {B} p q =  
+elttyeq {Γ} {a} {A} {B} p q =
     mk-elt (λ x → (e+ (>><< (ape q x)) (pj1 (apel p x))) , traV (pj2 (apel p x)) (e+prop (>><< (ape q x)) (pj1 (apel p x))) )
 
 
 
--- some auxiliary lemmas  
+-- some auxiliary lemmas
 
-pj1elttyeq :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ} 
+pj1elttyeq :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ}
 --
-      -> Γ ==> a :: A     -> Γ ==> A == B 
+      -> Γ ==> a :: A     -> Γ ==> A == B
       -> (x : || κ Γ ||)
       ->  || κ (apt B x) ||
 pj1elttyeq {Γ} {a} {A} {B} p q x = e+ (>><< (ape q x)) (pj1 (apel p x))
 
 
 
-elttyeq-lm :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ} 
-      -> (p : Γ ==> a :: A)     -> (q : Γ ==> A == B)  
-      -> (x : || κ Γ ||)     
+elttyeq-lm :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ}
+      -> (p : Γ ==> a :: A)     -> (q : Γ ==> A == B)
+      -> (x : || κ Γ ||)
       ->  (apr a x) ≐ (apt B x) ‣  (pj1elttyeq p q x) -- (pj1  (apel (elttyeq p q) x))
 elttyeq-lm {Γ} {a} {A} {B} p q x = memV-right-ext-lm2 (apr a x) (apt A x) (apt B x) (apel p x) (>><< (ape q x))
 
 
-elttyeq-lm2 :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ} 
-      -> (p : Γ ==> a :: A)     -> (q : Γ ==> A == B)  
-      -> (x : || κ Γ ||)     
+elttyeq-lm2 :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ}
+      -> (p : Γ ==> a :: A)     -> (q : Γ ==> A == B)
+      -> (x : || κ Γ ||)
       ->  (apr a x) ≐ (apt B x) ‣ (e+ (>><< (ape q x)) (pj1 (apel p x)))
-                           
-elttyeq-lm2 {Γ} {a} {A} {B} p q x = memV-right-ext-lm2 _ _ _ (apel p x) (>><< (ape q x)) 
+
+elttyeq-lm2 {Γ} {a} {A} {B} p q x = memV-right-ext-lm2 _ _ _ (apel p x) (>><< (ape q x))
 
 
 
 
 -- The other cruical type equality rule is verified
 
-elteqtyeq :  {Γ : ctx} ->  (a b : raw Γ)  -> (A B : ty Γ) 
+elteqtyeq :  {Γ : ctx} ->  (a b : raw Γ)  -> (A B : ty Γ)
 --
-      -> Γ ==>  a == b :: A    -> Γ ==> A == B 
+      -> Γ ==>  a == b :: A    -> Γ ==> A == B
 --  ---------------------------------------------
               -> Γ ==>  a == b :: B
 --
-elteqtyeq a b A B p q = pair (prj1 p) 
-                              (pair (elttyeq (prj1 (prj2 p)) q) 
+elteqtyeq a b A B p q = pair (prj1 p)
+                              (pair (elttyeq (prj1 (prj2 p)) q)
                                     (elttyeq (prj2 (prj2 p)) q))
 
 
@@ -384,7 +384,7 @@ infix 12 _[_]
 _[_] : {Δ Γ : ctx}  -> raw Γ ->  subst Δ Γ -> raw Δ
 a [ f ] = sub a f
 
-sub-apply : {Δ Γ : ctx}  
+sub-apply : {Δ Γ : ctx}
      -> (a : raw Γ) ->  (f : subst Δ Γ) -> (x : || κ Δ ||)
      -> apr (a [ f ]) x ≐ apr a (aps f x)
 sub-apply a f x = refV _
@@ -403,7 +403,7 @@ A [[ f ]] = Sub A f
 
 -- (Really want to use _[_] for this as well.)
 
-Sub-apply : {Δ Γ : ctx}  
+Sub-apply : {Δ Γ : ctx}
      -> (A : ty Γ) ->  (f : subst Δ Γ) -> (x : || κ Δ ||)
      -> apt (A [[ f ]]) x ≐ apt A (aps f x)
 Sub-apply a f x = refV _
@@ -412,39 +412,39 @@ Sub-apply a f x = refV _
 
 -- Functorial properties of substitutions for raw terms
 
-sub-id-prop : {Γ : ctx}  
-       -> (a : raw Γ) 
+sub-id-prop : {Γ : ctx}
+       -> (a : raw Γ)
 -- ------------------------------------
-       ->   << Raw Γ >> a [ ids ] ~ a   
+       ->   << Raw Γ >> a [ ids ] ~ a
 --
-sub-id-prop {Γ} a = <<>> (<<>> ((λ x → refl' VV _))) 
+sub-id-prop {Γ} a = <<>> (<<>> ((λ x → refl' VV _)))
 
-sub-comp-prop : {Θ Δ Γ : ctx}  
-       -> (a : raw Γ) 
-       ->  (f : subst Δ Γ) -> (g : subst Θ Δ) 
+sub-comp-prop : {Θ Δ Γ : ctx}
+       -> (a : raw Γ)
+       ->  (f : subst Δ Γ) -> (g : subst Θ Δ)
 -- ---------------------------------------------------
        -> << Raw Θ >>  a [ f ⌢ g ]  ~ (a [ f ] [ g ])
 --
-sub-comp-prop a f g = <<>> (<<>> ( λ x → refl' VV _)) 
+sub-comp-prop a f g = <<>> (<<>> ( λ x → refl' VV _))
 
 -- substitutions from a context equalities and their properties
 
 
--- use   ϕ \varphi for this  - to change ** 
+-- use   ϕ \varphi for this  - to change **
 
 subst-trp : {Γ Δ : ctx} ->  (p : << Ctx >> Γ ~ Δ) -> subst Γ Δ
 subst-trp {Γ} {Δ} p = subst.sb (ctx-trp {Γ} {Δ} (>><< p))
 
 
 
-sub-trp-prop : {Γ : ctx}  -> (a : raw Γ) 
-       ->  (p : << Ctx >> Γ ~ Γ) 
+sub-trp-prop : {Γ : ctx}  -> (a : raw Γ)
+       ->  (p : << Ctx >> Γ ~ Γ)
 -- --------------------------------------------
        -> << Raw Γ >> a [ subst-trp p ]  ~ a
 --
-sub-trp-prop {Γ} a p = 
+sub-trp-prop {Γ} a p =
   <<>> (<<>> (λ x → (let lm : << VV >> apr a (ap (ctx-trp (>><< p)) x) ~ (apr a  x)
-                         lm = extensionality1 (raw.rawterm a) (ap (ctx-trp (>><< p)) x) x (κ-trp-id (>><< p) x) 
+                         lm = extensionality1 (raw.rawterm a) (ap (ctx-trp (>><< p)) x) x (κ-trp-id (>><< p) x)
                       in lm)))
 
 
@@ -453,33 +453,33 @@ sub-trp-prop {Γ} a p =
 -- Functorial properties of substitutions for types
 
 
-Sub-id-prop : {Γ : ctx}  
-           -> (A : ty Γ) 
+Sub-id-prop : {Γ : ctx}
+           -> (A : ty Γ)
 -- -----------------------------------
-      ->  << Ty Γ >> A [[ ids ]] ~ A  
--- 
-Sub-id-prop {Γ} A = <<>> (<<>> (λ x → refl' VV (apt A  x))) 
+      ->  << Ty Γ >> A [[ ids ]] ~ A
+--
+Sub-id-prop {Γ} A = <<>> (<<>> (λ x → refl' VV (apt A  x)))
 
-Sub-id-prop-sym : {Γ : ctx}  
-           -> (A : ty Γ) 
+Sub-id-prop-sym : {Γ : ctx}
+           -> (A : ty Γ)
 -- -----------------------------------
-      ->  << Ty Γ >> A [[ ids ]] ~ A  
--- 
+      ->  << Ty Γ >> A [[ ids ]] ~ A
+--
 Sub-id-prop-sym {Γ} A = sym' (Sub-id-prop {Γ} A)
 
-Sub-comp-prop : {Θ Δ Γ : ctx}  
-       -> (A : ty Γ)  ->  (f : subst Δ Γ) -> (g : subst Θ Δ) 
+Sub-comp-prop : {Θ Δ Γ : ctx}
+       -> (A : ty Γ)  ->  (f : subst Δ Γ) -> (g : subst Θ Δ)
 -- -----------------------------------------------------------
       -> << Ty Θ >>  A [[ f ⌢ g ]]  ~ (A [[ f ]] [[ g ]])
 --
-Sub-comp-prop {Θ} {Δ} {Γ} A f g = <<>> (<<>> (λ x → refl' VV (apt (Sub {Θ} {Δ} (Sub {Δ} {Γ} A f) g) x))) 
+Sub-comp-prop {Θ} {Δ} {Γ} A f g = <<>> (<<>> (λ x → refl' VV (apt (Sub {Θ} {Δ} (Sub {Δ} {Γ} A f) g) x)))
 
 
-Sub-comp-prop-sym : {Θ Δ Γ : ctx}  
-       -> (A : ty Γ) 
-       ->  (f : subst Δ Γ) -> (g : subst Θ Δ) 
+Sub-comp-prop-sym : {Θ Δ Γ : ctx}
+       -> (A : ty Γ)
+       ->  (f : subst Δ Γ) -> (g : subst Θ Δ)
 -- -----------------------------------------------------------
-    -> << Ty Θ >>   (A [[ f ]] [[ g ]]) ~ (A [[ f ⌢ g ]]) 
+    -> << Ty Θ >>   (A [[ f ]] [[ g ]]) ~ (A [[ f ⌢ g ]])
 Sub-comp-prop-sym {Θ} {Δ} {Γ} A f g = sym' (Sub-comp-prop {Θ} {Δ} {Γ} A f g )
 
 
@@ -488,47 +488,47 @@ Sub-comp-prop-sym {Θ} {Δ} {Γ} A f g = sym' (Sub-comp-prop {Θ} {Δ} {Γ} A f 
 
 Sub-trp-prop : {Γ : ctx}  -> (A : ty Γ) ->  (p : << Ctx >> Γ ~ Γ) ->
        << Ty Γ >> A [[ subst-trp p ]]  ~ A
-Sub-trp-prop A p   = <<>> (<<>> (λ x → 
+Sub-trp-prop A p   = <<>> (<<>> (λ x →
                          let lm : << VV >> (apt A (ap (ctx-trp (>><< p)) x)) ~ (apt A  x)
-                             lm = extensionality1 (ty.type A) (ap (ctx-trp (>><< p)) x) x (κ-trp-id (>><< p) x)  
+                             lm = extensionality1 (ty.type A) (ap (ctx-trp (>><< p)) x) x (κ-trp-id (>><< p) x)
                              main :  << VV >> (apt (Sub A (subst-trp p))  x) ~ (apt A  x)
                              main = lm
-                         in main)) 
-             
+                         in main))
+
 
 
 
 -- Application of substitutions to judgements
 
 
-tyeq-subst :  {Δ Γ : ctx} -> {A B : ty Γ} -> (f : subst Δ Γ) 
+tyeq-subst :  {Δ Γ : ctx} -> {A B : ty Γ} -> (f : subst Δ Γ)
 --
-                  -> Γ ==> A == B 
---      -------------------------------------------------- 
+                  -> Γ ==> A == B
+--      --------------------------------------------------
          -> Δ ==> A [[ f ]] ==  B [[ f ]]
 --
 tyeq-subst f p = mk-eqty (λ x → (ape p (aps f x)))
 
 
 
-elt-subst :  {Δ Γ : ctx} -> {a : raw Γ} -> {A : ty Γ} -> (f : subst Δ Γ) 
+elt-subst :  {Δ Γ : ctx} -> {a : raw Γ} -> {A : ty Γ} -> (f : subst Δ Γ)
 --
-         -> Γ ==> a :: A 
---   -------------------------------------------------------- 
+         -> Γ ==> a :: A
+--   --------------------------------------------------------
          -> Δ ==> a [ f ] ::  A [[ f ]]
 --
 elt-subst f p = mk-elt (λ x → apel p (aps f x))
 
 
 
-elteq-subst :  {Δ Γ : ctx} -> {a b : raw Γ} -> {A : ty Γ} -> (f : subst Δ Γ) 
+elteq-subst :  {Δ Γ : ctx} -> {a b : raw Γ} -> {A : ty Γ} -> (f : subst Δ Γ)
 --
-         -> Γ ==> a == b :: A 
+         -> Γ ==> a == b :: A
 --   --------------------------------------------------------------------------
          -> Δ ==> a [ f ] == b [ f ] :: A [[ f ]]
 --
 
-elteq-subst f p = pair (\x -> prj1 p (aps f x)) 
+elteq-subst f p = pair (\x -> prj1 p (aps f x))
                                  (pair (elt-subst f (prj1 (prj2 p)))
                                        (elt-subst f (prj2 (prj2 p))))
 
@@ -537,7 +537,7 @@ elteq-subst f p = pair (\x -> prj1 p (aps f x))
 
 -- equality judgements from raw equalities
 
-tyeq-from-eq : {Γ : ctx} -> (A B : ty Γ) 
+tyeq-from-eq : {Γ : ctx} -> (A B : ty Γ)
      ->  << Ty Γ >> A  ~ B
 --   -------------------------
      -> Γ ==> A == B
@@ -550,35 +550,35 @@ elteq-from-eq : {Γ : ctx} -> (A : ty Γ) ->  (a b : raw Γ)
 --   -------------------------
      -> Γ ==> a == b :: A
 elteq-from-eq A a b p q r =  pair (λ x → >><< (>><< (>><< r) x))
-                                  (pair p q) 
+                                  (pair p q)
 
 -- and the reverse rules
 
-eq-from-tyeq : {Γ : ctx} -> (A B : ty Γ) 
-       -> Γ ==> A == B   
+eq-from-tyeq : {Γ : ctx} -> (A B : ty Γ)
+       -> Γ ==> A == B
 --   -------------------------
      ->  << Ty Γ >> A  ~ B
 eq-from-tyeq {Γ} A B p = <<>> (<<>> (λ x → ape p x))
 
 
 eq-from-elteq : {Γ : ctx} -> (A : ty Γ) ->  (a b : raw Γ)
-      -> Γ ==> a == b :: A 
+      -> Γ ==> a == b :: A
 --   -------------------------
      ->  << Raw Γ >> a ~ b
 eq-from-elteq {Γ} A a b r = <<>> (<<>> (λ x → <<>> (prj1 r x)))
 
 
-tyeq-subst2 :  {Δ Γ : ctx} -> (A : ty Γ) -> (f g : subst Δ Γ) 
+tyeq-subst2 :  {Δ Γ : ctx} -> (A : ty Γ) -> (f g : subst Δ Γ)
 --
                   -> < Subst Δ Γ > f ~ g
---      -------------------------------------------------- 
+--      --------------------------------------------------
          -> Δ ==> A [[ f ]] ==  A [[ g ]]
 --
 tyeq-subst2 A f g p = mk-eqty (\x -> (extensionality1 (ty.type A) (aps f x) (aps g x) ( (>< (>< p)) x)))
 
 
 
-elteq-subst2 :  {Δ Γ : ctx} -> {a  : raw Γ} -> {A : ty Γ} -> (f  g : subst Δ Γ) 
+elteq-subst2 :  {Δ Γ : ctx} -> {a  : raw Γ} -> {A : ty Γ} -> (f  g : subst Δ Γ)
 --
            -> Γ ==> a :: A
            -> < Subst Δ Γ > f ~ g
@@ -592,14 +592,14 @@ elteq-subst2 {Δ} {Γ} {a} {A} f g p q = pair (λ x → >><< ( extensionality1 (
 
 
 tysubst-id : {Γ : ctx}
-    -> (A  : ty Γ) 
+    -> (A  : ty Γ)
 --   -------------------------
      -> Γ ==> (A [[ ids ]]) == A
 --
 tysubst-id A = tyeq-from-eq (A [[ ids ]]) A (Sub-id-prop A)
 
 tysubst-id-sym : {Γ : ctx}
-    -> (A  : ty Γ) 
+    -> (A  : ty Γ)
 --   -------------------------
      -> Γ ==> A == (A [[ ids ]])
 --
@@ -636,11 +636,11 @@ eltsubst-com : {Θ Δ Γ : ctx}
      -> Θ ==> (a [ f ⌢ g ]) == (a [ f ] [ g ]) :: (A [[ f ⌢ g ]])
 --
 eltsubst-com {Θ} {Δ} {Γ} A f g a p = elteq-from-eq (A [[ f ⌢ g ]]) (a [ f ⌢ g ]) ((a [ f ]) [ g ])
-                                      (elt-subst (f ⌢ g) p) (elttyeq (elt-subst g (elt-subst f p)) (tysym (tysubst-com A f g))) (sub-comp-prop a f g) 
+                                      (elt-subst (f ⌢ g) p) (elttyeq (elt-subst g (elt-subst f p)) (tysym (tysubst-com A f g))) (sub-comp-prop a f g)
 
 
 
--- a form of subject reduction 
+-- a form of subject reduction
 
 subj-red : {Γ : ctx} -> {A : ty Γ} ->  (a b : raw Γ)
      -> Γ ==> a :: A    ->  << Raw Γ >> a ~ b
@@ -665,10 +665,9 @@ elteq-from-eq2 {Γ} A a b p q  = elteq-from-eq {Γ} A a b p (subj-red {Γ} {A} a
 
 -- useful coercing lemma
 
-A-Aid :  {Γ : ctx} ->  {a : raw Γ}  -> {A  : ty Γ} 
+A-Aid :  {Γ : ctx} ->  {a : raw Γ}  -> {A  : ty Γ}
 --
-              -> Γ ==> a :: A    
+              -> Γ ==> a :: A
 --  --------------------------------------------
               -> Γ ==> a :: A [[ ids ]]
 A-Aid {Γ} {a} {A} p = elttyeq p (tysubst-id-sym A)
-

--- a/MLTT-and-setoids/V-model-pt0.agda
+++ b/MLTT-and-setoids/V-model-pt0.agda
@@ -72,7 +72,7 @@ aps-ext {a} {b} f x y p = extensionality (subst.cmap f) x y p
 -- identity substitution and a short form
 
 idsubst : {Γ : ctx} -> subst Γ Γ
-idsubst {Γ} = subst.sb (idmap {κ Γ})
+idsubst {Γ} = sb (idmap {κ Γ})
 
 ids : {Γ : ctx} -> subst Γ Γ
 ids {Γ} = idsubst {Γ}
@@ -82,7 +82,7 @@ ids {Γ} = idsubst {Γ}
 infix 5 _⌢_  -- ⌢
 
 _⌢_ : {Θ Δ Γ : ctx} -> (f : subst Δ Γ) -> (g : subst Θ Δ) -> (subst Θ Γ)
-f ⌢ g = subst.sb (subst.cmap f ° subst.cmap g)
+f ⌢ g = sb (subst.cmap f ° subst.cmap g)
 
 
 
@@ -187,7 +187,7 @@ record tm (Γ : ctx) (A : ty Γ) : Set1 where
     corr : (x : || κ Γ ||) ->  (apr trm x) ∈ (apt A x)
 
 -- Definition of interpretation of the type-theoretic judgements
---  Γ context
+--  Γ contexts
 --  Γ ==> A type
 --  Γ ==> A == B
 --  Γ ==> a :: A
@@ -433,7 +433,7 @@ sub-comp-prop a f g = <<>> (<<>> ( λ x → refl' VV _))
 -- use   ϕ \varphi for this  - to change **
 
 subst-trp : {Γ Δ : ctx} ->  (p : << Ctx >> Γ ~ Δ) -> subst Γ Δ
-subst-trp {Γ} {Δ} p = subst.sb (ctx-trp {Γ} {Δ} (>><< p))
+subst-trp {Γ} {Δ} p = sb (ctx-trp {Γ} {Δ} (>><< p))
 
 
 

--- a/MLTT-and-setoids/V-model-pt1.agda
+++ b/MLTT-and-setoids/V-model-pt1.agda
@@ -4,7 +4,7 @@
 
 
 -- Agda version 2.5.2
- 
+
 
 module V-model-pt1 where
 
@@ -34,10 +34,10 @@ _▷_ : (Γ : ctx) -> (A : ty Γ) -> ctx
 
 pp-ext : {Γ : ctx} -> (A : ty Γ) -> (u v : || κ (Γ ▷ A) ||) -> (p : < κ (Γ ▷ A) > u ~ v)
      ->  < κ Γ > pj1 u ~ pj1 v
-pp-ext {Γ} A (u1 , u2) (v1 , v2) p = <> (prj1 (pairV-inv-1 (>< p))) 
+pp-ext {Γ} A (u1 , u2) (v1 , v2) p = <> (prj1 (pairV-inv-1 (>< p)))
 
 pp : {Γ : ctx} -> (A : ty Γ) -> subst (Γ ▷ A) Γ
-pp A = subst.sb (record { op = λ u → pj1 u 
+pp A = subst.sb (record { op = λ u → pj1 u
                         ; ext = λ u v p → pp-ext A u v p   })
 
 
@@ -56,7 +56,7 @@ vv {Γ} A = mkraw (pj2-sigmaV  Γ (ty.type A))
 
 asm : {Γ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
 --   --------------------------------------------------------
       -> Γ ▷ A ==> vv A :: A [[ ↓ A ]]
 --
@@ -71,21 +71,21 @@ asm-apply A x y = (pj2 (apel (asm A) (x , y)))
 
 
 
-ext-op : {Δ Γ : ctx} -> (A : ty Γ) 
-        ->  (f : subst Δ Γ) -> (a : raw Δ) 
+ext-op : {Δ Γ : ctx} -> (A : ty Γ)
+        ->  (f : subst Δ Γ) -> (a : raw Δ)
         -> Δ ==> a :: A [[ f ]]
         -> || κ Δ || -> || κ (Γ ▷ A) ||
 ext-op A f a p u = (aps f u) , (pj1 (apel p u))
-                   
 
 
-ext-ext : {Δ Γ : ctx} -> (A : ty Γ) 
-        ->  (f : subst Δ Γ) -> (a : raw Δ) 
+
+ext-ext : {Δ Γ : ctx} -> (A : ty Γ)
+        ->  (f : subst Δ Γ) -> (a : raw Δ)
         -> (p : Δ ==> a :: A [[ f ]])
-        -> (u  v : || κ Δ ||) 
+        -> (u  v : || κ Δ ||)
         -> < κ Δ > u ~ v
         -> < κ (Γ ▷ A) > ext-op A f a p u ~ ext-op A f a p v
-ext-ext {Δ} {Γ} A f a p u v q = 
+ext-ext {Δ} {Γ} A f a p u v q =
        let  lm1 : < κ Γ > ap (subst.cmap f) u ~ ap (subst.cmap f) v
             lm1 = (extensionality (subst.cmap f) _ _ q)
             lmA : << VV >> (apt A  (ap (subst.cmap f) u)) ~ (apt A  (ap (subst.cmap f) v))
@@ -98,57 +98,57 @@ ext-ext {Δ} {Γ} A f a p u v q =
             lmE = extensionality1 (raw.rawterm a) u v q
             lm2 :  (apt A (ap (subst.cmap f) u)) ‣ pj1 (apel p u) ≐
                    (apt A (ap (subst.cmap f) v)) ‣ pj1 (apel p v)
-            lm2 = traV (symV lmC) (traV (>><< lmE) lmD) 
+            lm2 = traV (symV lmC) (traV (>><< lmE) lmD)
 
        in <> (pairV-ext (>< lm1) lm2)
 
 
 
-ext : {Δ Γ : ctx} -> (A : ty Γ) 
-      ->  (f : subst Δ Γ) -> (a : raw Δ) 
+ext : {Δ Γ : ctx} -> (A : ty Γ)
+      ->  (f : subst Δ Γ) -> (a : raw Δ)
       -> Δ ==> a :: A [[ f ]]
       -> subst Δ (Γ ▷ A)
-ext {Δ} {Γ} A f a p = subst.sb (record { op = ext-op A f a p 
+ext {Δ} {Γ} A f a p = subst.sb (record { op = ext-op A f a p
                                        ; ext = ext-ext A f a p })
 
 
 
-ext-irr : {Δ Γ : ctx} -> (A : ty Γ) 
-      ->  (f : subst Δ Γ) -> (a : raw Δ) 
+ext-irr : {Δ Γ : ctx} -> (A : ty Γ)
+      ->  (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (q : Δ ==> a :: A [[ f ]])
-      -> < Subst Δ (Γ ▷ A) >  (ext A f a p) ~  (ext A f a q) 
-ext-irr {Δ} {Γ} A f a p q  =  
+      -> < Subst Δ (Γ ▷ A) >  (ext A f a p) ~  (ext A f a q)
+ext-irr {Δ} {Γ} A f a p q  =
     <> (<> (\ x -> <> (pairV-ext (refV (Γ ‣ aps f x)) (traV (symV (pj2 (apel p x))) (pj2 (apel q x))))))
 
 
 
 
-ext-prop1 : {Δ Γ : ctx} -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+ext-prop1 : {Δ Γ : ctx} -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> < Subst Δ Γ >  ((↓ A) ⌢ (ext A f a p)) ~ f
 ext-prop1 {Δ} {Γ} A f a p = <> (<> (λ x → refl (κ Γ) (ap (subst.cmap f) x)))
 
 
 
-ext-prop2 : {Δ Γ : ctx} -> (A : ty Γ) 
-      ->  (f : subst Δ Γ) -> (a : raw Δ) 
+ext-prop2 : {Δ Γ : ctx} -> (A : ty Γ)
+      ->  (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> << Raw Δ >>  (vv A) [ ext A f a p ] ~ a
-ext-prop2  A f a p = <<>> (<<>> (λ x → 
+ext-prop2  A f a p = <<>> (<<>> (λ x →
                               let lm5 : (apt A (ap (subst.cmap f) x)) ‣ (pj1 (apel p x)) ≐ (apr a  x)
-                                  lm5 = symV (pj2 (apel p x)) 
+                                  lm5 = symV (pj2 (apel p x))
                                   main : << VV >> apr (sub (vv A) (ext A f a p)) x ~ (apr a x)
                                   main = <<>> lm5
                                in main))
 
 
-ext-prop3-lm : {Γ : ctx}-> (A : ty Γ) -> 
+ext-prop3-lm : {Γ : ctx}-> (A : ty Γ) ->
         (ctx-maps (Γ ▷ A) (Γ ▷ A) setoid.∼
           subst.cmap (ext A (↓ A) (vv A) (asm A)))
           (subst.cmap (ids {Γ ▷ A}))
-ext-prop3-lm {Γ} A (x , y) = 
+ext-prop3-lm {Γ} A (x , y) =
                   <> (  let    lm2 :  < κ (Γ ▷ A) > (x , y)  ~  (x , y)
                                lm2 = refl (κ (Γ ▷ A)) (x , y)
                                lm1 :  < κ (Γ ▷ A) >
@@ -160,46 +160,46 @@ ext-prop3-lm {Γ} A (x , y) =
                                        ~  (x , y)
                                main = lm1
                         in >< main)
-      
+
 ext-prop3 : {Γ : ctx}-> (A : ty Γ) ->
             < Subst (Γ ▷ A) (Γ ▷ A) >  (ext A (↓ A) (vv A) (asm A)) ~ ids {Γ ▷ A}
 ext-prop3 {Γ} A  = <> (<> (ext-prop3-lm {Γ} A))
-      
 
 
 
 
-ext-prop4-lm : {Θ Δ Γ : ctx} -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+
+ext-prop4-lm : {Θ Δ Γ : ctx} -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (h : subst Θ Δ)
       -> Θ ==> a [ h ] :: A [[ f ⌢ h ]]
-ext-prop4-lm  {Θ} {Δ} {Γ} A f a p h = 
+ext-prop4-lm  {Θ} {Δ} {Γ} A f a p h =
           let lm1 :  Θ ==> sub a h :: Sub (Sub  A f) h
-              lm1  = elt-subst h p 
-              lm2a : << Ty Θ >>  (A [[ f ]] [[ h ]])  ~  (A [[ f ⌢ h ]]) 
+              lm1  = elt-subst h p
+              lm2a : << Ty Θ >>  (A [[ f ]] [[ h ]])  ~  (A [[ f ⌢ h ]])
               lm2a = Sub-comp-prop-sym {Θ} {Δ} {Γ} A f h
               lm2 : Θ ==> Sub (Sub A f) h == Sub A (f ⌢ h)
-              lm2 = tyeq-from-eq _ _ lm2a 
+              lm2 = tyeq-from-eq _ _ lm2a
               main :  Θ ==> sub a h :: Sub A (f ⌢ h)
               main = elttyeq lm1 lm2
           in main
 
 
-ext-prop4-lm2 : {Θ Δ Γ : ctx} -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+ext-prop4-lm2 : {Θ Δ Γ : ctx} -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (h : subst Θ Δ)
       -> (q : Θ ==> a [ h ] :: A [[ f ⌢ h ]])
 --    --------------------------------------------
       -> < Subst Θ (Γ ▷ A) > ((ext A f a p) ⌢ h) ~ (ext A (f ⌢ h) (a [ h ]) q)
 --
-ext-prop4-lm2 {Θ} {Δ} {Γ} A f a p h q = <> (<> (λ u → 
+ext-prop4-lm2 {Θ} {Δ} {Γ} A f a p h q = <> (<> (λ u →
               let lm1 :  Γ ‣ ap (subst.cmap f) (ap (subst.cmap h) u) ≐ Γ ‣ ap (subst.cmap (f ⌢ h)) u
                   lm1 = refV _
                   lm2 : << VV >> (apt A  (ap (subst.cmap f) (ap (subst.cmap h) u))) ~
                                (apt A  (ap (subst.cmap (f ⌢ h)) u))
-                  lm2 = extensionality1 (ty.type A) (ap (subst.cmap f) (ap (subst.cmap h) u)) 
+                  lm2 = extensionality1 (ty.type A) (ap (subst.cmap f) (ap (subst.cmap h) u))
                                                     (ap (subst.cmap (f ⌢ h)) u)  (<> lm1)
                   p2  : apr a (ap (subst.cmap h) u) ≐
                         (apt (A [[ f ]])  (ap (subst.cmap h) u) ‣ pj1 (apel p (ap (subst.cmap h) u)))
@@ -211,15 +211,15 @@ ext-prop4-lm2 {Θ} {Δ} {Γ} A f a p h q = <> (<> (λ u →
                   lm3 = traV (symV p2) (traV q2 (refV _))
                   main : < κ (Γ ▷ A) >  ap (subst.cmap (ext A f a p))  (ap (subst.cmap h) u) ~
                                         ap (subst.cmap (ext A (f ⌢ h) (sub a h) q)) u
-                  main = <> (pairV-ext lm1 lm3) 
+                  main = <> (pairV-ext lm1 lm3)
               in main))
-   
 
 
 
-           
-ext-prop4 : {Θ Δ Γ : ctx} -> (A : ty Γ) 
-      -> (f : subst Δ Γ) -> (a : raw Δ) 
+
+
+ext-prop4 : {Θ Δ Γ : ctx} -> (A : ty Γ)
+      -> (f : subst Δ Γ) -> (a : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (h : subst Θ Δ)
 --  --------------------------
@@ -233,7 +233,7 @@ ext-prop4 {Θ} {Δ} {Γ} A f a p h = ext-prop4-lm2 A f a p h (ext-prop4-lm  A f 
 
 ext-eq-half-lm : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (Γ ==> A == A')
 -- --------------------------
       -> (Γ ▷ A) ≤ (Γ ▷ A')
@@ -242,7 +242,7 @@ ext-eq-half-lm {Γ} A A' p (x , y) =  ( (x , (ap (κ-Fam ±± ape p x) y))) , (p
 
 ext-eq-half2-lm : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (Γ ==> A == A')
 -- --------------------------
       -> (Γ ▷ A) ≥ (Γ ▷ A')
@@ -253,54 +253,54 @@ ext-eq-half2-lm {Γ} A A' p (x , y) =  (x , (ap (κ-Fam ±± ape (tysym p) x) y)
 
 ext-eq : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (Γ ==> A == A')
 -- --------------------------
       -> (Γ ▷ A) ≐ (Γ ▷ A')
-ext-eq {Γ} A A' p = pair (ext-eq-half-lm  {Γ} A A' p) (ext-eq-half2-lm {Γ} A A' p) 
+ext-eq {Γ} A A' p = pair (ext-eq-half-lm  {Γ} A A' p) (ext-eq-half2-lm {Γ} A A' p)
 
 
 
 
 ext-eq-lm : {Γ : ctx}
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (p : Γ ==> A == A')
       -> (x : || κ Γ ||)
       -> (y : || κ (apt A x)||)
       -> < κ (Γ ▷ A') > (ap (κ-trp (ext-eq A A' p) ) (x , y)) ~ (x , (ap (κ-Fam ±± ape p x) y))
-ext-eq-lm {Γ} A A' p x y = refl _ _ 
+ext-eq-lm {Γ} A A' p x y = refl _ _
 
 
 
 
-subst-trp-id :  {Γ : ctx} ->  (p : << Ctx >> Γ ~ Γ) 
+subst-trp-id :  {Γ : ctx} ->  (p : << Ctx >> Γ ~ Γ)
       -> < Subst Γ Γ > subst-trp p ~ ids {Γ}
-subst-trp-id {Γ} p = <> (<> (λ x → κ-trp-id (>><< p) x)) 
+subst-trp-id {Γ} p = <> (<> (λ x → κ-trp-id (>><< p) x))
 
 
 
-subst-trp-irr :  {Γ Δ : ctx} 
-      ->  (p q : << Ctx >> Γ ~ Δ) 
+subst-trp-irr :  {Γ Δ : ctx}
+      ->  (p q : << Ctx >> Γ ~ Δ)
       -> < Subst Γ Δ > subst-trp p ~ subst-trp q
-subst-trp-irr {Γ} {Δ} p q = <> (<> (λ x → κ-trp-irr (>><< p) (>><< q) x))  
+subst-trp-irr {Γ} {Δ} p q = <> (<> (λ x → κ-trp-irr (>><< p) (>><< q) x))
 
 
-subst-trp-fun :  {Γ Δ  Θ : ctx} 
-    ->  (p : << Ctx >> Γ ~ Δ)   ->  (q : << Ctx >> Δ ~ Θ) 
+subst-trp-fun :  {Γ Δ  Θ : ctx}
+    ->  (p : << Ctx >> Γ ~ Δ)   ->  (q : << Ctx >> Δ ~ Θ)
     ->  (r : << Ctx >> Γ ~ Θ)
     -> < Subst Γ Θ > ((subst-trp q) ⌢ (subst-trp p)) ~ subst-trp r
 subst-trp-fun {Γ} {Δ} {Θ} p q r = <> (<> (λ x → sym (κ-trp-fn (>><< q) (>><< p) (>><< r) x)))
 
-subst-trp-inv :  {Γ Δ : ctx} 
-    ->  (p : << Ctx >> Γ ~ Δ)   ->  (q : << Ctx >> Δ ~ Γ) 
+subst-trp-inv :  {Γ Δ : ctx}
+    ->  (p : << Ctx >> Γ ~ Δ)   ->  (q : << Ctx >> Δ ~ Γ)
     -> < Subst Γ Γ > ((subst-trp q) ⌢ (subst-trp p)) ~ ids {Γ}
 subst-trp-inv {Γ} {Δ} p q = tra (subst-trp-fun p q (tra' p q)) (subst-trp-id _)
 
-subst-trp-lm :  {Γ Δ : ctx} 
-      ->  (p : << Ctx >> Γ ~ Δ) 
+subst-trp-lm :  {Γ Δ : ctx}
+      ->  (p : << Ctx >> Γ ~ Δ)
       ->  (x : # Γ)
       ->  Γ ‣ x ≐ Δ ‣ aps (subst-trp p) x
-subst-trp-lm {Γ} {Δ} p x = 
+subst-trp-lm {Γ} {Δ} p x =
      let q : Γ ≐ Δ
          q = >><< p
          main :  Γ ‣ x ≐ Δ ‣ aps (subst-trp p) x
@@ -309,16 +309,16 @@ subst-trp-lm {Γ} {Δ} p x =
 
 half1-ext-eq'' : {Γ Δ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
       -> (B : ty Δ)
       -> (p : << Ctx >> Γ ~ Δ)
       -> (Γ ==> A == B [[ subst-trp p ]])
 -- --------------------------
       -> (Γ ▷ A) ≤ (Δ ▷ B)
-half1-ext-eq'' {Γ} {Δ} A B p q (x , y) = 
+half1-ext-eq'' {Γ} {Δ} A B p q (x , y) =
           let eq :  (type A • x) ≐ (type B • aps (subst-trp p) x)
               eq = >><< (ape q x)
-          in ((aps (subst-trp p) x) ,  (ap (κ-Fam ±± ape q x) y)) , 
+          in ((aps (subst-trp p) x) ,  (ap (κ-Fam ±± ape q x) y)) ,
                     pairV-ext (subst-trp-lm {Γ} {Δ} p x) (e+prop eq y)
 
 
@@ -326,13 +326,13 @@ half1-ext-eq'' {Γ} {Δ} A B p q (x , y) =
 
 half2-ext-eq'' : {Γ Δ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
       -> (B : ty Δ)
       -> (p : << Ctx >> Γ ~ Δ)
       -> (Γ ==> A == B [[ subst-trp p ]])
 -- --------------------------
       -> (Γ ▷ A) ≥ (Δ ▷ B)
-half2-ext-eq'' {Γ} {Δ} A B p q (x , y) = 
+half2-ext-eq'' {Γ} {Δ} A B p q (x , y) =
   let lm : (Δ ==> A [[ subst-trp (sym' p) ]] == B [[ subst-trp p ]] [[ subst-trp (sym' p) ]])
       lm = tyeq-subst (subst-trp (sym' p)) q
       lm0 : < Subst Δ Δ >  (subst-trp p) ⌢ (subst-trp (sym' p))  ~  ids
@@ -345,7 +345,7 @@ half2-ext-eq'' {Γ} {Δ} A B p q (x , y) =
       lm3 = tysubst-id B
       q' :  (Δ ==> B == A [[ subst-trp (sym' p) ]])
       q' = tysym (tytra lm (tytra lm2 lm3))
-      eq :  (type B • x) ≐ (type A • aps (subst-trp (sym' p)) x) 
+      eq :  (type B • x) ≐ (type A • aps (subst-trp (sym' p)) x)
       eq =  >><< (ape q' x)
 
   in ((aps (subst-trp (sym' p)) x) ,  (ap (κ-Fam ±± ape q' x) y)) ,
@@ -355,18 +355,18 @@ half2-ext-eq'' {Γ} {Δ} A B p q (x , y) =
 
 ext-eq'' : {Γ Δ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
       -> (B : ty Δ)
       -> (p : << Ctx >> Γ ~ Δ)
       -> (Γ ==> A == B [[ subst-trp p ]])
 -- --------------------------
       -> << Ctx >> (Γ ▷ A) ~ (Δ ▷ B)
-ext-eq'' {Γ} {Δ} A B p q = <<>> (pair (half1-ext-eq'' {Γ} {Δ} A B p q) (half2-ext-eq'' {Γ} {Δ} A B p q)) 
+ext-eq'' {Γ} {Δ} A B p q = <<>> (pair (half1-ext-eq'' {Γ} {Δ} A B p q) (half2-ext-eq'' {Γ} {Δ} A B p q))
 
 
 ↓-cong-lm  : {Γ Δ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
       -> (B : ty Δ)
       -> (p : << Ctx >> Γ ~ Δ)
       -> (q : Γ ==> A == B [[ subst-trp p ]])
@@ -378,19 +378,19 @@ ext-eq'' {Γ} {Δ} A B p q = <<>> (pair (half1-ext-eq'' {Γ} {Δ} A B p q) (half
 
 ↓-cong  : {Γ Δ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
       -> (B : ty Δ)
       -> (p : << Ctx >> Γ ~ Δ)
       -> (q : Γ ==> A == B [[ subst-trp p ]])
 -- --------------------------
-      -> < Subst (Γ ▷ A) Δ > ((subst-trp p) ⌢ (↓ A)) ~ ((↓ B) ⌢ (subst-trp (ext-eq'' {Γ} {Δ} A B p q))) 
+      -> < Subst (Γ ▷ A) Δ > ((subst-trp p) ⌢ (↓ A)) ~ ((↓ B) ⌢ (subst-trp (ext-eq'' {Γ} {Δ} A B p q)))
 ↓-cong {Γ} {Δ} A B p q = <> (<> (λ x → <> (↓-cong-lm  {Γ} {Δ} A B p q x)))
 
 
 
 asm-cong-raw-lm  : {Γ Δ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
       -> (B : ty Δ)
       -> (p : << Ctx >> Γ ~ Δ)
       -> (q : Γ ==> A == B [[ subst-trp p ]])
@@ -400,7 +400,7 @@ asm-cong-raw-lm  : {Γ Δ : ctx}
 asm-cong-raw-lm {Γ} {Δ} A B p q (x , y) =
    let lm : raw.rawterm (vv A) • (x , y) ≐ (apt A  x) ‣ y
        lm = refV _
-       lm0 :  apt A x ≐  apt (B [[ subst-trp p ]]) x 
+       lm0 :  apt A x ≐  apt (B [[ subst-trp p ]]) x
        lm0 = >><< (ape q x)
        lm0b :  apt (B [[ subst-trp p ]]) x ≐  apt B (aps (subst-trp p) x)
        lm0b = Sub-apply B (subst-trp p) x
@@ -409,9 +409,9 @@ asm-cong-raw-lm {Γ} {Δ} A B p q (x , y) =
        lm0d :  apt B (aps (subst-trp p) x) ‣ e+ (traV (>><< (ape q x)) (Sub-apply B (subst-trp p) x)) y
                 ≐ apt B (aps (subst-trp p) x) ‣ ap (κ-Fam ±± ape q x) y
        lm0d = >< (κ-trp-irr (traV (>><< (ape q x)) (Sub-apply B (subst-trp p) x)) lm0 y)
-       lm1 :  (apt A x) ‣ y ≐ (apt B (aps (subst-trp p) x)) ‣ (ap (κ-Fam ±± ape q x) y) 
+       lm1 :  (apt A x) ‣ y ≐ (apt B (aps (subst-trp p) x)) ‣ (ap (κ-Fam ±± ape q x) y)
        lm1 = traV (e+prop lm0c y) lm0d
-       lm2 : apr (vv B [ subst-trp (ext-eq'' A B p q) ]) (x , y)  ≐ 
+       lm2 : apr (vv B [ subst-trp (ext-eq'' A B p q) ]) (x , y)  ≐
              apr (vv B) (aps (subst-trp (ext-eq'' A B p q)) (x , y))
        lm2 = sub-apply (vv B) (subst-trp (ext-eq'' A B p q)) (x , y)
        main : raw.rawterm (vv A) • (x , y) ≐ (raw.rawterm (vv B [ subst-trp (ext-eq'' A B p q) ]) • (x , y))
@@ -422,7 +422,7 @@ asm-cong-raw-lm {Γ} {Δ} A B p q (x , y) =
 
 asm-cong-raw  : {Γ Δ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
       -> (B : ty Δ)
       -> (p : << Ctx >> Γ ~ Δ)
       -> (q : Γ ==> A == B [[ subst-trp p ]])
@@ -432,21 +432,21 @@ asm-cong-raw {Γ} {Δ} A B p q = <<>> (<<>> (λ x → <<>> (asm-cong-raw-lm {Γ}
 
 asm-cong  : {Γ Δ : ctx}
 --
-      -> (A : ty Γ) 
+      -> (A : ty Γ)
       -> (B : ty Δ)
       -> (p : << Ctx >> Γ ~ Δ)
       -> (q : Γ ==> A == B [[ subst-trp p ]])
 -- --------------------------
       ->  Γ ▷ A ==>  vv A == (vv B) [ subst-trp (ext-eq'' {Γ} {Δ} A B p q) ] :: A [[ ↓ A ]]
-asm-cong {Γ} {Δ} A B p q = 
+asm-cong {Γ} {Δ} A B p q =
    let rw = (asm-cong-raw {Γ} {Δ} A B p q)
-   in  pair (Raw-lm rw) 
-            (pair (asm A) 
+   in  pair (Raw-lm rw)
+            (pair (asm A)
                   (subj-red _ _  (asm A) rw))
 
 
-ext-cong-lm : {Δ Γ : ctx} -> (A : ty Γ) 
-      -> (f g : subst Δ Γ) -> (a b : raw Δ) 
+ext-cong-lm : {Δ Γ : ctx} -> (A : ty Γ)
+      -> (f g : subst Δ Γ) -> (a b : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (q : Δ ==> b :: A [[ g ]])
       ->  < Subst Δ Γ > f ~ g
@@ -466,8 +466,8 @@ ext-cong-lm {Δ} {Γ} A f g a b p q eq r u =
   in <> (pairV-ext lm lm2)
 
 
-ext-cong : {Δ Γ : ctx} -> (A : ty Γ) 
-      -> (f g : subst Δ Γ) -> (a b : raw Δ) 
+ext-cong : {Δ Γ : ctx} -> (A : ty Γ)
+      -> (f g : subst Δ Γ) -> (a b : raw Δ)
       -> (p : Δ ==> a :: A [[ f ]])
       -> (q : Δ ==> b :: A [[ g ]])
       ->  < Subst Δ Γ > f ~ g
@@ -479,9 +479,9 @@ ext-cong {Δ} {Γ} A f g a b p q eq r = <> (<> (λ u → (ext-cong-lm {Δ} {Γ} 
 
 -- substitution of an element in the last argument and a short form
 
-ext-el :  
-       {Γ : ctx} 
-    -> (A : ty Γ)   
+ext-el :
+       {Γ : ctx}
+    -> (A : ty Γ)
     -> (a : raw Γ)
     -> (Γ ==> a :: A)
     -> subst Γ (Γ ▷ A)
@@ -490,17 +490,17 @@ ext-el {Γ} A a p = ext A (ids {Γ}) a p
 
 
 
-els  :  
-       {Γ : ctx} 
-    -> {A : ty Γ}   
+els  :
+       {Γ : ctx}
+    -> {A : ty Γ}
     -> {a : raw Γ}
     -> (Γ ==> a :: A)
     -> subst Γ (Γ ▷ A)
 els {Γ} {A} {a} p = ext-el {Γ} A a p
 
 
-els-irr :   {Γ : ctx} 
-    -> {A : ty Γ}   
+els-irr :   {Γ : ctx}
+    -> {A : ty Γ}
     -> {a : raw Γ}
     -> (p : Γ ==> a :: A)
     -> (q : Γ ==> a :: A)
@@ -508,20 +508,20 @@ els-irr :   {Γ : ctx}
 els-irr {Γ} {A} {a} p q = ext-irr A (ids {Γ}) a p q
 
 
-els-cong :   {Γ : ctx} 
-    -> {A : ty Γ}   
+els-cong :   {Γ : ctx}
+    -> {A : ty Γ}
     -> {a a' : raw Γ}
     -> (p : Γ ==> a :: A)
     -> (q : Γ ==> a' :: A)
     -> (Γ ==> a == a' :: A)
     -> < Subst Γ (Γ ▷ A) > els p ~ els q
 els-cong {Γ} {A} {a} {a'} p q r =
- <> (<> 
-   (\ x -> 
- 
+ <> (<>
+   (\ x ->
+
      let lm1 : apr a x ≐ apt A x ‣ pj1 (apel p x)
          lm1 = pj2 (apel p x)
-         lm2 : apr a' x ≐ apt A x ‣ pj1 (apel q x)         
+         lm2 : apr a' x ≐ apt A x ‣ pj1 (apel q x)
          lm2 = pj2 (apel q x)
          lm : (ty.type A • aps (ids {Γ}) x) ‣ pj1 (apel p x) ≐ (ty.type A • aps (ids {Γ}) x) ‣ pj1 (apel q x)
          lm = traV (symV lm1) (traV (prj1 r x) lm2)
@@ -529,24 +529,24 @@ els-cong {Γ} {A} {a} {a'} p q r =
   ))
 
 
-els-exp : {Γ : ctx} 
-    -> {A : ty Γ}   
+els-exp : {Γ : ctx}
+    -> {A : ty Γ}
     -> {a : raw Γ}
     -> (p : Γ ==> a :: A)
-    -> < Subst Γ (Γ ▷ A) > els p ~  ext A (ids {Γ}) a p 
-els-exp {Γ} {A} {a} p = refl (Subst Γ (Γ ▷ A)) (els p) 
+    -> < Subst Γ (Γ ▷ A) > els p ~  ext A (ids {Γ}) a p
+els-exp {Γ} {A} {a} p = refl (Subst Γ (Γ ▷ A)) (els p)
 
 
-qq :  {Δ Γ : ctx} 
+qq :  {Δ Γ : ctx}
 --
-     -> (A : ty Γ)    -> (h : subst Δ Γ) 
+     -> (A : ty Γ)    -> (h : subst Δ Γ)
 --  --------------------------------------
      -> subst (Δ ▷ (A [[ h ]])) (Γ ▷ A)
-qq A h = ext  A 
-                         (h ⌢ (↓ (A [[ h ]]))) 
-                         (vv (A [[ h ]])) (elttyeq  
+qq A h = ext  A
+                         (h ⌢ (↓ (A [[ h ]])))
+                         (vv (A [[ h ]])) (elttyeq
                                      (asm (A [[ h ]]))
-                                     (tyeq-from-eq  ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) (A [[ h ⌢ ↓ (A [[ h ]]) ]]) 
+                                     (tyeq-from-eq  ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) (A [[ h ⌢ ↓ (A [[ h ]]) ]])
                                            (Sub-comp-prop-sym A h (↓ (A [[ h ]])))
                                      ))
 
@@ -556,32 +556,32 @@ qq A h = ext  A
 
 -- short for qq is ↑ entered  \u
 
-↑ :  {Δ Γ : ctx}  -> (A : ty Γ)    -> (h : subst Δ Γ) 
+↑ :  {Δ Γ : ctx}  -> (A : ty Γ)    -> (h : subst Δ Γ)
      -> subst (Δ ▷ (A [[ h ]])) (Γ ▷ A)
 ↑ A h = qq A h
 
 
 
 
-qq-eq :  {Δ Γ : ctx} 
-       -> (A : ty Γ)    -> (h : subst Δ Γ) 
+qq-eq :  {Δ Γ : ctx}
+       -> (A : ty Γ)    -> (h : subst Δ Γ)
        -> (x : # Δ)
        -> (y : # (apt (A [[ h ]]) x))
-       -> < κ (Γ ▷ A) > aps (↑ A h) (x , y) ~ (aps h x , y) 
-qq-eq {Δ} {Γ} A h x y = 
+       -> < κ (Γ ▷ A) > aps (↑ A h) (x , y) ~ (aps h x , y)
+qq-eq {Δ} {Γ} A h x y =
 
     let lm2 = elttyeq-lm (asm (A [[ h ]]))
-                         (tyeq-from-eq 
+                         (tyeq-from-eq
                            ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]])
                            (A [[ h ⌢ ↓ (A [[ h ]]) ]])
                            (Sub-comp-prop-sym A h (↓ (A [[ h ]]))))
                          (x , y)
-              
+
         lm : (apt A (aps (h ⌢ ↓ (A [[ h ]])) (x , y))) ‣
               pj1
-             (apel (elttyeq 
+             (apel (elttyeq
                       (asm (A [[ h ]]))
-             (tyeq-from-eq 
+             (tyeq-from-eq
                ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]])
                (A [[ h ⌢ ↓ (A [[ h ]]) ]])
                (Sub-comp-prop-sym A h (↓ (A [[ h ]])))
@@ -593,37 +593,37 @@ qq-eq {Δ} {Γ} A h x y =
 
 
 
-qq-ext-el-lm :  {Γ : ctx} 
+qq-ext-el-lm :  {Γ : ctx}
     -> (A : ty Γ)
     -> < Subst (Γ ▷ A) (Γ ▷ A) >  ((↑ A (↓ A))  ⌢  (els (asm A)))
                                          ~ (ids {Γ ▷ A})
-qq-ext-el-lm {Γ} A  = 
-  <> (<> (λ z → 
+qq-ext-el-lm {Γ} A  =
+  <> (<> (λ z →
    let lm2 = elttyeq-lm
                 (asm {Γ ▷ A} (A [[ ↓ A ]]))
-                (tyeq-from-eq 
+                (tyeq-from-eq
                  ((A [[ ↓ A ]]) [[ ↓ (A [[ ↓ A ]]) ]])
                     (A [[ ↓ A ⌢ ↓ (A [[ ↓ A ]]) ]])
                  (Sub-comp-prop-sym A (↓ A) (↓ (A [[ ↓ A ]]))))
-                (aps (els (asm A)) 
+                (aps (els (asm A))
                   z)
- 
+
        lm : (apt A
              (aps (pp A ⌢ ↓ (A [[ ↓ A ]]))
              (aps (els (asm A))
               z)))
             ‣
             pj1
-            (apel (elttyeq 
+            (apel (elttyeq
                   (asm (A [[ ↓ A ]]))
-                  (tyeq-from-eq 
+                  (tyeq-from-eq
                       ((A [[ ↓ A ]]) [[ ↓ (A [[ ↓ A ]]) ]])
                       (A [[ ↓ A ⌢ ↓ (A [[ ↓ A ]]) ]])
                      (Sub-comp-prop-sym A ( ↓ A) ( ↓ (A [[ ↓ A ]])))))
                   (aps (els (asm A))
               z))
             ≐ (apt A (pj1 z)) ‣ (pj2 z)
-       lm = traV (symV lm2) (refV _)  
+       lm = traV (symV lm2) (refV _)
 
    in <> (pairV-ext (refV (Γ ‣ (pj1 z))) lm )))
 
@@ -640,10 +640,10 @@ B-up-lm2 :  {Δ Γ : ctx}  -> (h : subst Δ Γ)
     -> (x  : || κ Δ ||)
     -> (y : || κ (apt (A [[ h ]]) x) ||)
     -> (z : || κ (apt (B [[ ↑ A (h) ]]) (x , y)) ||)
-    -> apt (B [[ ↑ A (h) ]]) (x , y)  ‣ z  ≐ apt B ((aps h x) , y)  ‣ (e+ (B-up-lm {Δ} {Γ} h A B x y) z) 
-B-up-lm2 {Δ} {Γ} h A B x y z = e+prop  (B-up-lm {Δ} {Γ} h A B x y) z 
+    -> apt (B [[ ↑ A (h) ]]) (x , y)  ‣ z  ≐ apt B ((aps h x) , y)  ‣ (e+ (B-up-lm {Δ} {Γ} h A B x y) z)
+B-up-lm2 {Δ} {Γ} h A B x y z = e+prop  (B-up-lm {Δ} {Γ} h A B x y) z
 
-B-up-down-lm :  {Γ : ctx} 
+B-up-down-lm :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (x  : || κ (Γ ▷ A) ||)
     -> (y : || κ (apt (A [[ (↓ A) ]]) x) ||)
@@ -651,27 +651,26 @@ B-up-down-lm :  {Γ : ctx}
 B-up-down-lm  {Γ} A B x y = >><< (extensionality1 (ty.type B) _ (((aps (↓ A) x) , y)) (qq-eq {Γ ▷ A} {Γ} A (↓ A) x y ))
 
 
-B-up-down-lm2 :  {Γ : ctx}  
+B-up-down-lm2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (x  : || κ (Γ ▷ A) ||)
     -> (y : || κ (apt (A [[ ↓ A ]]) x) ||)
     -> (z : || κ (apt (B [[ ↑ A (↓ A) ]]) (x , y)) ||)
-    -> apt (B [[ ↑ A (↓ A) ]]) (x , y)  ‣ z  ≐ apt B ((aps (↓ A) x) , y)  ‣ (e+ (B-up-down-lm {Γ} A B x y) z) 
-B-up-down-lm2 {Γ} A B x y z = e+prop  (B-up-down-lm  {Γ}  A B x y) z 
+    -> apt (B [[ ↑ A (↓ A) ]]) (x , y)  ‣ z  ≐ apt B ((aps (↓ A) x) , y)  ‣ (e+ (B-up-down-lm {Γ} A B x y) z)
+B-up-down-lm2 {Γ} A B x y z = e+prop  (B-up-down-lm  {Γ}  A B x y) z
 
 
 
 
 
 
-qq-exp : {Δ Γ : ctx}  
-       -> (A : ty Γ)  -> (h : subst Δ Γ) 
+qq-exp : {Δ Γ : ctx}
+       -> (A : ty Γ)  -> (h : subst Δ Γ)
        -> (a : raw Δ)
        -> (p : (Δ  ▷ (A [[ h ]]) ==> (vv (A [[ h ]])) :: A [[ h ⌢ (↓ (A [[ h ]])) ]]))
        -> < Subst (Δ ▷ (A [[ h ]])) (Γ ▷ A) > (↑ A h) ~ (ext A (h ⌢ (↓ (A [[ h ]]))) (vv (A [[ h ]])) p)
-qq-exp {Δ} {Γ} A h a p = ext-irr A (h ⌢ (↓ (A [[ h ]]))) (vv (A [[ h ]])) 
-             (elttyeq (asm (A [[ h ]])) (tyeq-from-eq  ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) (A [[ h ⌢ ↓ (A [[ h ]]) ]]) 
+qq-exp {Δ} {Γ} A h a p = ext-irr A (h ⌢ (↓ (A [[ h ]]))) (vv (A [[ h ]]))
+             (elttyeq (asm (A [[ h ]])) (tyeq-from-eq  ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) (A [[ h ⌢ ↓ (A [[ h ]]) ]])
                                            (Sub-comp-prop-sym A h (↓ (A [[ h ]])))
                                      )) p
-
 

--- a/MLTT-and-setoids/V-model-pt1.agda
+++ b/MLTT-and-setoids/V-model-pt1.agda
@@ -37,7 +37,7 @@ pp-ext : {Γ : ctx} -> (A : ty Γ) -> (u v : || κ (Γ ▷ A) ||) -> (p : < κ (
 pp-ext {Γ} A (u1 , u2) (v1 , v2) p = <> (prj1 (pairV-inv-1 (>< p)))
 
 pp : {Γ : ctx} -> (A : ty Γ) -> subst (Γ ▷ A) Γ
-pp A = subst.sb (record { op = λ u → pj1 u
+pp A = sb (record { op = λ u → pj1 u
                         ; ext = λ u v p → pp-ext A u v p   })
 
 
@@ -108,7 +108,7 @@ ext : {Δ Γ : ctx} -> (A : ty Γ)
       ->  (f : subst Δ Γ) -> (a : raw Δ)
       -> Δ ==> a :: A [[ f ]]
       -> subst Δ (Γ ▷ A)
-ext {Δ} {Γ} A f a p = subst.sb (record { op = ext-op A f a p
+ext {Δ} {Γ} A f a p = sb (record { op = ext-op A f a p
                                        ; ext = ext-ext A f a p })
 
 
@@ -673,4 +673,3 @@ qq-exp {Δ} {Γ} A h a p = ext-irr A (h ⌢ (↓ (A [[ h ]]))) (vv (A [[ h ]]))
              (elttyeq (asm (A [[ h ]])) (tyeq-from-eq  ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) (A [[ h ⌢ ↓ (A [[ h ]]) ]])
                                            (Sub-comp-prop-sym A h (↓ (A [[ h ]])))
                                      )) p
-

--- a/MLTT-and-setoids/V-model-pt10.agda
+++ b/MLTT-and-setoids/V-model-pt10.agda
@@ -15,7 +15,7 @@ open import subsetoids          -- 341 lines
 open import iterative-sets      -- 869 lines
 open import iterative-sets-pt2  -- 326 lines
 open import iterative-sets-pt3  -- 439 lines
-open import iterative-sets-pt4  
+open import iterative-sets-pt4
 open import V-model-pt0
 open import V-model-pt1         -- 776 lines
 open import V-model-pt2         -- 511 lines
@@ -37,7 +37,7 @@ open import V-model-pt9         -- 441 lines
 ⊤-unique 0₁ 0₁ = <> (easy-eqV _  br-zeroV  br-zeroV (λ z → exfalso _ z))
 
 ! : (Γ : ctx) -> subst Γ ⊤
-! Γ = sb (record { op = λ x → 0₁ 
+! Γ = sb (record { op = λ x → 0₁
                  ; ext = λ x y p → <> (easy-eqV _ br-zeroV br-zeroV (λ z → exfalso _ z))})
 
 !-unique : (Γ : ctx) -> (f : subst Γ ⊤) -> < Subst Γ ⊤ > f ~ ! Γ
@@ -45,28 +45,28 @@ open import V-model-pt9         -- 441 lines
 
 
 !-sub : (Δ Γ : ctx) -> (f : subst  Δ Γ) -> < Subst Δ ⊤ >  ! Γ ⌢ f ~ ! Δ
-!-sub Δ Γ f = !-unique Δ (! Γ ⌢ f) 
+!-sub Δ Γ f = !-unique Δ (! Γ ⌢ f)
 
 
 -- to be moved elsewhere probably
 
 
 
-Ext-eq-lm1 :  (Γ : ctx) 
+Ext-eq-lm1 :  (Γ : ctx)
            -> (A : ty Γ)
            ->  (z z' : || κ (Γ ▷ A) ||)
            ->  (< κ (Γ ▷ A) >  z ~ z')
-           ->  and (Γ ‣ (pj1 z)  ≐  Γ ‣ (pj1 z')) 
+           ->  and (Γ ‣ (pj1 z)  ≐  Γ ‣ (pj1 z'))
                    (((ty.type A) • (pj1 z)) ‣ (pj2 z)  ≐  ((ty.type A) • (pj1 z')) ‣ (pj2 z'))
-Ext-eq-lm1 Γ A z z' p = pairV-inv-1 (>< p) 
+Ext-eq-lm1 Γ A z z' p = pairV-inv-1 (>< p)
 
-Ext-eq-lm2 :   (Γ : ctx) 
+Ext-eq-lm2 :   (Γ : ctx)
            ->  (A : ty Γ)
            ->  (z z' : || κ (Γ ▷ A) ||)
-           ->  (Γ ‣ (pj1 z)  ≐  Γ ‣ (pj1 z')) 
+           ->  (Γ ‣ (pj1 z)  ≐  Γ ‣ (pj1 z'))
            ->  (((ty.type A) • (pj1 z)) ‣ (pj2 z)  ≐  ((ty.type A) • (pj1 z')) ‣ (pj2 z'))
            ->  (< κ (Γ ▷ A) >  z ~ z')
-Ext-eq-lm2 a g z z' p q = <> (pairV-ext p q) 
+Ext-eq-lm2 a g z z' p q = <> (pairV-ext p q)
 
 
 
@@ -75,7 +75,7 @@ Ext-eq-lm2 a g z z' p q = <> (pairV-ext p q)
 -- Ext : (Γ : ctx) -> (A : ty Γ) -> ctx
 -- Ext Γ A = sigmaV Γ (ty.type A)
 -- sigmaV : (a : V) -> (g :  setoidmap1 (κ a) VV) -> V
--- sigmaV a g =  sup (Σ (# a) (\y -> # (g • y))) 
+-- sigmaV a g =  sup (Σ (# a) (\y -> # (g • y)))
 --                     (\u -> < a ‣ (pj1 u) , (g • (pj1 u)) ‣ (pj2 u) >)
 
 
@@ -86,36 +86,36 @@ Ext-eq-lm2 a g z z' p q = <> (pairV-ext p q)
 -- constant type
 
 Const⊤ : V -> ty ⊤
-Const⊤ u = tyy (record { op = λ x → u 
+Const⊤ u = tyy (record { op = λ x → u
                        ; ext = λ x y p → <<>> (refV u) })
 
 Const : V -> (Γ : ctx) -> ty Γ
 Const u Γ =  (Const⊤ u) [[ ! Γ ]]
-             -- tyy (record { op = λ x → u 
+             -- tyy (record { op = λ x → u
              --            ; ext = λ x y p → refV u })
 
-Const-sub : (u : V) -> {Δ Γ : ctx} -> (f : subst Δ Γ) 
+Const-sub : (u : V) -> {Δ Γ : ctx} -> (f : subst Δ Γ)
      -> Δ ==> Const u Γ [[ f ]] == Const u Δ
 Const-sub u {Δ} {Γ} f = (tysym (tysubst-com (Const⊤ u) ( ! Γ) f))
 
 
 const⊤ :  V ->  raw ⊤
-const⊤ u =   mkraw (record { op = λ x → u 
+const⊤ u =   mkraw (record { op = λ x → u
                             ; ext = λ x y p → <<>> (refV u) })
 
 const :  V -> (Γ : ctx) -> raw Γ
-const u Γ =   const⊤ u [ ! Γ ] 
+const u Γ =   const⊤ u [ ! Γ ]
 
 
-const-sub : (u : V) -> {Δ Γ : ctx} -> (f : subst Δ Γ) 
+const-sub : (u : V) -> {Δ Γ : ctx} -> (f : subst Δ Γ)
      -> << Raw Δ >>  (const u Γ [ f ]) ~ (const u Δ)
-const-sub u {Δ} {Γ} f = <<>> (<<>> (λ x → <<>> (refV _)))  
+const-sub u {Δ} {Γ} f = <<>> (<<>> (λ x → <<>> (refV _)))
 
 {--
 
-sub-comp-prop : {Θ Δ Γ : ctx}  
-       -> (a : raw Γ) 
-       ->  (f : subst Δ Γ) -> (g : subst Θ Δ) 
+sub-comp-prop : {Θ Δ Γ : ctx}
+       -> (a : raw Γ)
+       ->  (f : subst Δ Γ) -> (g : subst Θ Δ)
 -- ---------------------------------------------------
        -> << Raw Θ >>  a [ f ⌢ g ]  ~ (a [ f ] [ g ])
 
@@ -127,12 +127,12 @@ sub-comp-prop : {Θ Δ Γ : ctx}
 -- function on a constant type
 
 fun⊤-op : (u v : V) -> || (κ u) => (κ v) || ->  || κ (⊤ ▷ Const⊤ u) || ->  || κ (⊤ ▷ Const⊤ v) ||
-fun⊤-op  u v h (x , y) = x , ap h y 
+fun⊤-op  u v h (x , y) = x , ap h y
 
-fun⊤-ext : (u v : V) -> (h : || (κ u) => (κ v) ||) -> (z z' :  || κ (⊤ ▷ Const⊤ u) ||) 
+fun⊤-ext : (u v : V) -> (h : || (κ u) => (κ v) ||) -> (z z' :  || κ (⊤ ▷ Const⊤ u) ||)
     -> (< κ (⊤ ▷ Const⊤ u) > z ~ z')
     -> < κ (⊤ ▷ Const⊤ v) > fun⊤-op u v h z ~ fun⊤-op u v h z'
-fun⊤-ext u v h (x , y) (x' , y') p = 
+fun⊤-ext u v h (x , y) (x' , y') p =
      let lm = Ext-eq-lm1 ⊤ (Const⊤ u) _ _ p
          lm2 : (ty.type (Const⊤ u) • x) ‣ y ≐ (ty.type (Const⊤ u) • x') ‣ y'
          lm2 = prj2 lm
@@ -141,34 +141,34 @@ fun⊤-ext u v h (x , y) (x' , y') p =
          lm4 : v ‣ ap h y ≐  v ‣ ap h y'
          lm4 = >< (extensionality h y y' (<> lm3))
          lm5 : (ty.type (Const⊤ v) • x) ‣ ap h y ≐
-               (ty.type (Const⊤ v) • x') ‣ ap h y' 
+               (ty.type (Const⊤ v) • x') ‣ ap h y'
          lm5 = lm4
-      
+
      in  Ext-eq-lm2 ⊤ (Const⊤ v) _ _ (prj1 lm) lm5
-  
+
 
 -- pairV-inv-1 : {x y z u : V} -> < x , y > ≐ < z , u > ->  and (x ≐ z) (y ≐ u)
 
 fun⊤ : (u v : V) -> || (κ u) => (κ v) ||  -> subst (⊤ ▷ (Const⊤ u))  (⊤ ▷ (Const⊤ v))
-fun⊤ u v h = sb (record { op = fun⊤-op u v h  
+fun⊤ u v h = sb (record { op = fun⊤-op u v h
                         ; ext = fun⊤-ext u v h })
 
 pr⊤ : (u : V) -> (Γ : ctx) -> subst (Γ ▷ (Const u Γ))  (⊤ ▷ (Const⊤ u))
 pr⊤ u Γ = ↑ (Const⊤ u) (! Γ)
- 
+
 -- better names for these :
 
-lm :   (u : V) -> ⊤ ▷ (Const⊤ u) ==> vv (Const⊤ u) :: (Const⊤ u) [[ ↓ (Const⊤ u) ]] 
+lm :   (u : V) -> ⊤ ▷ (Const⊤ u) ==> vv (Const⊤ u) :: (Const⊤ u) [[ ↓ (Const⊤ u) ]]
 lm u = asm (Const⊤ u)
 
-lm2 : (u v : V) -> (f : || (κ u) => (κ v) ||) -> 
+lm2 : (u v : V) -> (f : || (κ u) => (κ v) ||) ->
        ⊤ ▷ (Const⊤ u) ==> vv (Const⊤ v) [ fun⊤ u v f ] :: (Const⊤ v) [[ ↓ (Const⊤ v) ]] [[ fun⊤ u v f ]]
 lm2 u v f = elt-subst (fun⊤ u v f) (lm v)
 
 lm3 :  (u v : V) -> (f : || (κ u) => (κ v) ||) ->  (Γ : ctx) ->
-    Γ ▷ (Const u Γ) ==> vv (Const⊤ v) [ fun⊤ u v f ] [ pr⊤ u Γ ] 
+    Γ ▷ (Const u Γ) ==> vv (Const⊤ v) [ fun⊤ u v f ] [ pr⊤ u Γ ]
             :: (Const⊤ v) [[ ↓ (Const⊤ v) ]] [[ fun⊤ u v f ]] [[ pr⊤ u Γ ]]
-lm3 u v f Γ = elt-subst (pr⊤ u Γ) (lm2 u v f) 
+lm3 u v f Γ = elt-subst (pr⊤ u Γ) (lm2 u v f)
 
 lm4 : (u v : V) -> (f : || (κ u) => (κ v) ||) ->  (Γ : ctx) ->
       Γ ▷ (Const u Γ) ==> (Const⊤ v) [[ ↓ (Const⊤ v) ]] [[ fun⊤ u v f ]] [[ pr⊤ u Γ ]]
@@ -176,20 +176,20 @@ lm4 : (u v : V) -> (f : || (κ u) => (κ v) ||) ->  (Γ : ctx) ->
 lm4 u v f Γ = mk-eqty (λ x → <<>> (refV _))
 
 lm5 :  (u v : V) -> (f : || (κ u) => (κ v) ||) ->  (Γ : ctx) ->
-    Γ ▷ (Const u Γ) ==> vv (Const⊤ v) [ fun⊤ u v f ] [ pr⊤ u Γ ] 
+    Γ ▷ (Const u Γ) ==> vv (Const⊤ v) [ fun⊤ u v f ] [ pr⊤ u Γ ]
             :: (Const⊤ v [[ ! Γ ]]) [[ ↓ (Const⊤ u [[ ! Γ ]]) ]]
 lm5 u v f Γ = elttyeq (lm3 u v f Γ) (lm4 u v f Γ)
 
 
 {--
-↑ :  {Δ Γ : ctx}  -> (A : ty Γ)    -> (h : subst Δ Γ) 
+↑ :  {Δ Γ : ctx}  -> (A : ty Γ)    -> (h : subst Δ Γ)
      -> subst (Δ ▷ (A [[ h ]])) (Γ ▷ A)
 ↑ A h = qq A h
 --}
 
-lift : (u v : V)  -> (f : || (κ u) => (κ v) ||) -> (Γ : ctx) 
+lift : (u v : V)  -> (f : || (κ u) => (κ v) ||) -> (Γ : ctx)
       -> subst (Γ ▷ ((Const⊤ u) [[ ! Γ ]]))  (Γ ▷ ((Const⊤ v) [[ ! Γ ]]))
-lift  u v f Γ = ext ((Const⊤ v) [[ ! Γ ]]) (↓  ((Const⊤ u) [[ ! Γ ]]) ) 
+lift  u v f Γ = ext ((Const⊤ v) [[ ! Γ ]]) (↓  ((Const⊤ u) [[ ! Γ ]]) )
                            (vv (Const⊤ v) [ fun⊤ u v f ] [ pr⊤ u Γ ]) (lm5 u v f Γ)
 
 lift-fun : (u v : V) -> || (κ u) => (κ v) || -> (Γ : ctx) -> subst (Γ ▷ (Const u Γ)) (Γ ▷ (Const v Γ))
@@ -198,7 +198,7 @@ lift-fun u v h Γ = lift u v h Γ
 
 
 
--- 
+--
 
 
 
@@ -216,17 +216,17 @@ zero Γ = const zeroV Γ
 
 zero-sub : {Δ Γ : ctx} -> (f : subst Δ Γ)
         -> << Raw Δ >>  (zero Γ [ f ]) ~ (zero Δ)
-zero-sub {Δ} {Γ} f = const-sub zeroV {Δ} {Γ} f 
+zero-sub {Δ} {Γ} f = const-sub zeroV {Δ} {Γ} f
 
 succ : (Γ : ctx) -> raw Γ -> raw Γ
-succ Γ a = mkraw (record { op = λ x → succV (apr a x) 
+succ Γ a = mkraw (record { op = λ x → succV (apr a x)
                          ; ext = λ x y p → <<>> (succV-ext _ _ (>><< (extensionality1 (raw.rawterm a) x y p))) })
 
 succ-sub : {Δ Γ : ctx} -> (f : subst Δ Γ) -> (a : raw Γ)
         -> << Raw Δ >>  ((succ Γ a) [ f ]) ~ (succ Δ (a [ f ]))
 succ-sub {Δ} {Γ} f a = <<>> (<<>> (λ x → <<>> (refV _)))
 
-Nat-i-O : (Γ : ctx) -> 
+Nat-i-O : (Γ : ctx) ->
 --  -------------------------------------------
           Γ ==> zero Γ :: Nat Γ
 --
@@ -234,9 +234,9 @@ Nat-i-O Γ = mk-elt (λ x → zeroV-in-natV)
 
 
 
-Nat-i-s : (Γ : ctx) 
+Nat-i-s : (Γ : ctx)
         -> (a : raw Γ)
-        -> (Γ ==> a :: Nat Γ)      
+        -> (Γ ==> a :: Nat Γ)
 --  -------------------------------------------
        ->  Γ ==> succ Γ a :: Nat Γ
 --
@@ -251,7 +251,7 @@ Nat-i-s Γ a p =
 
 
 
-step-sub : (Γ : ctx) 
+step-sub : (Γ : ctx)
         ->  subst (Γ ▷ Nat Γ) (Γ ▷ Nat Γ)
 step-sub Γ = lift-fun natV natV succ-fun Γ
 
@@ -265,7 +265,7 @@ mk-step-e  : {Γ : ctx}
       -> (u : || κ Γ ||)
       -> (m : || κ natV ||) -> (z : || κ (apt C (u , m)) ||) ->  || κ (apt C (u , (s m))) ||
 mk-step-e  {Γ} C e q u m z = pj1 (apel q ((u , m) , z))
-{--   let 
+{--   let
        eu = apr e ((u , m) , z)
        qu = apel q ((u , m) , z)
        lm : apt ((C [[ step-sub Γ ]]) [[ ↓ C ]]) ((u , m) , z) ≐ apt C (u , s m)
@@ -284,9 +284,9 @@ mk-step-e-xt :  {Γ : ctx}
       -> (z : || κ Γ ||)
       -> (m  k : || κ natV ||) -> (u :  || κ (apt C (z , m)) ||) -> (v :  || κ (apt C (z , k)) ||)
                -> < κ natV > m ~ k -> (apt C (z , m)) ‣ u ≐ (apt C (z , k)) ‣ v ->
-                     (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u) 
+                     (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u)
                    ≐ (apt C (z , (s k))) ‣ (mk-step-e {Γ} C e q z k v)
-mk-step-e-xt {Γ} C e q z m k u v p r = 
+mk-step-e-xt {Γ} C e q z m k u v p r =
    let lm1 : apr e ((z , m) , u) ∈ apt C (z , (s m))
        lm1 = apel q ((z , m) , u)
        eq1 : apr e ((z , m) , u) ≐
@@ -296,11 +296,11 @@ mk-step-e-xt {Γ} C e q z m k u v p r =
        lm2 = apel q ((z , k) , v)
        eq2 : apr e ((z , k) , v) ≐
           apt C (z , s k) ‣ pj1 (apel q ((z , k) , v))
-       eq2 = pj2 lm2 
+       eq2 = pj2 lm2
        eq3 = extensionality1 (raw.rawterm e) ((z , m) , u) ((z , k) , v)
        eq4 : apr e ((z , m) , u) ≐ apr e ((z , k) , v)
        eq4 = >><< (eq3 (<> (pairV-ext (pairV-ext (refV _) (>< p)) r)))
-       main : (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u) 
+       main : (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u)
                    ≐ (apt C (z , (s k))) ‣ (mk-step-e {Γ} C e q z k v)
        main = traV (symV eq1) (traV eq4 eq2 )
    in main
@@ -311,13 +311,13 @@ mk-step-e-xt2 :  {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (e : raw ((Γ ▷ Nat Γ) ▷ C))
       -> (q : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]])
-      -> (z z' : || κ Γ ||)     
+      -> (z z' : || κ Γ ||)
       -> (m m' : N) -> (u :  || κ (apt C (z , m)) ||) -> (v :  || κ (apt C (z' , m')) ||)
                -> < κ Γ > z ~ z'  -> < κ natV > m ~ m'
                -> (apt C (z , m)) ‣ u ≐ (apt C (z' , m')) ‣ v ->
-                     (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u) 
+                     (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u)
                    ≐ (apt C (z' , (s m'))) ‣ (mk-step-e {Γ} C e q z' m' v)
-mk-step-e-xt2 {Γ} C e q z z' m m' u v p1 p2 p3 = 
+mk-step-e-xt2 {Γ} C e q z z' m m' u v p1 p2 p3 =
    let lm1 : apr e ((z , m) , u) ∈ apt C (z , (s m))
        lm1 = apel q ((z , m) , u)
        eq1 : apr e ((z , m) , u) ≐
@@ -327,19 +327,19 @@ mk-step-e-xt2 {Γ} C e q z z' m m' u v p1 p2 p3 =
        lm2 = apel q ((z' , m') , v)
        eq2 : apr e ((z' , m') , v) ≐
           apt C (z' , s m') ‣ pj1 (apel q ((z' , m') , v))
-       eq2 = pj2 lm2 
+       eq2 = pj2 lm2
        eq3 = extensionality1 (raw.rawterm e) ((z , m) , u) ((z' , m') , v)
        eq4 : apr e ((z , m) , u) ≐ apr e ((z' , m') , v)
-       eq4 = >><< (eq3 (<> (pairV-ext (pairV-ext (>< p1) (>< p2)) p3) )) 
-       main : (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u) 
+       eq4 = >><< (eq3 (<> (pairV-ext (pairV-ext (>< p1) (>< p2)) p3) ))
+       main : (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u)
                    ≐ (apt C (z' , (s m'))) ‣ (mk-step-e {Γ} C e q z' m' v)
        main = traV (symV eq1) (traV eq4 eq2 )
    in main
 
--- 
+--
 {--
 
-natV-rec : 
+natV-rec :
          (C : setoidmap1 (κ natV) VV)
       -> (d : || κ (ap1 C O) ||)
       -> (e : (m : || κ natV ||) -> (z :  || κ (ap1 C m) ||) ->  || κ (ap1 C (s m)) ||)
@@ -353,7 +353,7 @@ natV-rec C d e xt (s m) = e m (natV-rec C d e xt m)
 
 --}
 
-natV-rec-lm-s : 
+natV-rec-lm-s :
          (C : setoidmap1 (κ natV) VV)
       -> (d : || κ (ap1 C O) ||)
       -> (e : (m : || κ natV ||) -> (z :  || κ (ap1 C m) ||) ->  || κ (ap1 C (s m)) ||)
@@ -371,10 +371,10 @@ lmbC : {Γ : ctx}
         -> (u : || κ Γ ||)
         -> setoidmap1 (κ natV) VV
 lmbC {Γ} C u =
-            record { op = λ x →  apt C (u , x) 
-                    ; ext = λ x y pf → extensionality1 (ty.type C) (u , x) (u , y) 
+            record { op = λ x →  apt C (u , x)
+                    ; ext = λ x y pf → extensionality1 (ty.type C) (u , x) (u , y)
                                         (<> (pairV-ext (refV _) (>< pf))) }
-       
+
 
 
 Rec-op : {Γ : ctx}
@@ -387,11 +387,11 @@ Rec-op : {Γ : ctx}
       -> (r : Γ ==> c :: Nat Γ)
       -> (u : || κ Γ ||)
       -> V
-Rec-op {Γ} C d p e q c r u = 
-    let 
+Rec-op {Γ} C d p e q c r u =
+    let
         pu = apel p u
         pu1 : # (apt (C [[ els (Nat-i-O Γ) ]]) u)
-        pu1 = pj1 pu  
+        pu1 = pj1 pu
         pu2 = pj2 pu
         cu = apr c u
         ru = apel r u
@@ -399,11 +399,11 @@ Rec-op {Γ} C d p e q c r u =
         lm : || κ (ap1 (lmbC {Γ} C u) ru1) ||
         lm = natV-rec (lmbC {Γ} C u) pu1 (mk-step-e {Γ} C e q u) (mk-step-e-xt {Γ} C e q u) ru1
         main : V
-        main = (ap1  (lmbC {Γ} C u) ru1) ‣ lm 
+        main = (ap1  (lmbC {Γ} C u) ru1) ‣ lm
     in main
 -- explicitly:
--- Rec-op {Γ} C d p e q c r u 
--- = (ap1  (lmbC {Γ} C u) (pj1 (apel r u))) ‣ 
+-- Rec-op {Γ} C d p e q c r u
+-- = (ap1  (lmbC {Γ} C u) (pj1 (apel r u))) ‣
 --     (natV-rec (lmbC {Γ} C u) (pj1 (apel p u)) (mk-step-e {Γ} C e q u) (mk-step-e-xt {Γ} C e q u) (pj1 (apel r u)))
 
 Rec-op-lm2 : {Γ : ctx}
@@ -416,10 +416,10 @@ Rec-op-lm2 : {Γ : ctx}
       -> (r : Γ ==> c :: Nat Γ)
       -> (u : || κ Γ ||)
       ->  Rec-op {Γ} C d p e q c r u ∈ (ap1  (lmbC {Γ} C u) (pj1 (apel r u)))
-Rec-op-lm2 {Γ} C d p e q c r u = 
-     (natV-rec (lmbC {Γ} C u) (pj1 (apel p u)) 
-                          (mk-step-e {Γ} C e q u) 
-                           (mk-step-e-xt {Γ} C e q u) (pj1 (apel r u)))    
+Rec-op-lm2 {Γ} C d p e q c r u =
+     (natV-rec (lmbC {Γ} C u) (pj1 (apel p u))
+                          (mk-step-e {Γ} C e q u)
+                           (mk-step-e-xt {Γ} C e q u) (pj1 (apel r u)))
      , (refV _)
 
 
@@ -432,13 +432,13 @@ Rec-ext-lm3 : {Γ : ctx}
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> (m k : || κ natV ||)
-      -> (pf1 : < κ natV > m ~ k) 
+      -> (pf1 : < κ natV > m ~ k)
       -> (x y : || κ Γ ||)
       ->  (pf2 : < κ Γ > x ~ y)
-      ->  (ap1  (lmbC {Γ} C x) m) ‣ 
-                  (natV-rec (lmbC {Γ} C x) (pj1 (apel p x)) (mk-step-e {Γ} C e q x) (mk-step-e-xt {Γ} C e q x) m) 
+      ->  (ap1  (lmbC {Γ} C x) m) ‣
+                  (natV-rec (lmbC {Γ} C x) (pj1 (apel p x)) (mk-step-e {Γ} C e q x) (mk-step-e-xt {Γ} C e q x) m)
                ≐
-          (ap1  (lmbC {Γ} C y) k) ‣ 
+          (ap1  (lmbC {Γ} C y) k) ‣
                   (natV-rec (lmbC {Γ} C y) (pj1 (apel p y)) (mk-step-e {Γ} C e q y) (mk-step-e-xt {Γ} C e q y) k)
 Rec-ext-lm3 {Γ} C d p e q c r O O         pf1 x y pf2 =
    let deq :  apr d x ≐ apr d y
@@ -448,7 +448,7 @@ Rec-ext-lm3 {Γ} C d p e q c r O O         pf1 x y pf2 =
        main :  ap1 (lmbC {Γ} C x) O ‣ pj1 (apel p x) ≐
                ap1 (lmbC {Γ} C y) O ‣ pj1 (apel p y)
        main = traV (symV px) (traV deq py)
-   in main   
+   in main
 Rec-ext-lm3 {Γ} C d p e q c r (s m) O     pf1 x y pf2 = exfalso _ (Peano4 (nV m) (>< pf1))
 Rec-ext-lm3 {Γ} C d p e q c r O (s k)     pf1 x y pf2 = exfalso _ (Peano4 (nV k) (symV (>< pf1)))
 Rec-ext-lm3 {Γ} C d p e q c r (s m) (s k) pf1 x y pf2 =
@@ -472,7 +472,7 @@ Rec-ext-lm3 {Γ} C d p e q c r (s m) (s k) pf1 x y pf2 =
              (natV-rec (lmbC {Γ} C y) (pj1 (apel p y)) (mk-step-e {Γ} C e q y)
              (mk-step-e-xt {Γ} C e q y) k)
        main = mk-step-e-xt2 {Γ} C e q x y m k _ _ pf2 pf1' ih
-   in main   
+   in main
 
 
 
@@ -485,10 +485,10 @@ Rec-ext-lm : {Γ : ctx}
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> (x y : || κ Γ ||)
-      -> < κ Γ > x ~ y 
+      -> < κ Γ > x ~ y
       -> Rec-op C d p e q c r x ≐ Rec-op C d p e q c r y
-Rec-ext-lm {Γ} C d p e q c r x y pf = 
-  let  
+Rec-ext-lm {Γ} C d p e q c r x y pf =
+  let
        px1 : # (apt (C [[ els (Nat-i-O Γ) ]]) x)
        px1 = pj1 (apel p x)
        py1 : # (apt (C [[ els (Nat-i-O Γ) ]]) y)
@@ -503,13 +503,13 @@ Rec-ext-lm {Γ} C d p e q c r x y pf =
        cxcyeq = >><< (extensionality1 (raw.rawterm c) x y pf)
        rx1ry1eq : < κ natV > pj1 (apel r x) ~ pj1 (apel r y)
        rx1ry1eq = <> (traV (symV rx2) (traV cxcyeq ry2))
-       lm : (ap1  (lmbC {Γ} C x) rx1) ‣ 
-                  (natV-rec (lmbC {Γ} C x) px1 (mk-step-e {Γ} C e q x) (mk-step-e-xt {Γ} C e q x) rx1) 
+       lm : (ap1  (lmbC {Γ} C x) rx1) ‣
+                  (natV-rec (lmbC {Γ} C x) px1 (mk-step-e {Γ} C e q x) (mk-step-e-xt {Γ} C e q x) rx1)
                ≐
-            (ap1  (lmbC {Γ} C y) ry1) ‣ 
+            (ap1  (lmbC {Γ} C y) ry1) ‣
                   (natV-rec (lmbC {Γ} C y) py1 (mk-step-e {Γ} C e q y) (mk-step-e-xt {Γ} C e q y) ry1)
        lm = Rec-ext-lm3 {Γ} C d p e q c r rx1 ry1 rx1ry1eq x y pf
-    
+
        main :  Rec-op C d p e q c r x ≐ Rec-op C d p e q c r y
        main = lm
   in main
@@ -524,7 +524,7 @@ Rec-ext : {Γ : ctx}
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> (x y : || κ Γ ||)
-      -> < κ Γ > x ~ y 
+      -> < κ Γ > x ~ y
       -> << VV >> Rec-op C d p e q c r x ~ Rec-op C d p e q c r y
 Rec-ext {Γ} C d p e q c r x y pf = <<>> (Rec-ext-lm {Γ} C d p e q c r x y pf)
 
@@ -538,7 +538,7 @@ Rec : {Γ : ctx}
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> raw Γ
-Rec {Γ} C d p e q c r = mkraw (record { op = Rec-op {Γ} C d p e q c r  
+Rec {Γ} C d p e q c r = mkraw (record { op = Rec-op {Γ} C d p e q c r
                                       ; ext = Rec-ext {Γ} C d p e q c r })
 
 N-sub : {Δ Γ : ctx}
@@ -563,36 +563,36 @@ Rec-sub-lm2 : {Δ Γ : ctx}
       -> (p' : Δ ==> (d [ f ]) :: C [[  N-sub f  ]] [[ els (Nat-i-O Δ) ]])
       -> (e : raw ((Γ ▷ Nat Γ) ▷ C))
       -> (q  : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]])
-      -> (q' : (Δ ▷ Nat Δ ) ▷ (C [[ N-sub f ]])  ==> 
+      -> (q' : (Δ ▷ Nat Δ ) ▷ (C [[ N-sub f ]])  ==>
                e [ C-sub f C ] ::  C [[  N-sub f  ]] [[ step-sub Δ ]] [[ ↓ ( C [[  N-sub f  ]]) ]])
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> (r' : Δ ==> (c [ f ]) :: (Nat Γ) [[ f ]])
       -> (x  : || κ Δ ||)
       -> (u v : || κ natV ||) ->  < κ natV > u ~ v
-      ->    (ap1  (lmbC {Γ} C (aps f x)) u) ‣ 
-                 (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x))) 
-                          (mk-step-e {Γ} C e q (aps f x)) (mk-step-e-xt {Γ} C e q (aps f x)) 
+      ->    (ap1  (lmbC {Γ} C (aps f x)) u) ‣
+                 (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x)))
+                          (mk-step-e {Γ} C e q (aps f x)) (mk-step-e-xt {Γ} C e q (aps f x))
                      u)
               ≐
-            (ap1  (lmbC {Δ} (C [[ N-sub f ]]) x) v) ‣ 
+            (ap1  (lmbC {Δ} (C [[ N-sub f ]]) x) v) ‣
                  (natV-rec (lmbC {Δ} (C [[ N-sub f ]]) x) (pj1 (apel p' x))
-                       (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x) 
+                       (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
                        (mk-step-e-xt {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
                   v)
-Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x O O eq = 
+Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x O O eq =
   let eq3 : apr d (aps f x) ≐ apr (d [ f ]) x
       eq3 = refV _
       eq1 = pj2 (apel p (aps f x))
       eq2 = pj2 (apel p' x)
-      lm :  ap1 (lmbC {Γ} C (aps f x)) O ‣ pj1 (apel p (aps f x)) ≐  
+      lm :  ap1 (lmbC {Γ} C (aps f x)) O ‣ pj1 (apel p (aps f x)) ≐
             ap1 (lmbC {Δ} (C [[ N-sub f ]]) x) O ‣ pj1 (apel p' x)
       lm = traV (symV eq1) (traV eq3 eq2)
-  in lm 
+  in lm
 
-Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x O (s v) eq = exfalso _ (Peano4 _ (>< (sym eq))) 
-Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x (s u) O eq = exfalso _ (Peano4 _ (>< eq)) 
-Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x (s u) (s v) eq = 
+Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x O (s v) eq = exfalso _ (Peano4 _ (>< (sym eq)))
+Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x (s u) O eq = exfalso _ (Peano4 _ (>< eq))
+Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x (s u) (s v) eq =
     let eq' : < κ natV > u ~ v
         eq' = succ-inj u v eq
         eq2 : (type (Nat Γ) • aps f x) ‣ u ≐ (type (Nat Γ) • aps f x) ‣ v
@@ -608,12 +608,12 @@ Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x (s u) (s v) eq =
         IH = Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x u v eq'
         rc1 : || κ (ap1 (lmbC {Γ} C (aps f x)) u) ||
         rc1 = (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x)))
-                     (mk-step-e {Γ} C e q (aps f x)) 
+                     (mk-step-e {Γ} C e q (aps f x))
                      (mk-step-e-xt {Γ} C e q (aps f x)) u)
         rc2 : || κ (ap1 (lmbC {Δ} (C [[ N-sub f ]]) x) v) ||
         rc2 = (natV-rec (lmbC {Δ} (C [[ N-sub f ]]) x) (pj1 (apel p' x))
                      (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
-                     (mk-step-e-xt {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x) v) 
+                     (mk-step-e-xt {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x) v)
         IH'  : apt C (aps f x , u) ‣ rc1
                         ≐
                apt C (aps f x , v) ‣  rc2
@@ -625,9 +625,9 @@ Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x (s u) (s v) eq =
         exe :    (apr e ((aps f x , u) , rc1))
                                ≐
                  (apr e ((aps f x , v) , rc2))
-        exe = >><< (extensionality1 (raw.rawterm e) 
+        exe = >><< (extensionality1 (raw.rawterm e)
                               (((aps f x) , u) , rc1) (((aps f x) , v) , rc2) IH2)
-        eq1 : apr e ((aps f x , u) , rc1) ≐ 
+        eq1 : apr e ((aps f x , u) , rc1) ≐
               apt ((C [[ step-sub Γ ]]) [[ ↓ C ]])
                    ((aps f x , u) , rc1)  ‣
                   pj1 (apel q (((aps f x) , u) , rc1))
@@ -645,7 +645,7 @@ Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x (s u) (s v) eq =
                (Sub-comp-prop-sym C (N-sub f) (↓ (C [[ N-sub f ]]))))
               ((x , v) , rc2)))
         lm0 :  (apr e ((aps f x , v) , rc2)) ≐ apr (e [ C-sub f C ]) ((x , v) , rc2)
-        lm0 = >><< (extensionality1 (raw.rawterm e) _ _ 
+        lm0 = >><< (extensionality1 (raw.rawterm e) _ _
                         (<> (pairV-ext (pairV-ext (refV _) (refV _)) (e+prop pf rc2) )))
 
         lm1 : apt (((C [[ N-sub f ]]) [[ step-sub Δ ]]) [[ ↓ (C [[ N-sub f ]]) ]])
@@ -664,15 +664,15 @@ Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x (s u) (s v) eq =
                 apt C (aps f x , s v) ‣
                   pj1 (apel q' ((x , v) , rc2))
                  --  mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x v rc2
-        lm3 = traV (symV eq1) (traV exe lm2) 
-        main : 
-                apt C (aps f x , s u) ‣                  
+        lm3 = traV (symV eq1) (traV exe lm2)
+        main :
+                apt C (aps f x , s u) ‣
                   mk-step-e {Γ} C e q (aps f x) u rc1
                   ≐
                 apt C (aps f x , s v) ‣
                    mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x v rc2
         main = lm3
-    in main 
+    in main
 
 {--
 
@@ -684,14 +684,14 @@ mk-step-e-xt2 :  {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (e : raw ((Γ ▷ Nat Γ) ▷ C))
       -> (q : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]])
-      -> (z z' : || κ Γ ||)     
+      -> (z z' : || κ Γ ||)
       -> (m m' : N) -> (u :  || κ (apt C (z , m)) ||) -> (v :  || κ (apt C (z' , m')) ||)
                -> < κ Γ > z ~ z'  -> < κ natV > m ~ m'
                -> (apt C (z , m)) ‣ u ≐ (apt C (z' , m')) ‣ v ->
-                     (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u) 
+                     (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u)
                    ≐ (apt C (z' , (s m'))) ‣ (mk-step-e {Γ} C e q z' m' v)
 
-natV-rec-lm-s : 
+natV-rec-lm-s :
          (C : setoidmap1 (κ natV) VV)
       -> (d : || κ (ap1 C O) ||)
       -> (e : (m : || κ natV ||) -> (z :  || κ (ap1 C m) ||) ->  || κ (ap1 C (s m)) ||)
@@ -710,14 +710,14 @@ Rec-sub-lm : {Δ Γ : ctx}
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
       -> (p' : Δ ==> (d [ f ]) :: C [[  N-sub f  ]] [[ els (Nat-i-O Δ) ]])
       -> (e : raw ((Γ ▷ Nat Γ) ▷ C))
-      -> (q  : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]]) 
-      -> (q' : (Δ ▷ Nat Δ ) ▷ (C [[ N-sub f ]])  ==> 
+      -> (q  : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]])
+      -> (q' : (Δ ▷ Nat Δ ) ▷ (C [[ N-sub f ]])  ==>
                e [ C-sub f C ] ::  C [[  N-sub f  ]] [[ step-sub Δ ]] [[ ↓ ( C [[  N-sub f  ]]) ]])
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> (r' : Δ ==> (c [ f ]) :: (Nat Γ) [[ f ]])
       -> (x  : || κ Δ ||)
-      ->  Rec-op {Γ} C d p e q c r (aps f x) ≐ 
+      ->  Rec-op {Γ} C d p e q c r (aps f x) ≐
           Rec-op {Δ} (C [[ N-sub f ]]) (d [ f ]) p' (e [ C-sub f C ]) q' (c [ f ])  r' x
 Rec-sub-lm {Δ} {Γ} f C d p p' e q q' c r r' x =
      let ts = aps f x
@@ -728,40 +728,40 @@ Rec-sub-lm {Δ} {Γ} f C d p p' e q q' c r r' x =
          eq : < κ natV > tm1 ~ tm2
          eq = <> (traV (symV tm4) tm3)
          lm3 : (u v : || κ natV ||) ->  < κ natV > u ~ v ->
-             (ap1  (lmbC {Γ} C (aps f x)) u) ‣ 
-                 (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x))) 
-                          (mk-step-e {Γ} C e q (aps f x)) (mk-step-e-xt {Γ} C e q (aps f x)) 
+             (ap1  (lmbC {Γ} C (aps f x)) u) ‣
+                 (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x)))
+                          (mk-step-e {Γ} C e q (aps f x)) (mk-step-e-xt {Γ} C e q (aps f x))
                      u)
               ≐
              -- Rec-op {Δ} (C [[ N-sub f ]]) (d [ f ]) p' (e [ C-sub f C ]) q' (c [ f ])  r'  x
-             (ap1  (lmbC {Δ} (C [[ N-sub f ]]) x) v) ‣ 
+             (ap1  (lmbC {Δ} (C [[ N-sub f ]]) x) v) ‣
                  (natV-rec (lmbC {Δ} (C [[ N-sub f ]]) x) (pj1 (apel p' x))
-                       (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x) 
+                       (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
                        (mk-step-e-xt {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
                   v)
          lm3 = Rec-sub-lm2 {Δ} {Γ} f C d p p' e q q' c r r' x
-         lm2 : (ap1  (lmbC {Γ} C (aps f x)) tm1) ‣ 
-                 (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x))) 
-                          (mk-step-e {Γ} C e q (aps f x)) (mk-step-e-xt {Γ} C e q (aps f x)) 
+         lm2 : (ap1  (lmbC {Γ} C (aps f x)) tm1) ‣
+                 (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x)))
+                          (mk-step-e {Γ} C e q (aps f x)) (mk-step-e-xt {Γ} C e q (aps f x))
                      tm1)
               ≐
              -- Rec-op {Δ} (C [[ N-sub f ]]) (d [ f ]) p' (e [ C-sub f C ]) q' (c [ f ])  r'  x
-             (ap1  (lmbC {Δ} (C [[ N-sub f ]]) x) tm2) ‣ 
+             (ap1  (lmbC {Δ} (C [[ N-sub f ]]) x) tm2) ‣
                  (natV-rec (lmbC {Δ} (C [[ N-sub f ]]) x) (pj1 (apel p' x))
-                       (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x) 
+                       (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
                        (mk-step-e-xt {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
                   tm2)
          lm2 = lm3 tm1 tm2 eq
-         lm : -- Rec-op {Γ} C d p e q c r (aps f x) ≐ 
-             (ap1  (lmbC {Γ} C (aps f x)) (pj1 (apel r (aps f x)))) ‣ 
-                 (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x))) 
-                          (mk-step-e {Γ} C e q (aps f x)) (mk-step-e-xt {Γ} C e q (aps f x)) 
+         lm : -- Rec-op {Γ} C d p e q c r (aps f x) ≐
+             (ap1  (lmbC {Γ} C (aps f x)) (pj1 (apel r (aps f x)))) ‣
+                 (natV-rec (lmbC {Γ} C (aps f x)) (pj1 (apel p (aps f x)))
+                          (mk-step-e {Γ} C e q (aps f x)) (mk-step-e-xt {Γ} C e q (aps f x))
                      (pj1 (apel r (aps f x))))
               ≐
              -- Rec-op {Δ} (C [[ N-sub f ]]) (d [ f ]) p' (e [ C-sub f C ]) q' (c [ f ])  r'  x
-             (ap1  (lmbC {Δ} (C [[ N-sub f ]]) x) (pj1 (apel r' x))) ‣ 
+             (ap1  (lmbC {Δ} (C [[ N-sub f ]]) x) (pj1 (apel r' x))) ‣
                  (natV-rec (lmbC {Δ} (C [[ N-sub f ]]) x) (pj1 (apel p' x))
-                       (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x) 
+                       (mk-step-e {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
                        (mk-step-e-xt {Δ} (C [[ N-sub f ]]) (e [ C-sub f C ]) q' x)
                   (pj1 (apel r' x)))
 
@@ -771,8 +771,8 @@ Rec-sub-lm {Δ} {Γ} f C d p p' e q q' c r r' x =
 
 
 {-- explicitly:
-   Rec-op {Γ} C d p e q c r u 
-   = (ap1  (lmbC {Γ} C u) (pj1 (apel r u))) ‣ 
+   Rec-op {Γ} C d p e q c r u
+   = (ap1  (lmbC {Γ} C u) (pj1 (apel r u))) ‣
      (natV-rec (lmbC {Γ} C u) (pj1 (apel p u)) (mk-step-e {Γ} C e q u) (mk-step-e-xt {Γ} C e q u) (pj1 (apel r u)))
 --}
 
@@ -800,7 +800,7 @@ Rec-sub' {Δ} {Γ} f C d p p' e q q' c r r' = <<>> (<<>> (λ x → <<>> (Rec-sub
 
 
 
-Nat-e : {Γ : ctx} 
+Nat-e : {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (d : raw Γ)
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
@@ -809,7 +809,7 @@ Nat-e : {Γ : ctx}
       -> (c : raw Γ)
       -> (r : Γ ==> c :: Nat Γ)
       -> Γ ==> Rec C d p e q c r :: C [[ els r ]]
-Nat-e {Γ} C d p e q c r = 
+Nat-e {Γ} C d p e q c r =
       mk-elt (λ x ->
                 let rx = apel r x
                     rx1 : # (apt (Nat Γ) x)
@@ -825,7 +825,7 @@ Nat-e {Γ} C d p e q c r =
                 in main
              )
 
-Nat-c-O-raw-eq : {Γ : ctx} 
+Nat-c-O-raw-eq : {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (d : raw Γ)
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
@@ -837,8 +837,8 @@ Nat-c-O-raw-eq {Γ} C d p e q x =
    let px = apel p x
        px1 = pj1 px
        px2 = pj2 px
-       tm =       (natV-rec (lmbC {Γ} C x) (pj1 (apel p x)) 
-                          (mk-step-e {Γ} C e q x) 
+       tm =       (natV-rec (lmbC {Γ} C x) (pj1 (apel p x))
+                          (mk-step-e {Γ} C e q x)
                            (mk-step-e-xt {Γ} C e q x) (pj1 (apel (Nat-i-O Γ) x)))
        lm2  : < κ (ap1 (lmbC {Γ} C x) O) > tm ~ px1
        lm2 = refl _ px1
@@ -848,7 +848,7 @@ Nat-c-O-raw-eq {Γ} C d p e q x =
 
 
 
-Nat-c-O : {Γ : ctx} 
+Nat-c-O : {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (d : raw Γ)
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
@@ -858,7 +858,7 @@ Nat-c-O : {Γ : ctx}
 Nat-c-O {Γ} C d p e q = pair (Nat-c-O-raw-eq {Γ} C d p e q)
                              (pair (Nat-e {Γ} C d p e q (zero Γ) (Nat-i-O Γ)) p)
 
-Nat-c-s-raw-eq : {Γ : ctx} 
+Nat-c-s-raw-eq : {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (d : raw Γ)
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
@@ -869,7 +869,7 @@ Nat-c-s-raw-eq : {Γ : ctx}
       -> (x : || κ Γ ||)
       -> apr (Rec C d p e q (succ _ a) (Nat-i-s Γ a r)) x ≐
          apr (e [ ext C (els r) (Rec C d p e q a r) (Nat-e C d p e q a r) ]) x
-Nat-c-s-raw-eq {Γ} C d p e q a r x = 
+Nat-c-s-raw-eq {Γ} C d p e q a r x =
    let ax = apel r x
        ax1 = pj1 ax
        ax2 = pj2 ax
@@ -879,10 +879,10 @@ Nat-c-s-raw-eq {Γ} C d p e q a r x =
        qi = apel q ((x , ax1) , rcx1 )
        qi1 = pj1 qi
        qi2 = pj2 qi
-       tm =  (natV-rec (lmbC {Γ} C x) (pj1 (apel p x)) 
-                          (mk-step-e {Γ} C e q x) 
+       tm =  (natV-rec (lmbC {Γ} C x) (pj1 (apel p x))
+                          (mk-step-e {Γ} C e q x)
                            (mk-step-e-xt {Γ} C e q x) (pj1 (apel (Nat-i-s Γ a r) x)))
-       tm' = (mk-step-e {Γ} C e q x) ax1 (natV-rec (lmbC {Γ} C x) 
+       tm' = (mk-step-e {Γ} C e q x) ax1 (natV-rec (lmbC {Γ} C x)
                   (pj1 (apel p x)) (mk-step-e {Γ} C e q x) (mk-step-e-xt {Γ} C e q x) ax1)
        eq : < κ (apt C (x , s (pj1 (apel r x)))) > tm ~ tm'
        eq = refl _ _
@@ -893,7 +893,7 @@ Nat-c-s-raw-eq {Γ} C d p e q a r x =
 
 
 
-Nat-c-s : {Γ : ctx} 
+Nat-c-s : {Γ : ctx}
       -> (C : ty (Γ ▷ Nat Γ))
       -> (d : raw Γ)
       -> (p : Γ ==> d :: C [[ els (Nat-i-O Γ) ]])
@@ -901,17 +901,17 @@ Nat-c-s : {Γ : ctx}
       -> (q : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]])
       -> (a : raw Γ)
       -> (r : Γ ==> a :: Nat Γ)
-      -> Γ ==> Rec C d p e q (succ Γ a) (Nat-i-s Γ a r) 
+      -> Γ ==> Rec C d p e q (succ Γ a) (Nat-i-s Γ a r)
            == e [  ext C (els r) (Rec C d p e q a r) (Nat-e {Γ} C d p e q a r) ] :: C [[ els (Nat-i-s Γ a r)]]
 -- R d e (s a) = e a (R d e a)
 -- < < 1_Γ , a> , Rec C d o e q a r >
 -- < els r ,  Rec C d o e q a r  >
-Nat-c-s {Γ} C d p e q a r = pair (Nat-c-s-raw-eq {Γ} C d p e q a r) 
-                                 (pair (Nat-e {Γ} C d p e q (succ Γ a) (Nat-i-s Γ a r)) 
-                                       (subj-red {Γ} {C [[ els (Nat-i-s Γ a r) ]]} 
-                                          (Rec C d p e q (succ Γ a) (Nat-i-s Γ a r)) 
+Nat-c-s {Γ} C d p e q a r = pair (Nat-c-s-raw-eq {Γ} C d p e q a r)
+                                 (pair (Nat-e {Γ} C d p e q (succ Γ a) (Nat-i-s Γ a r))
+                                       (subj-red {Γ} {C [[ els (Nat-i-s Γ a r) ]]}
+                                          (Rec C d p e q (succ Γ a) (Nat-i-s Γ a r))
                                           (e [ ext C (els r) (Rec C d p e q a r) (Nat-e C d p e q a r) ])
-                                           (Nat-e {Γ} C d p e q (succ Γ a) (Nat-i-s Γ a r)) 
+                                           (Nat-e {Γ} C d p e q (succ Γ a) (Nat-i-s Γ a r))
                                            (<<>> (<<>> (λ x → <<>> ((Nat-c-s-raw-eq {Γ} C d p e q a r) x))))))
 
 {--
@@ -919,7 +919,7 @@ Nat-c-s {Γ} C d p e q a r = pair (Nat-c-s-raw-eq {Γ} C d p e q a r)
 
 ext-eq' : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (Γ ==> A == A')
 -- --------------------------
       -> << Ctx >> (Γ ▷ A) ~ (Γ ▷ A')
@@ -936,13 +936,13 @@ mk-step-e-xt3 :  {Γ : ctx}
       -> (q : (Γ ▷ Nat Γ) ▷ C  ==> e :: C [[ step-sub Γ ]] [[ ↓ C ]])
       -> (q' : (Γ ▷ Nat Γ) ▷ C'  ==> e' :: C' [[ step-sub Γ ]] [[ ↓ C' ]])
       -> << Raw ((Γ ▷ Nat Γ) ▷ C) >> e ~ (e' [ subst-trp (ext-eq' {Γ ▷ Nat Γ} C C' Cq) ])
-      -> (z z' : || κ Γ ||)           
+      -> (z z' : || κ Γ ||)
       -> (m m' : N) -> (u :  || κ (apt C (z , m)) ||) -> (v :  || κ (apt C' (z' , m')) ||)
                -> < κ Γ > z ~ z'  -> < κ natV > m ~ m'
                -> (apt C (z , m)) ‣ u ≐ (apt C' (z' , m')) ‣ v ->
-                     (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u) 
+                     (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u)
                    ≐ (apt C' (z' , (s m'))) ‣ (mk-step-e {Γ} C' e' q' z' m' v)
-mk-step-e-xt3 {Γ} C C' Cq e e' q q' eq z z' m m' u v p1 p2 p3 = 
+mk-step-e-xt3 {Γ} C C' Cq e e' q q' eq z z' m m' u v p1 p2 p3 =
     let lm1 : apr e ((z , m) , u) ∈ apt C (z , (s m))
         lm1 = apel q ((z , m) , u)
         eq1 : apr e ((z , m) , u) ≐ apt C (z , s m) ‣ pj1 (apel q ((z , m) , u))
@@ -950,16 +950,16 @@ mk-step-e-xt3 {Γ} C C' Cq e e' q q' eq z z' m m' u v p1 p2 p3 =
         lm2 : apr e' ((z' , m') , v) ∈ apt C' (z' , (s m'))
         lm2 = apel q' ((z' , m') , v)
         eq2 : apr e' ((z' , m') , v) ≐ apt C' (z' , s m') ‣ pj1 (apel q' ((z' , m') , v))
-        eq2 = pj2 lm2 
+        eq2 = pj2 lm2
         lmeq = >><< (>><< (>><< eq) ((z , m) , u))
         eq4 : (Γ ▷ Nat Γ) ‣ (z , m)  ≐  (Γ ▷ Nat Γ) ‣ (z' , m')
-        eq4 = pairV-ext (>< p1) (>< p2) 
+        eq4 = pairV-ext (>< p1) (>< p2)
         eq5  : < κ (Γ ▷ Nat Γ ▷ C') >
                ap (κ-trp (ext-eq C C' Cq)) ((z , m) , u) ~
               ((z , m) , ap (κ-Fam ±± ape Cq (z , m)) u)
-        eq5 = ext-eq-lm {Γ ▷ Nat Γ} C C' Cq (z , m) u 
+        eq5 = ext-eq-lm {Γ ▷ Nat Γ} C C' Cq (z , m) u
 
-        eq8 :  apt C (z , m) ‣ u ≐ apt C' (z , m) ‣ ap (κ-Fam ±± ape Cq (z , m)) u 
+        eq8 :  apt C (z , m) ‣ u ≐ apt C' (z , m) ‣ ap (κ-Fam ±± ape Cq (z , m)) u
         eq8 = e+prop' (apt C (z , m)) (apt C' (z , m)) (>><< (ape Cq  (z , m))) u
         eq7 : (ty.type C' • (z , m)) ‣ ap (κ-Fam ±± ape Cq (z , m)) u ≐
                 (ty.type C' • (z' , m')) ‣ v
@@ -973,8 +973,8 @@ mk-step-e-xt3 {Γ} C C' Cq e e' q q' eq z z' m m' u v p1 p2 p3 =
         lmeq2 :  ap1 (raw.rawterm (e' [ subst-trp (ext-eq' C C' Cq) ])) ((z , m) , u)
                   ≐ ap1 (raw.rawterm e') ((z' , m') , v)
         lmeq2 =  >><< (extensionality1 (raw.rawterm e') _ _ eq3)
-    
-        main :  (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u) 
+
+        main :  (apt C (z , (s m))) ‣ (mk-step-e {Γ} C e q z m u)
                    ≐ (apt C' (z' , (s m'))) ‣ (mk-step-e {Γ} C' e' q' z' m' v)
         main = traV (symV eq1) (traV (traV lmeq lmeq2) eq2)
     in main
@@ -996,8 +996,8 @@ Rec-cong' : {Γ : ctx}
       -> << Raw ((Γ ▷ Nat Γ) ▷ C) >> e ~ (e' [ subst-trp (ext-eq' {Γ ▷ Nat Γ} C C' Cq) ])
       -> << Raw Γ >> c ~ c'
       -> << Raw Γ >>  Rec {Γ} C d p e q c r ~ Rec {Γ} C' d' p' e' q' c' r'
-Rec-cong' {Γ} C C' d d' p p' e e' q q' c c' r r' Cq dq eq cq = 
-     <<>> (<<>> (λ x → 
+Rec-cong' {Γ} C C' d d' p p' e e' q q' c c' r r' Cq dq eq cq =
+     <<>> (<<>> (λ x →
       <<>> (
            let cqx = (>><< (>><< cq) x)
                eq1 : < κ natV > pj1 (apel r x) ~ pj1 (apel r' x)
@@ -1019,25 +1019,25 @@ Rec-cong' {Γ} C C' d d' p p' e e' q q' c c' r r' Cq dq eq cq =
                        in lm
 
 
-               lm : 
-                 (ap1  (lmbC {Γ} C x) (pj1 (apel r x))) ‣ 
-                   (natV-rec (lmbC {Γ} C x) (pj1 (apel p x)) 
+               lm :
+                 (ap1  (lmbC {Γ} C x) (pj1 (apel r x))) ‣
+                   (natV-rec (lmbC {Γ} C x) (pj1 (apel p x))
                      (mk-step-e {Γ} C e q x) (mk-step-e-xt {Γ} C e q x) (pj1 (apel r x)))
                   ≐
-                 (ap1  (lmbC {Γ} C' x) (pj1 (apel r' x))) ‣ 
-                   (natV-rec (lmbC {Γ} C' x) (pj1 (apel p' x)) 
+                 (ap1  (lmbC {Γ} C' x) (pj1 (apel r' x))) ‣
+                   (natV-rec (lmbC {Γ} C' x) (pj1 (apel p' x))
                      (mk-step-e {Γ} C' e' q' x) (mk-step-e-xt {Γ} C' e' q' x) (pj1 (apel r' x)))
-               lm = natV-rec-ext2 
-                        (lmbC {Γ} C x) (lmbC {Γ} C' x) 
-                        (pj1 (apel p x)) 
+               lm = natV-rec-ext2
+                        (lmbC {Γ} C x) (lmbC {Γ} C' x)
+                        (pj1 (apel p x))
                         (pj1 (apel p' x))
-                        (mk-step-e {Γ} C e q x) 
-                        (mk-step-e-xt {Γ} C e q x) 
-                        (mk-step-e {Γ} C' e' q' x) 
+                        (mk-step-e {Γ} C e q x)
+                        (mk-step-e-xt {Γ} C e q x)
+                        (mk-step-e {Γ} C' e' q' x)
                         (mk-step-e-xt {Γ} C' e' q' x)
-                        (pj1 (apel r x)) 
-                        (pj1 (apel r' x)) 
-                        eq1 
+                        (pj1 (apel r x))
+                        (pj1 (apel r' x))
+                        eq1
                         eq2
                         eq3
 
@@ -1066,14 +1066,14 @@ Rec-cong : {Γ : ctx}
                      C [[ step-sub Γ ]] [[ ↓ C ]])
       -> (Γ ==> c == c' :: Nat Γ)
       -> (Γ ==>  Rec {Γ} C d p e q c r == Rec {Γ} C' d' p' e' q' c' r' :: C [[ els r ]])
-Rec-cong {Γ} C C' d d' p p' e e' q q' c c' r r' t dq eq cq =  
+Rec-cong {Γ} C C' d d' p p' e e' q q' c c' r r' t dq eq cq =
     let  dq' = (Raw-lm2 {Γ} {d} {d'} (prj1 dq))
          eq' = (Raw-lm2 {(Γ ▷ Nat Γ) ▷ C } {e} {(e' [ subst-trp (ext-eq' {Γ ▷ Nat Γ} C C' t) ])} (prj1 eq))
          cq' = (Raw-lm2 {Γ} {c} {c'} (prj1 cq))
          lm = Rec-cong' {Γ} C C' d d' p p' e e' q q' c c' r r' t dq' eq' cq'
-      
+
     in pair (Raw-lm lm) (pair (Nat-e {Γ} C d p e q c r) (subj-red _ _ (Nat-e {Γ} C d p e q c r ) lm))
-    
+
 
 
 
@@ -1091,7 +1091,7 @@ Rec-sub : {Δ Γ : ctx}
       -> (r' : Δ ==> (c [ h ]) :: (Nat Γ) [[ h ]])
       ->  Δ ==> ((Rec {Γ} C d p e q c r) [ h ])
                    == (Rec {Δ} (C [[  N-sub h  ]]) (d [ h ]) p' (e [ C-sub h C ])  q' (c [ h ]) r') :: C [[ els r ]] [[ h ]]
-Rec-sub {Δ} {Γ} h C d p p' e q q' c r r' = 
+Rec-sub {Δ} {Γ} h C d p p' e q q' c r r' =
     let lm = Rec-sub' {Δ} {Γ} h C d p p' e q q' c r r'
         lm2 :  Δ ==> Rec C d p e q c r [ h ] :: (C [[ els r ]]) [[ h ]]
         lm2 = elt-subst h (Nat-e {Γ} C d p e q c r)
@@ -1127,8 +1127,8 @@ R0-ext : {Γ : ctx}
       -> (C : ty (Γ ▷ N0 Γ))
       -> (c : raw Γ)
       -> (r : Γ ==> c :: N0 Γ)
-      -> (x y : || κ Γ ||) 
-      -> < κ Γ > x ~ y 
+      -> (x y : || κ Γ ||)
+      -> < κ Γ > x ~ y
       -> << VV >> R0-op C c r x ~ R0-op C c r y
 R0-ext {Γ} C c r x y p =  exfalso _ (pj1 (apel r x))
 
@@ -1137,7 +1137,7 @@ R0 : {Γ : ctx}
       -> (c : raw Γ)
       -> (r : Γ ==> c :: N0 Γ)
       -> raw Γ
-R0 {Γ} C c r = mkraw (record { op = R0-op {Γ} C c r 
+R0 {Γ} C c r = mkraw (record { op = R0-op {Γ} C c r
                              ; ext = R0-ext {Γ} C c r })
 
 R0-sub' : {Δ Γ : ctx}
@@ -1148,14 +1148,14 @@ R0-sub' : {Δ Γ : ctx}
       -> (r' : Δ ==> c [ f ] :: (N0 Γ) [[ f ]])
       -> << Raw Δ >>  ((R0 {Γ} C c r) [[ f ]])  ~  (R0 {Δ} (C [[ ↑ (N0 Γ) f ]]) (c [ f ]) r')
 R0-sub' {Δ} {Γ} f C c r r' = <<>> (<<>> (λ x → <<>> (exfalso _ (pj1 (apel r' x)))))
- 
 
--- ↑ :  {Δ Γ : ctx}  -> (A : ty Γ)    -> (h : subst Δ Γ) 
+
+-- ↑ :  {Δ Γ : ctx}  -> (A : ty Γ)    -> (h : subst Δ Γ)
 --     -> subst (Δ ▷ (A [[ h ]])) (Γ ▷ A)
 -- ↑ A h = qq A h
 
 
-N0-e : {Γ : ctx} 
+N0-e : {Γ : ctx}
       -> (C : ty (Γ ▷ N0 Γ))
       -> (c : raw Γ)
       -> (r : Γ ==> c :: N0 Γ)
@@ -1176,7 +1176,7 @@ R0-cong' {Γ} C C' c c' r r' Cq p = <<>> (<<>> (λ x → <<>> (exfalso _ (pj1 (a
 -- ** TO DO
 
 R0-cong : {Γ : ctx}
--- 
+--
       -> (C C' : ty (Γ ▷ N0 Γ))
       -> (c c' : raw Γ)
       -> (r : Γ ==> c :: N0 Γ)
@@ -1185,11 +1185,11 @@ R0-cong : {Γ : ctx}
       -> (Γ ==> c == c' :: N0 Γ)
       -> Γ ==> R0 {Γ} C c r  ==  R0 {Γ} C' c' r' :: C [[ els r ]]
 -- ----------------------------------------------------------------------------------------
-R0-cong {Γ} C C' c c' r r' Cq p = pair (Raw-lm (R0-cong' {Γ} C C' c c' r r' Cq (Raw-lm2 (prj1 p)))) 
-                                        (pair (N0-e {Γ} C c r) 
-                                              (subj-red _ _ (N0-e {Γ} C c r) 
+R0-cong {Γ} C C' c c' r r' Cq p = pair (Raw-lm (R0-cong' {Γ} C C' c c' r r' Cq (Raw-lm2 (prj1 p))))
+                                        (pair (N0-e {Γ} C c r)
+                                              (subj-red _ _ (N0-e {Γ} C c r)
                                                   (R0-cong' {Γ} C C' c c' r r' Cq (Raw-lm2 (prj1 p)))))
--- eq-from-elteq (N0 Γ) p 
+-- eq-from-elteq (N0 Γ) p
 R0-sub : {Δ Γ : ctx}
 --
       -> (h : subst Δ Γ)
@@ -1198,9 +1198,8 @@ R0-sub : {Δ Γ : ctx}
       -> (r : Γ ==> c :: N0 Γ)
       -> (r' : Δ ==> c [ h ] :: N0 Γ [[ h ]])
 -- ----------------------------------------------------------------------------------------
-      -> Δ ==> R0 {Γ} C c r [ h ]  ==  R0 {Δ} (C [[ ↑ (N0 Γ) h ]]) (c [ h ]) r' :: C [[ els r ]] [[ h ]] 
-R0-sub {Δ} {Γ} h C c r r' = pair (Raw-lm (R0-sub' {Δ} {Γ} h C c r r')) 
-                                 (pair (elt-subst h (N0-e {Γ} C c r)) 
+      -> Δ ==> R0 {Γ} C c r [ h ]  ==  R0 {Δ} (C [[ ↑ (N0 Γ) h ]]) (c [ h ]) r' :: C [[ els r ]] [[ h ]]
+R0-sub {Δ} {Γ} h C c r r' = pair (Raw-lm (R0-sub' {Δ} {Γ} h C c r r'))
+                                 (pair (elt-subst h (N0-e {Γ} C c r))
                                        (subj-red _ _  (elt-subst h (N0-e {Γ} C c r)) (R0-sub' {Δ} {Γ} h C c r r')))
-
 

--- a/MLTT-and-setoids/V-model-pt11.agda
+++ b/MLTT-and-setoids/V-model-pt11.agda
@@ -29,31 +29,31 @@ open import V-model-pt6         -- 842 lines
 open import V-model-pt7         --  66 lines
 open import V-model-pt8         -- 134 lines
 open import V-model-pt9         -- 441 lines
-open import V-model-pt10  
-open import V-model-pt13         
+open import V-model-pt10
+open import V-model-pt13
 
 
 -- Universes à la Russell with parameters
--- 
---       
+--
+--
 
 
 
 -- constant type
 
 
-U-f  :   (I : Set) -> (F : I -> Set) 
+U-f  :   (I : Set) -> (F : I -> Set)
         -> (Γ : ctx)  -> ty Γ
 U-f I F Γ = Const (uV I F)  Γ
 
-T-f :  (I : Set) -> (F : I -> Set) 
+T-f :  (I : Set) -> (F : I -> Set)
      -> {Γ : ctx}  -> (A : raw Γ)
      -> (Γ ==> A :: U-f I F Γ)
 -- --------------------------
      -> ty Γ
 T-f I F {Γ} A p = A  -- tyy (raw.rawterm A)
 
-T-f-Russell-eq : (I : Set) -> (F : I -> Set) 
+T-f-Russell-eq : (I : Set) -> (F : I -> Set)
      -> {Γ : ctx}  -> (A : raw Γ)
      -> (p : Γ ==> A :: U-f I F Γ)
 -- -------------------------------
@@ -61,21 +61,21 @@ T-f-Russell-eq : (I : Set) -> (F : I -> Set)
 --
 T-f-Russell-eq I F {Γ} A p = tyrefl A
 
-U-f-sub : (I : Set) -> (F : I -> Set) 
+U-f-sub : (I : Set) -> (F : I -> Set)
      ->  (Δ Γ : ctx)  -> (f : subst Δ Γ)
      ->  Δ ==> (U-f I F Γ) [[ f ]] == U-f I F Δ
 U-f-sub I F Δ Γ f = mk-eqty (λ x → <<>> (refV _))
 
 
 natU : (Γ : ctx) -> raw Γ
-natU Γ = mkraw (record { op = λ x → natV 
-                       ; ext = λ x y p → refl' _ _  
+natU Γ = mkraw (record { op = λ x → natV
+                       ; ext = λ x y p → refl' _ _
                        })
 
 
 
-U-f-nat :  (I : Set) -> (F : I -> Set) 
-           -> (Γ : ctx) 
+U-f-nat :  (I : Set) -> (F : I -> Set)
+           -> (Γ : ctx)
 -- -----------------------------------
     -> Γ ==> natU Γ :: U-f I F Γ
 --
@@ -84,20 +84,20 @@ U-f-nat I F Γ = mk-elt (λ x → nat-sV I F , (symV (emb-nat I F)))
 
 
 
-T-f-nat :  (I : Set) -> (F : I -> Set) 
+T-f-nat :  (I : Set) -> (F : I -> Set)
               -> (Γ : ctx)
 -- ------------------------------------------------------
       -> Γ ==> T-f I F (natU Γ) (U-f-nat I F Γ) == Nat Γ
 --
-T-f-nat I F Γ = mk-eqty (λ x → <<>> (traV (easy-eqV _ _ _ (λ y → symV (nat-sV-V I F y))) (emb-nat I F))) 
+T-f-nat I F Γ = mk-eqty (λ x → <<>> (traV (easy-eqV _ _ _ (λ y → symV (nat-sV-V I F y))) (emb-nat I F)))
 
 
-U-f-Russell-nat :  (I : Set) -> (F : I -> Set) 
-              -> (Γ : ctx) 
+U-f-Russell-nat :  (I : Set) -> (F : I -> Set)
+              -> (Γ : ctx)
 -- -----------------------------------
     -> Γ ==> Nat Γ :: U-f I F Γ
 --
-U-f-Russell-nat I F Γ = mk-elt (λ x → natV-in-uV I F)  
+U-f-Russell-nat I F Γ = mk-elt (λ x → natV-in-uV I F)
 
 
 
@@ -106,19 +106,19 @@ U-f-Russell-nat I F Γ = mk-elt (λ x → natV-in-uV I F)
 -- sigma-sV
 
 
-U-f-Russell-sigma-lm : (I : Set) -> (F : I -> Set) 
-    -> {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-f-Russell-sigma-lm : (I : Set) -> (F : I -> Set)
+    -> {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U-f I F Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U-f I F Γ [[ ↓ A ]])
     ->  (x :  || κ Γ ||)
     ->  apr (Σ-f A B) x ∈ uV I F
-U-f-Russell-sigma-lm I F {Γ} A p B q x = 
+U-f-Russell-sigma-lm I F {Γ} A p B q x =
   let lm : (apt (Σ-f A B) x) ≐ sigmaV (apt A x) (mk-Par-op-Fx A B x)
       lm = Σ-f-exp1 {Γ} A B x
       lm2 : sigmaV (apt A x) (mk-Par-op-Fx A B x) ∈ uV I F
-      lm2 = sigmaV-reflection I F (apt A x) (mk-Par-op-Fx A B x) 
+      lm2 = sigmaV-reflection I F (apt A x) (mk-Par-op-Fx A B x)
                   (apel p x) (λ y → apel q (x , y))
       main : apr (Σ-f A B) x ∈ uV I F
       main = memV-left-ext (apr (Σ-f A B) x)  _ (uV I F)  lm lm2
@@ -126,31 +126,31 @@ U-f-Russell-sigma-lm I F {Γ} A p B q x =
 
 
 
-U-f-Russell-sigma :  (I : Set) -> (F : I -> Set) 
-    -> {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-f-Russell-sigma :  (I : Set) -> (F : I -> Set)
+    -> {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U-f I F Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U-f I F Γ [[ ↓ A ]])
     ->  Γ ==> Σ-f A B :: U-f I F Γ
-U-f-Russell-sigma I F {Γ} A p B q  
+U-f-Russell-sigma I F {Γ} A p B q
     = mk-elt (U-f-Russell-sigma-lm I F {Γ} A p B q)
 
 
 
-U-f-Russell-pi-lm : (I : Set) -> (F : I -> Set) 
-    -> {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-f-Russell-pi-lm : (I : Set) -> (F : I -> Set)
+    -> {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U-f I F Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U-f I F Γ [[ ↓ A ]])
     ->  (x :  || κ Γ ||)
     ->  apr (Π-f A B) x ∈ uV I F
-U-f-Russell-pi-lm I F {Γ} A p B q x = 
+U-f-Russell-pi-lm I F {Γ} A p B q x =
   let lm : (apt (Π-f A B) x) ≐ piV (apt A x) (mk-Par-op-Fx A B x)
       lm = Π-f-exp1 {Γ} A B x
       lm2 : piV (apt A x) (mk-Par-op-Fx A B x) ∈ uV I F
-      lm2 = piV-reflection I F (apt A x) (mk-Par-op-Fx A B x) 
+      lm2 = piV-reflection I F (apt A x) (mk-Par-op-Fx A B x)
                   (apel p x) (λ y → apel q (x , y))
       main : apr (Π-f A B) x ∈ uV I F
       main = memV-left-ext (apr (Π-f A B) x)  _ (uV I F)  lm lm2
@@ -158,9 +158,9 @@ U-f-Russell-pi-lm I F {Γ} A p B q x =
 
 
 
-U-f-Russell-pi : (I : Set) -> (F : I -> Set) 
-    -> {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-f-Russell-pi : (I : Set) -> (F : I -> Set)
+    -> {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U-f I F Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U-f I F Γ [[ ↓ A ]])
@@ -169,7 +169,7 @@ U-f-Russell-pi I F {Γ} A p B q  = mk-elt (U-f-Russell-pi-lm I F {Γ} A p B q)
 
 
 
-U-f-Russell-ID-lm :  (I : Set) -> (F : I -> Set) 
+U-f-Russell-ID-lm :  (I : Set) -> (F : I -> Set)
      -> {Γ : ctx}
      -> (A : ty Γ)
      -> (p : Γ ==> A :: U-f I F Γ)
@@ -199,20 +199,20 @@ U-f-Russell-ID-lm I F {Γ} A p a qa b qb x =
 
 
 
-U-f-Russell-ID :  (I : Set) -> (F : I -> Set) 
+U-f-Russell-ID :  (I : Set) -> (F : I -> Set)
      -> {Γ : ctx}
      -> (A : ty Γ)
      -> (p : Γ ==> A :: U-f I F Γ)
      -> (a : raw Γ)
      -> (qa : Γ ==> a :: A)
      -> (b : raw Γ)
-     -> (qb : Γ ==> b :: A)    
+     -> (qb : Γ ==> b :: A)
      -> Γ ==> ID A a qa b qb :: U-f I F Γ
 U-f-Russell-ID I F {Γ} A p a qa b qb = mk-elt (U-f-Russell-ID-lm I F{Γ} A p a qa b qb)
 
 
 
-U-f-Russell-N0 :  (I : Set) -> (F : I -> Set) 
+U-f-Russell-N0 :  (I : Set) -> (F : I -> Set)
       -> {Γ : ctx}
       -> Γ ==> N0 Γ :: U-f I F Γ
 U-f-Russell-N0 I F {Γ} = mk-elt (λ x →  (zeroV-reflection I F))
@@ -220,14 +220,14 @@ U-f-Russell-N0 I F {Γ} = mk-elt (λ x →  (zeroV-reflection I F))
 
 
 
-U-f-Russell-Sum-lm :  (I : Set) -> (F : I -> Set) 
-    -> {Γ : ctx} 
-    ->  (A B : ty Γ) 
+U-f-Russell-Sum-lm :  (I : Set) -> (F : I -> Set)
+    -> {Γ : ctx}
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U-f I F Γ)
     ->  (q : Γ ==> B :: U-f I F Γ)
     ->  (x :  || κ Γ ||)
     ->  apr (Sum A B) x ∈ uV I F
-U-f-Russell-Sum-lm I F {Γ} A B p q x = 
+U-f-Russell-Sum-lm I F {Γ} A B p q x =
   let  lm : (apt (Sum A B) x) ≐ sumV (apt A x) (apt B x)
        lm =  refV _
        lm2 : sumV (apt A x) (apt B x) ∈ uV I F
@@ -236,13 +236,13 @@ U-f-Russell-Sum-lm I F {Γ} A B p q x =
        main = memV-left-ext (apr (Sum A B) x)  _ (uV I F)  lm lm2
   in main
 
-U-f-Russell-Sum :  (I : Set) -> (F : I -> Set) 
-    ->  {Γ : ctx} 
-    ->  (A B : ty Γ) 
+U-f-Russell-Sum :  (I : Set) -> (F : I -> Set)
+    ->  {Γ : ctx}
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U-f I F Γ)
     ->  (q : Γ ==> B :: U-f I F Γ)
     ->  Γ ==> Sum A B :: U-f I F Γ
-U-f-Russell-Sum I F {Γ} A B p q  
+U-f-Russell-Sum I F {Γ} A B p q
     = mk-elt (U-f-Russell-Sum-lm I F {Γ} A B p q)
 
 -- instantiate the parameters I and F
@@ -259,7 +259,7 @@ T-0 : {Γ : ctx}  -> (A : raw Γ)
      -> (Γ ==> A :: U-0 Γ)
 -- --------------------------
      -> ty Γ
-T-0 A p = A 
+T-0 A p = A
 
 
 -- U-f I F Γ = Const (uV I F)  Γ
@@ -274,7 +274,7 @@ T-0 A p = A
 -- uV I0 F0 = sup (sV I0 F0) (emb I0 F0)
 -- uV I1 F1 = sup (sV I1 F1) (emb I1 F1)
 
--- emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V 
+-- emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V
 -- emb I F (sup A f) = sup (To {I} {F} A) (\x -> emb I F (f x))
 
 
@@ -296,7 +296,7 @@ T-0 A p = A
 -- uV I0 F0 = sup (sV I0 F0) (emb I0 F0)
 -- uV I1 F1 = sup (sV I1 F1) (emb I1 F1)
 
--- emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V 
+-- emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V
 -- emb I F (sup A f) = sup (To {I} {F} A) (\x -> emb I F (f x))
 
 
@@ -318,15 +318,15 @@ T-1 : {Γ : ctx}  -> (A : raw Γ)
      -> (Γ ==> A :: U-1 Γ)
 -- --------------------------
      -> ty Γ
-T-1 A p = A 
+T-1 A p = A
 
 
 
-emb-W-W : (I : Set) -> (F : I -> Set) 
+emb-W-W : (I : Set) -> (F : I -> Set)
          -> (J : Set) -> (G : J -> Set)
          -> (h : I -> J) -> (g : (i : I) -> G (h i) -> F i )
          -> W I F -> W J G
-emb-W-W I F J G h g (sup a f) = 
+emb-W-W I F J G h g (sup a f) =
       sup (h a) (\x -> emb-W-W I F J G h g (f (g a x)))
 
 
@@ -365,14 +365,14 @@ emb-zV = pair emb-zV-le emb-zV-ge
 Cu-1a-lm2 : uV I0 F0 ∈ uV I1 F1
 Cu-1a-lm2 = zV , emb-zV
 
-Cu-1a : (Γ : ctx)  
+Cu-1a : (Γ : ctx)
      -> (Γ ==> U-0 Γ :: U-1 Γ)
 Cu-1a Γ = mk-elt (λ x → Cu-1a-lm2)
 
 
 
 transitive-uV : (I : Set) -> (F : I -> Set) -> (u : V) -> u ∈ uV I F -> u ⊆ uV I F
-transitive-uV I F u (sup a f , p2) x q = 
+transitive-uV I F u (sup a f , p2) x q =
     let lm : u ≐ emb I F (sup a f)
         lm = p2
         lm2 : x ∈ sup (To a) (λ x₁ → emb I F (f x₁))
@@ -382,8 +382,8 @@ transitive-uV I F u (sup a f , p2) x q =
         lm4 = (f (pj1 lm2))
         main : x ∈ uV I F
         main = lm4 , lm3
-    in main 
-  
+    in main
+
 
 
 Cu-1b-lm2 : uV I0 F0 ⊆ uV I1 F1
@@ -393,7 +393,7 @@ Cu-1b-lm : {Γ : ctx}  -> (A : raw Γ)
      -> (Γ ==> A :: U-0 Γ)
      -> (x : || κ Γ ||)
      -> apr A x ∈ apt (U-1 Γ) x
-Cu-1b-lm {Γ} A p x  = 
+Cu-1b-lm {Γ} A p x  =
     let r : apr A x ∈ apt (U-0 Γ) x
         r = apel p x
         main : apr A x ∈ apt (U-1 Γ) x
@@ -429,7 +429,7 @@ T- : (k : N) -> {Γ : ctx}  -> (A : raw Γ)
      -> (Γ ==> A :: U- k Γ)
 -- --------------------------
      -> ty Γ
-T- k {Γ} A p = A 
+T- k {Γ} A p = A
 
 
 
@@ -450,7 +450,7 @@ zV- k = sup (za- k) (zf- k)
 
 
 
-zf-lm- : (k : N) -> (v : (sV (I- k) (F- k))) ->  
+zf-lm- : (k : N) -> (v : (sV (I- k) (F- k))) ->
           emb (I- k) (F- k) v ≐  emb (I- (s k)) (F- (s k)) (zf- (s k) v)
 zf-lm- k (sup a f) = easy-eqV _ _ _ (λ x → zf-lm- k (f x))
 
@@ -461,7 +461,7 @@ emb-zV-le- k v = v , (let lm : emb (I- k) (F- k) v ≐  emb (I- (s k)) (F- (s k)
                           lm = zf-lm- k v
                       in lm)
 
- 
+
 emb-zV-ge- : (k : N) -> sup (sV (I- k) (F- k)) (emb (I- k) (F- k)) ≥ emb  (I- (s k)) (F- (s k)) (zV- (s k))
 emb-zV-ge- k v = v , zf-lm- k v
 
@@ -473,7 +473,7 @@ emb-zV- k = pair (emb-zV-le- k) (emb-zV-ge- k)
 Cu-1a-lm2- : (k : N) -> uV (I- k) (F- k) ∈ uV (I- (s k)) (F- (s k))
 Cu-1a-lm2- k = (zV- (s k)) , (emb-zV- k)
 
-Cu-1a- : (k : N) -> (Γ : ctx)  
+Cu-1a- : (k : N) -> (Γ : ctx)
      -> (Γ ==> U- k Γ :: U- (s k) Γ)
 Cu-1a- k Γ = mk-elt (λ x → Cu-1a-lm2- k)
 
@@ -487,7 +487,7 @@ Cu-1b-lm- :  (k : N) -> {Γ : ctx}  -> (A : raw Γ)
      -> (Γ ==> A :: U- k Γ)
      -> (x : || κ Γ ||)
      -> apr A x ∈ apt (U- (s k) Γ) x
-Cu-1b-lm- k {Γ} A p x  = 
+Cu-1b-lm- k {Γ} A p x  =
     let r : apr A x ∈ apt (U- k Γ) x
         r = apel p x
         main : apr A x ∈ apt (U- (s k) Γ) x
@@ -502,7 +502,7 @@ Cu-1b- k {Γ} A p = mk-elt (λ x → Cu-1b-lm- k {Γ} A p x)
 
 -- Closure rules
 
-T-eq- : (k : N) 
+T-eq- : (k : N)
      -> {Γ : ctx}  -> (A : raw Γ)
      -> (p : Γ ==> A :: U- k  Γ)
 -- -------------------------------
@@ -510,33 +510,33 @@ T-eq- : (k : N)
 --
 T-eq- k {Γ} A p = tyrefl A
 
-U-sub- : (k : N)  
+U-sub- : (k : N)
      ->  (Δ Γ : ctx)  -> (f : subst Δ Γ)
      ->  Δ ==> (U- k Γ) [[ f ]] == U- k  Δ
 U-sub- k Δ Γ f = mk-eqty (λ x → <<>> (refV _))
 
 
-U-nat- :  (k : N) -> (Γ : ctx) 
+U-nat- :  (k : N) -> (Γ : ctx)
 -- -----------------------------------
     -> Γ ==> Nat Γ :: U- k Γ
 --
-U-nat- k Γ = mk-elt (λ x → natV-in-uV (I- k) (F- k))  
+U-nat- k Γ = mk-elt (λ x → natV-in-uV (I- k) (F- k))
 
 
 
-U-sigma-lm- : (k : N) 
-    -> {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-sigma-lm- : (k : N)
+    -> {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U- k Γ [[ ↓ A ]])
     ->  (x :  || κ Γ ||)
     ->  apr (Σ-f A B) x ∈ uV (I- k) (F- k)
-U-sigma-lm- k {Γ} A p B q x = 
+U-sigma-lm- k {Γ} A p B q x =
   let lm : (apt (Σ-f A B) x) ≐ sigmaV (apt A x) (mk-Par-op-Fx A B x)
       lm = Σ-f-exp1 {Γ} A B x
       lm2 : sigmaV (apt A x) (mk-Par-op-Fx A B x) ∈ uV (I- k) (F- k)
-      lm2 = sigmaV-reflection (I- k) (F- k) (apt A x) (mk-Par-op-Fx A B x) 
+      lm2 = sigmaV-reflection (I- k) (F- k) (apt A x) (mk-Par-op-Fx A B x)
                   (apel p x) (λ y → apel q (x , y))
       main : apr (Σ-f A B) x ∈ uV (I- k) (F- k)
       main = memV-left-ext (apr (Σ-f A B) x)  _ (uV (I- k) (F- k))  lm lm2
@@ -544,32 +544,32 @@ U-sigma-lm- k {Γ} A p B q x =
 
 
 
-U-sigma- : (k : N)  
-    -> {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-sigma- : (k : N)
+    -> {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U- k Γ [[ ↓ A ]])
     ->  Γ ==> Σ-f A B :: U- k Γ
-U-sigma- k {Γ} A p B q  
+U-sigma- k {Γ} A p B q
     = mk-elt (U-sigma-lm- k {Γ} A p B q)
 
 
 
 
-U-pi-lm- :  (k : N)  
-    -> {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-pi-lm- :  (k : N)
+    -> {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U- k Γ [[ ↓ A ]])
     ->  (x :  || κ Γ ||)
     ->  apr (Π-f A B) x ∈ uV (I- k) (F- k)
-U-pi-lm- k {Γ} A p B q x = 
+U-pi-lm- k {Γ} A p B q x =
   let lm : (apt (Π-f A B) x) ≐ piV (apt A x) (mk-Par-op-Fx A B x)
       lm = Π-f-exp1 {Γ} A B x
       lm2 : piV (apt A x) (mk-Par-op-Fx A B x) ∈ uV (I- k) (F- k)
-      lm2 = piV-reflection  (I- k) (F- k) (apt A x) (mk-Par-op-Fx A B x) 
+      lm2 = piV-reflection  (I- k) (F- k) (apt A x) (mk-Par-op-Fx A B x)
                   (apel p x) (λ y → apel q (x , y))
       main : apr (Π-f A B) x ∈ uV  (I- k) (F- k)
       main = memV-left-ext (apr (Π-f A B) x)  _ (uV (I- k) (F- k))  lm lm2
@@ -577,9 +577,9 @@ U-pi-lm- k {Γ} A p B q x =
 
 
 
-U-pi- : (k : N) 
-    -> {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-pi- : (k : N)
+    -> {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U- k Γ [[ ↓ A ]])
@@ -589,7 +589,7 @@ U-pi- k {Γ} A p B q  = mk-elt (U-pi-lm- k {Γ} A p B q)
 
 
 
-U-ID-lm- : (k : N) 
+U-ID-lm- : (k : N)
      -> {Γ : ctx}
      -> (A : ty Γ)
      -> (p : Γ ==> A :: U- k Γ)
@@ -612,21 +612,21 @@ U-ID-lm- k {Γ} A p a qa b qb x =
       lm2 = pair (λ r → traV (symV qa2) (traV r qb2) , qa2)
                  (λ r → traV qa2 (traV r (symV qb2)) , qa2)
       main : apr (ID A a qa b qb) x ∈ uV (I- k) (F- k)
-      main = memV-left-ext (apr (ID A a qa b qb) x) 
+      main = memV-left-ext (apr (ID A a qa b qb) x)
                (idV (apt A x) (pj1 (apel qa x)) (pj1 (apel qb x))) (uV (I- k) (F- k))
                (traV lm lm2)
                (idV-reflection (I- k) (F- k) (apt A x) (pj1 (apel qa x)) (pj1 (apel qb x)) (apel p x))
   in main
 
 
-U-ID- :  (k : N) 
+U-ID- :  (k : N)
      -> {Γ : ctx}
      -> (A : ty Γ)
      -> (p : Γ ==> A :: U- k Γ)
      -> (a : raw Γ)
      -> (qa : Γ ==> a :: A)
      -> (b : raw Γ)
-     -> (qb : Γ ==> b :: A)    
+     -> (qb : Γ ==> b :: A)
      -> Γ ==> ID A a qa b qb :: U- k Γ
 U-ID- k {Γ} A p a qa b qb = mk-elt (U-ID-lm- k {Γ} A p a qa b qb)
 
@@ -638,14 +638,14 @@ U-N0- :  (k : N)
 U-N0- k {Γ} = mk-elt (λ x →  (zeroV-reflection (I- k) (F- k)))
 
 
-U-Sum-lm- :  (k : N) 
-    ->  {Γ : ctx} 
-    ->  (A B : ty Γ) 
+U-Sum-lm- :  (k : N)
+    ->  {Γ : ctx}
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (q : Γ ==> B :: U- k Γ)
     ->  (x :  || κ Γ ||)
     ->  apr (Sum A B) x ∈ uV (I- k) (F- k)
-U-Sum-lm- k {Γ} A B p q x = 
+U-Sum-lm- k {Γ} A B p q x =
   let  lm : (apt (Sum A B) x) ≐ sumV (apt A x) (apt B x)
        lm =  refV _
        lm2 : sumV (apt A x) (apt B x) ∈ uV  (I- k) (F- k)
@@ -655,19 +655,19 @@ U-Sum-lm- k {Γ} A B p q x =
   in main
 
 U-Sum- :  (k : N)
-    ->  {Γ : ctx} 
-    ->  (A B : ty Γ) 
+    ->  {Γ : ctx}
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (q : Γ ==> B :: U- k Γ)
     ->  Γ ==> Sum A B :: U- k Γ
-U-Sum- k {Γ} A B p q  
+U-Sum- k {Γ} A B p q
     = mk-elt (U-Sum-lm- k {Γ} A B p q)
 
 -- reflection of type equalities
 
 U-eq-refl1 :  (k : N)
-    ->  {Γ : ctx} 
-    ->  (A B : ty Γ) 
+    ->  {Γ : ctx}
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (q : Γ ==> B :: U- k Γ)
     ->  (Γ ==> A == B)
@@ -675,8 +675,8 @@ U-eq-refl1 :  (k : N)
 U-eq-refl1 k {Γ} A B p q r = pair (Raw-lm (eq-from-tyeq A B r)) (pair p q)
 
 U-eq-refl2 :  (k : N)
-    ->  {Γ : ctx} 
-    ->  (A B : ty Γ) 
+    ->  {Γ : ctx}
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U- k Γ)
     ->  (q : Γ ==> B :: U- k Γ)
     ->  (Γ ==> A == B :: U- k Γ)

--- a/MLTT-and-setoids/V-model-pt12.agda
+++ b/MLTT-and-setoids/V-model-pt12.agda
@@ -87,7 +87,7 @@ ext : {Δ Γ : ctx} -> (A : ty Γ)
       ->  (f : subst Δ Γ) -> (a : raw Δ)
       -> Δ ==> a :: A [[ f ]]
       -> subst Δ (Γ ▷ A)
-ext {Δ} {Γ} A f a p = subst.sb (record { op = ext-op A f a p
+ext {Δ} {Γ} A f a p = sb (record { op = ext-op A f a p
                                        ; ext = ext-ext A f a p })
 --}
 
@@ -150,4 +150,3 @@ Quot-e  : {Γ : ctx}
        -> (r : Γ ==> c :: (Quot {Γ} A R))
        -> Γ ==> QE-op {Γ} A R P d p e q c r :: P [[ els r ]]
 Quot-e = {!!}
-

--- a/MLTT-and-setoids/V-model-pt12.agda
+++ b/MLTT-and-setoids/V-model-pt12.agda
@@ -42,7 +42,7 @@ quot : {Γ : ctx}
    -> (a : raw Γ)
    -> (p : Γ ==> a :: A)
    -> raw Γ
-quot {Γ} A R a p = {!!}  
+quot {Γ} A R a p = {!!}
 
 Quot-i : {Γ : ctx}
    -> (A : ty Γ)
@@ -65,7 +65,7 @@ els2-lm :  {Γ : ctx}
     -> {a  : raw Γ}
     -> (p : Γ ==> a :: A)
     -> Γ ==> A == (A [[ ↓ A ]]) [[ els p ]]
-els2-lm {Γ} {A} {a} p = {!!} 
+els2-lm {Γ} {A} {a} p = {!!}
 
 els2 : {Γ : ctx}
     -> {A : ty Γ}
@@ -77,17 +77,17 @@ els2 {Γ} {A} {a} {a'} p p' = ext  (A [[ ↓ A ]]) (els p) a' (elttyeq p' (els2
 
 {--
 
-elttyeq :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ} 
+elttyeq :  {Γ : ctx} ->  {a : raw Γ}  -> {A B : ty Γ}
 --
-      -> Γ ==> a :: A     -> Γ ==> A == B 
+      -> Γ ==> a :: A     -> Γ ==> A == B
 --  --------------------------------------------
               -> Γ ==> a :: B
 
-ext : {Δ Γ : ctx} -> (A : ty Γ) 
-      ->  (f : subst Δ Γ) -> (a : raw Δ) 
+ext : {Δ Γ : ctx} -> (A : ty Γ)
+      ->  (f : subst Δ Γ) -> (a : raw Δ)
       -> Δ ==> a :: A [[ f ]]
       -> subst Δ (Γ ▷ A)
-ext {Δ} {Γ} A f a p = subst.sb (record { op = ext-op A f a p 
+ext {Δ} {Γ} A f a p = subst.sb (record { op = ext-op A f a p
                                        ; ext = ext-ext A f a p })
 --}
 
@@ -110,7 +110,7 @@ Quot-ID-exd : {Γ : ctx}
    -> (p' : Γ ==> a' :: A)
    -> (r : raw Γ)
    -> (q : Γ ==> r :: R [[ els2 p p' ]])
-   -> Γ ==> omicron {Γ} A R a a' p p' r q 
+   -> Γ ==> omicron {Γ} A R a a' p p' r q
         :: ID (Quot {Γ} A R) (quot {Γ} A R a p) (Quot-i {Γ} A R a p)
                              (quot {Γ} A R a' p') (Quot-i {Γ} A R a' p')
 Quot-ID-exd {Γ} A R a a' p p' r q = {!!}
@@ -130,12 +130,12 @@ QE-op : {Γ : ctx}
        -> (p : Γ ▷ A ==> d :: P [[ quot-subst A R ]])
        -> (e : raw (Γ ▷ A ▷ (A [[ ↓ A ]]) ▷ R))
        -- need transport here
-       -> (q : Γ ▷ A ▷ (A [[ ↓ A ]]) ▷ R ==> 
+       -> (q : Γ ▷ A ▷ (A [[ ↓ A ]]) ▷ R ==>
                  e :: ID (P [[ quot-subst A R ]] [[ ↓ (A [[ ↓ A ]]) ]] [[ ↓ R ]] )
                         ( d  [ ↓ (A [[ ↓ A ]]) ] [ ↓ R ] ) {!!} {!!} {!!})
        -> (c : raw Γ)
        -> (r : Γ ==> c :: (Quot {Γ} A R))
-       -> raw Γ 
+       -> raw Γ
 QE-op = {!!}
 
 Quot-e  : {Γ : ctx}

--- a/MLTT-and-setoids/V-model-pt13.agda
+++ b/MLTT-and-setoids/V-model-pt13.agda
@@ -33,7 +33,7 @@ open import V-model-pt9         -- 441 lines
 --  binary sum types
 
 
- 
+
 -- sumV : (a b : V) -> V
 -- sumV a b = sup (# a + # b) (bV-sumV a b)
 
@@ -42,7 +42,7 @@ lfV-op a b x = inl x
 
 lfV-ext : (a b : V) -> (x y : || κ a ||)
         ->  < κ a > x ~ y -> < κ (sumV a b) > lfV-op a b x ~ lfV-op a b y
-lfV-ext a b x y p = <> (pairV-ext (refV _) (>< p))  
+lfV-ext a b x y p = <> (pairV-ext (refV _) (>< p))
 
 lfV : (a b : V) -> || (κ a) => (κ (sumV a b)) ||
 lfV a b = record { op = lfV-op a b
@@ -70,7 +70,7 @@ ty-trp-op : {Γ : ctx}
    -> < κ Γ > x ~ y
    -> # (apt A x)
    -> # (apt A y)
-ty-trp-op {Γ} A {x} {y} p a = κ-trp-op (>><< (extensionality1 (ty.type A) x y p)) a   
+ty-trp-op {Γ} A {x} {y} p a = κ-trp-op (>><< (extensionality1 (ty.type A) x y p)) a
 
 ty-trp-prop : {Γ : ctx}
    -> (A : ty Γ)
@@ -81,7 +81,7 @@ ty-trp-prop : {Γ : ctx}
 ty-trp-prop {Γ} A {x} {y} p a =
    let  lm : apt A x ≐ apt A y
         lm = (>><< (extensionality1 (ty.type A) x y p))
-   in e+prop lm a 
+   in e+prop lm a
 
 
 
@@ -96,7 +96,7 @@ Sum-ext-half1 : {Γ : ctx}
    -> (A : ty Γ)
    -> (B : ty Γ)
    -> (x y : || κ Γ ||)
-   -> < κ Γ > x ~ y 
+   -> < κ Γ > x ~ y
    -> Sum-op A B x ≤ Sum-op A B y
 Sum-ext-half1 {Γ} A B x y p (inl a) =
   let lm :  (apt A x) ‣ a ≐   (apt A y) ‣ (ty-trp-op A p a)
@@ -113,9 +113,9 @@ Sum-ext-half2 : {Γ : ctx}
    -> (A : ty Γ)
    -> (B : ty Γ)
    -> (x y : || κ Γ ||)
-   -> < κ Γ > x ~ y 
+   -> < κ Γ > x ~ y
    -> Sum-op A B x ≥ Sum-op A B y
-Sum-ext-half2 {Γ} A B x y p u = 
+Sum-ext-half2 {Γ} A B x y p u =
     let lm = Sum-ext-half1 {Γ} A B y x (sym p) u
     in pj1 lm , symV (pj2 lm)
 
@@ -125,7 +125,7 @@ Sum-ext : {Γ : ctx}
    -> (A : ty Γ)
    -> (B : ty Γ)
    -> (x y : || κ Γ ||)
-   -> < κ Γ > x ~ y 
+   -> < κ Γ > x ~ y
    -> Sum-op A B x ≐ Sum-op A B y
 Sum-ext {Γ} A B x y p = pair (Sum-ext-half1 {Γ} A B x y p) (Sum-ext-half2 {Γ} A B x y p)
 
@@ -133,8 +133,8 @@ Sum : {Γ : ctx}
    -> (A : ty Γ)
    -> (B : ty Γ)
    -> ty Γ
-Sum {Γ} A B = mkraw (record { op = Sum-op {Γ} A B 
-                            ; ext = λ x y p → <<>> (Sum-ext {Γ} A B x y p) 
+Sum {Γ} A B = mkraw (record { op = Sum-op {Γ} A B
+                            ; ext = λ x y p → <<>> (Sum-ext {Γ} A B x y p)
                             })
 
 
@@ -144,7 +144,7 @@ Sum-cong : {Γ : ctx}
    -> Γ ==> A == A'
    -> Γ ==> B == B'
    -> Γ ==> Sum A B == Sum A' B'
-Sum-cong {Γ} A A' B B' p q = mk-eqty (λ x → <<>> (sumV-ext (apt A x) (apt B x) (apt A' x) (apt B' x) 
+Sum-cong {Γ} A A' B B' p q = mk-eqty (λ x → <<>> (sumV-ext (apt A x) (apt B x) (apt A' x) (apt B' x)
                                                    (>><< (ape p x)) (>><< (ape q x))))
 
 -- sumV-ext : (a b a' b' : V) -> a ≐ a' -> b ≐ b' -> sumV a b ≐ sumV a' b'
@@ -153,7 +153,7 @@ Sum-sub : {Δ Γ : ctx}
    -> (f : subst Δ Γ)
    -> (A : ty Γ)
    -> (B : ty Γ)
-   -> Δ ==> (Sum A B) [[ f ]] == Sum (A [[ f ]]) (B [[ f ]]) 
+   -> Δ ==> (Sum A B) [[ f ]] == Sum (A [[ f ]]) (B [[ f ]])
 Sum-sub {Δ} {Γ} f A B  = mk-eqty (λ x → <<>> (refV _))
 
 
@@ -165,7 +165,7 @@ aprex : {Γ : ctx}
    -> (x  : || κ Γ ||)
    -> apr a x ≐ apr a' x
 aprex {Γ} a a' p x = >><< (>><< (>><< p) x)
- 
+
 
 lf-op : {Γ : ctx}
    -> (A B : ty Γ)
@@ -190,7 +190,7 @@ lf-ext {Γ} A B a p x y q =
         py = pj2 (apel p y)
         lm : (apt A x) ‣ (pj1 (apel p x)) ≐ (apt A y) ‣ (pj1 (apel p y))
         lm = traV (symV px) (traV (>><< (extensionality1 (raw.rawterm a) _ _ q)) py)
-    in pairV-ext (refV _) lm 
+    in pairV-ext (refV _) lm
 
 
 
@@ -201,7 +201,7 @@ lf : {Γ : ctx}
    -> (p : Γ ==> a :: A)
    -> raw Γ
 lf {Γ} A B a p = mkraw (record { op = lf-op {Γ} A B a p
-                               ; ext = λ x y q → <<>> (lf-ext {Γ} A B a p x y q)})  
+                               ; ext = λ x y q → <<>> (lf-ext {Γ} A B a p x y q)})
 
 
 lf-pf : {Γ : ctx}
@@ -221,11 +221,11 @@ lf-cong' : {Γ : ctx}
    -> (r : Γ ==> B == B')
    -> << Raw Γ >>  a ~ a'
    -> << Raw Γ >> (lf {Γ} A B a p) ~ (lf {Γ} A' B' a' p')
-lf-cong' {Γ} A B A' B' a a' p p' q r t = 
-      <<>> (<<>> (λ x → <<>> (inl-ext-gen (apt A x) (apt B x) (apt A' x) (apt B' x) 
-                              (pj1 (apel p x)) (pj1 (apel p' x)) 
-                              (traV (symV (pj2 (apel p x))) 
-                                (traV  (aprex a a' t x) 
+lf-cong' {Γ} A B A' B' a a' p p' q r t =
+      <<>> (<<>> (λ x → <<>> (inl-ext-gen (apt A x) (apt B x) (apt A' x) (apt B' x)
+                              (pj1 (apel p x)) (pj1 (apel p' x))
+                              (traV (symV (pj2 (apel p x)))
+                                (traV  (aprex a a' t x)
                                       (pj2 (apel p' x)))))))
 
 
@@ -237,10 +237,10 @@ lf-cong : {Γ : ctx}
    -> (q : Γ ==> A == A')
    -> (r : Γ ==> B == B')
    -> (Γ ==> a == a' :: A)
-   -> Γ ==> lf {Γ} A B a p == lf {Γ} A' B' a' p' :: Sum A B 
-lf-cong {Γ} A B A' B' a a' p p' q r t = 
-                     pair (Raw-lm (lf-cong' {Γ} A B A' B' a a' p p' q r (Raw-lm2 (prj1 t) ))) 
-                          (pair (lf-pf A B a p) 
+   -> Γ ==> lf {Γ} A B a p == lf {Γ} A' B' a' p' :: Sum A B
+lf-cong {Γ} A B A' B' a a' p p' q r t =
+                     pair (Raw-lm (lf-cong' {Γ} A B A' B' a a' p p' q r (Raw-lm2 (prj1 t) )))
+                          (pair (lf-pf A B a p)
                                 (subj-red _ _ (lf-pf A B a p) (lf-cong' {Γ} A B A' B' a a' p p' q r (Raw-lm2 (prj1 t) ))))
 
 
@@ -253,7 +253,7 @@ lf-sub-lm : {Δ Γ : ctx}
    -> (p' : Δ ==> a [ f ] :: A [[ f ]])
    -> (x  : || κ Δ ||)
    -> lf-op {Γ} A B a p (aps f x) ≐  lf-op {Δ} (A [[ f ]]) (B [[ f ]]) (a [ f ]) p' x
-lf-sub-lm {Δ} {Γ} f A B a p p' x = 
+lf-sub-lm {Δ} {Γ} f A B a p p' x =
   let lm1 : apr a (aps f x) ≐ apt A (aps f x) ‣ pj1 (apel p (aps f x))
       lm1 = pj2 (apel p (aps f x))
       lm2 : apr (a [ f ]) x ≐ apt (A [[ f ]]) x ‣ pj1 (apel p' x)
@@ -264,7 +264,7 @@ lf-sub-lm {Δ} {Γ} f A B a p p' x =
       lm : (sumV (apt A (aps f x)) (apt B (aps f x))) ‣ (inl ( pj1 (apel p (aps f x))))
            ≐ (sumV (apt (A [[ f ]]) x) (apt (B [[ f ]]) x)) ‣ (inl ( pj1 (apel p' x)))
       lm = inl-ext-gen (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) _ _ lm4
-  in lm 
+  in lm
 
 
 
@@ -285,7 +285,7 @@ lf-sub : {Δ Γ : ctx}
    -> (p : Γ ==> a :: A)
    -> (p' : Δ ==> a [ h ] :: A [[ h ]])
    ->  Δ ==> (lf A B a p) [ h ] == lf (A [[ h ]])  (B [[ h ]]) (a [ h ]) p' :: (Sum A B) [[ h ]]
-lf-sub {Δ} {Γ} h A B a p p' = pair (Raw-lm (lf-sub' {Δ} {Γ} h A B a p p')) 
+lf-sub {Δ} {Γ} h A B a p p' = pair (Raw-lm (lf-sub' {Δ} {Γ} h A B a p p'))
                                     (pair (elt-subst h (lf-pf A B a p))
                                           (subj-red _ _ (elt-subst h (lf-pf A B a p)) (lf-sub' {Δ} {Γ} h A B a p p')))
 
@@ -306,12 +306,12 @@ rg-ext : {Γ : ctx}
    -> (x y : || κ Γ ||)
    -> < κ Γ > x ~ y
    -> rg-op A B b p x ≐ rg-op A B b p y
-rg-ext {Γ} A B b p x y  q = 
+rg-ext {Γ} A B b p x y  q =
     let px = pj2 (apel p x)
         py = pj2 (apel p y)
         lm : (apt B x) ‣ (pj1 (apel p x)) ≐ (apt B y) ‣ (pj1 (apel p y))
         lm = traV (symV px) (traV (>><< (extensionality1 (raw.rawterm b) _ _ q)) py)
-    in pairV-ext (refV _) lm 
+    in pairV-ext (refV _) lm
 
 rg : {Γ : ctx}
    -> (A B : ty Γ)
@@ -319,7 +319,7 @@ rg : {Γ : ctx}
    -> (p : Γ ==> b :: B)
    -> raw Γ
 rg {Γ} A B b p = mkraw (record { op = rg-op {Γ} A B b p
-                               ; ext =  λ x y q → <<>> (rg-ext {Γ} A B b p x y q) })  
+                               ; ext =  λ x y q → <<>> (rg-ext {Γ} A B b p x y q) })
 
 rg-pf : {Γ : ctx}
    -> (A B : ty Γ)
@@ -338,11 +338,11 @@ rg-cong' : {Γ : ctx}
    -> (r : Γ ==> B == B')
    -> << Raw Γ >>  b ~ b'
    -> << Raw Γ >> (rg {Γ} A B b p) ~ (rg {Γ} A' B' b' p')
-rg-cong' {Γ} A B A' B' b b' p p' q r t =   
-     <<>> (<<>> (λ x → <<>> (inr-ext-gen (apt A x) (apt B x) (apt A' x) (apt B' x) 
-                              (pj1 (apel p x)) (pj1 (apel p' x)) 
-                              (traV (symV (pj2 (apel p x))) 
-                                (traV  (aprex b b' t x) 
+rg-cong' {Γ} A B A' B' b b' p p' q r t =
+     <<>> (<<>> (λ x → <<>> (inr-ext-gen (apt A x) (apt B x) (apt A' x) (apt B' x)
+                              (pj1 (apel p x)) (pj1 (apel p' x))
+                              (traV (symV (pj2 (apel p x)))
+                                (traV  (aprex b b' t x)
                                       (pj2 (apel p' x)))))))
 
 rg-cong : {Γ : ctx}
@@ -353,10 +353,10 @@ rg-cong : {Γ : ctx}
    -> (q : Γ ==> A == A')
    -> (r : Γ ==> B == B')
    -> (Γ ==> b == b' :: B)
-   -> Γ ==> rg {Γ} A B b p == rg {Γ} A' B' b' p' :: Sum A B 
-rg-cong {Γ} A B A' B' b b' p p' q r t = 
-                 pair (Raw-lm (rg-cong' {Γ} A B A' B' b b' p p' q r (Raw-lm2 (prj1 t) ))) 
-                          (pair (rg-pf A B b p) 
+   -> Γ ==> rg {Γ} A B b p == rg {Γ} A' B' b' p' :: Sum A B
+rg-cong {Γ} A B A' B' b b' p p' q r t =
+                 pair (Raw-lm (rg-cong' {Γ} A B A' B' b b' p p' q r (Raw-lm2 (prj1 t) )))
+                          (pair (rg-pf A B b p)
                                 (subj-red _ _ (rg-pf A B b p) (rg-cong' {Γ} A B A' B' b b' p p' q r (Raw-lm2 (prj1 t) ))))
 
 
@@ -368,7 +368,7 @@ rg-sub-lm : {Δ Γ : ctx}
    -> (p' : Δ ==> b [ f ] :: B [[ f ]])
    -> (x  : || κ Δ ||)
    -> rg-op {Γ} A B b p (aps f x) ≐  rg-op {Δ} (A [[ f ]]) (B [[ f ]]) (b [ f ]) p' x
-rg-sub-lm {Δ} {Γ} f A B b p p' x = 
+rg-sub-lm {Δ} {Γ} f A B b p p' x =
   let lm1 : apr b (aps f x) ≐ apt B (aps f x) ‣ pj1 (apel p (aps f x))
       lm1 = pj2 (apel p (aps f x))
       lm2 : apr (b [ f ]) x ≐ apt (B [[ f ]]) x ‣ pj1 (apel p' x)
@@ -379,7 +379,7 @@ rg-sub-lm {Δ} {Γ} f A B b p p' x =
       lm : (sumV (apt A (aps f x)) (apt B (aps f x))) ‣ (inr ( pj1 (apel p (aps f x))))
            ≐ (sumV (apt (A [[ f ]]) x) (apt (B [[ f ]]) x)) ‣ (inr ( pj1 (apel p' x)))
       lm = inr-ext-gen (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) _ _ lm4
-  in lm 
+  in lm
 
 rg-sub' : {Δ Γ : ctx}
    -> (f : subst Δ Γ)
@@ -398,29 +398,29 @@ rg-sub : {Δ Γ : ctx}
    -> (p : Γ ==> b :: B)
    -> (p' : Δ ==> b [ h ] :: B [[ h ]])
    ->  Δ ==> (rg A B b p) [ h ] == rg (A [[ h ]])  (B [[ h ]]) (b [ h ]) p' :: (Sum A B) [[ h ]]
-rg-sub {Δ} {Γ} h A B b p p' = pair (Raw-lm (rg-sub' {Δ} {Γ} h A B b p p')) 
+rg-sub {Δ} {Γ} h A B b p p' = pair (Raw-lm (rg-sub' {Δ} {Γ} h A B b p p'))
                                     (pair (elt-subst h (rg-pf A B b p))
                                           (subj-red _ _ (elt-subst h (rg-pf A B b p)) (rg-sub' {Δ} {Γ} h A B b p p')))
 
 
 
 
-Sum-sub-lf : {Γ : ctx} 
+Sum-sub-lf : {Γ : ctx}
         -> (A B : ty Γ)
         ->  subst (Γ ▷ A) (Γ ▷ (Sum A B))
-Sum-sub-lf {Γ} A B = 
+Sum-sub-lf {Γ} A B =
   let lm = lf-pf  (A [[ ↓ A ]]) (B [[ ↓ A ]]) (vv A) (asm A)
       lm2 :  Γ ▷ A ==> (Sum A B [[ ↓ A ]]) == Sum (A [[ ↓ A ]]) (B [[ ↓ A ]])
       lm2 = Sum-sub  (↓ A) A B
-  in ext (Sum A B) (↓ A) (lf (A [[ ↓ A ]]) (B [[ ↓ A ]]) (vv A) (asm A) ) 
+  in ext (Sum A B) (↓ A) (lf (A [[ ↓ A ]]) (B [[ ↓ A ]]) (vv A) (asm A) )
                          (elttyeq lm (tysym lm2))
 
 
 
-Sum-sub-rg : {Γ : ctx} 
+Sum-sub-rg : {Γ : ctx}
         -> (A B : ty Γ)
         ->  subst (Γ ▷ B) (Γ ▷ (Sum A B))
-Sum-sub-rg {Γ} A B  = 
+Sum-sub-rg {Γ} A B  =
   let lm = rg-pf  (A [[ ↓ B ]]) (B [[ ↓ B ]]) (vv B) (asm B)
       lm2 :  Γ ▷ B ==> (Sum A B [[ ↓ B ]]) == Sum (A [[ ↓ B ]]) (B [[ ↓ B ]])
       lm2 = Sum-sub  (↓ B) A B
@@ -429,7 +429,7 @@ Sum-sub-rg {Γ} A B  =
 
 
 
-Sum-rec-op-aux : {Γ : ctx}   
+Sum-rec-op-aux : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -444,7 +444,7 @@ Sum-rec-op-aux {Γ} A B C d p e q x (inr v) = (apt C (x , inr v)) ‣ (pj1 (apel
 
 
 
-Sum-rec-op-aux-lm : {Γ : ctx}   
+Sum-rec-op-aux-lm : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -459,7 +459,7 @@ Sum-rec-op-aux-lm {Γ} A B C d p e q x (inr v) =  pj1 (apel q (x , v)) , refV _
 
 
 
-Sum-rec-op : {Γ : ctx}   
+Sum-rec-op : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -475,7 +475,7 @@ Sum-rec-op {Γ} A B C d p e q c r x = Sum-rec-op-aux {Γ} A B C d p e q x (pj1 (
 
 
 
-Sum-rec-ext-lm : {Γ : ctx}   
+Sum-rec-ext-lm : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -489,36 +489,36 @@ Sum-rec-ext-lm : {Γ : ctx}
        -> (apt (Sum A B) x) ‣ u ≐ (apt (Sum A B) y) ‣ v
        ->  Sum-rec-op-aux {Γ} A B C d p e q x u ≐
            Sum-rec-op-aux {Γ} A B C d p e q y v
-Sum-rec-ext-lm {Γ} A B C d p e q x y pf (inl a) (inl a') qf = 
+Sum-rec-ext-lm {Γ} A B C d p e q x y pf (inl a) (inl a') qf =
        let lm1 =  pj2 (apel p (x , a))
            lm2 =  pj2 (apel p (y , a'))
            lm3 :  < κ (Γ ▷ A) > (x , a) ~ (y , a')
-           lm3 = <> (pairV-ext (>< pf) (inl-inj-gen (apt A x) (apt B x) (apt A y) (apt B y) a a' qf) ) 
-           lm4 : apr d (x , a) ≐  apr d (y , a') 
+           lm3 = <> (pairV-ext (>< pf) (inl-inj-gen (apt A x) (apt B x) (apt A y) (apt B y) a a' qf) )
+           lm4 : apr d (x , a) ≐  apr d (y , a')
            lm4 = >><< (extensionality1 (raw.rawterm d) (x , a)   (y , a') lm3)
            main : apt C (x , inl a) ‣ pj1 (apel p (x , a)) ≐
                   apt C (y , inl a') ‣ pj1 (apel p (y , a'))
            main = traV (symV lm1) (traV lm4 lm2)
-       in main    
-Sum-rec-ext-lm {Γ} A B C d p e q x y pf (inl a) (inr b) qf = 
-      exfalso _  (inl-inr-dis (apt A x) (apt B x) (apt A y) (apt B y) a b qf) 
-Sum-rec-ext-lm {Γ} A B C d p e q x y pf (inr b) (inl a) qf = 
-      exfalso _  (inr-inl-dis (apt A x) (apt B x) (apt A y) (apt B y) a b qf) 
+       in main
+Sum-rec-ext-lm {Γ} A B C d p e q x y pf (inl a) (inr b) qf =
+      exfalso _  (inl-inr-dis (apt A x) (apt B x) (apt A y) (apt B y) a b qf)
+Sum-rec-ext-lm {Γ} A B C d p e q x y pf (inr b) (inl a) qf =
+      exfalso _  (inr-inl-dis (apt A x) (apt B x) (apt A y) (apt B y) a b qf)
 Sum-rec-ext-lm {Γ} A B C d p e q x y pf (inr b) (inr b') qf =
        let lm1 =  pj2 (apel q (x , b))
            lm2 =  pj2 (apel q (y , b'))
            lm3 :  < κ (Γ ▷ B) > (x , b) ~ (y , b')
-           lm3 = <> (pairV-ext (>< pf) (inr-inj-gen (apt A x) (apt B x) (apt A y) (apt B y) b b' qf) ) 
-           lm4 : apr e (x , b) ≐  apr e (y , b') 
+           lm3 = <> (pairV-ext (>< pf) (inr-inj-gen (apt A x) (apt B x) (apt A y) (apt B y) b b' qf) )
+           lm4 : apr e (x , b) ≐  apr e (y , b')
            lm4 = >><< (extensionality1 (raw.rawterm e) (x , b) (y , b') lm3)
            main : apt C (x , inr b) ‣ pj1 (apel q (x , b)) ≐
                   apt C (y , inr b') ‣ pj1 (apel q (y , b'))
            main = traV (symV lm1) (traV lm4 lm2)
-       in main    
+       in main
 
 
 
-Sum-rec-ext : {Γ : ctx}   
+Sum-rec-ext : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -530,7 +530,7 @@ Sum-rec-ext : {Γ : ctx}
        -> (x y : || κ Γ ||)
        ->  < κ Γ > x ~ y
        ->  Sum-rec-op A B C d p e q c r x ≐  Sum-rec-op A B C d p e q c r y
-Sum-rec-ext {Γ} A B C d p e q c r x y pf = 
+Sum-rec-ext {Γ} A B C d p e q c r x y pf =
   let ec : apr c x ≐ apr c y
       ec = >><< (extensionality1 (raw.rawterm c) x y pf)
       eq : (apt (Sum A B) x) ‣ (pj1 (apel r x)) ≐ (apt (Sum A B) y) ‣ (pj1 (apel r y))
@@ -540,7 +540,7 @@ Sum-rec-ext {Γ} A B C d p e q c r x y pf =
       main = Sum-rec-ext-lm {Γ} A B C d p e q x y pf (pj1 (apel r x)) (pj1 (apel r y)) eq
   in main
 
-Sum-rec : {Γ : ctx}   
+Sum-rec : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -550,14 +550,14 @@ Sum-rec : {Γ : ctx}
        -> (c : raw Γ)
        -> (r : Γ ==> c :: Sum A B)
        -> raw Γ
-Sum-rec {Γ} A B C d p e q c r =  mkraw (record { op = Sum-rec-op {Γ} A B C d p e q c r 
+Sum-rec {Γ} A B C d p e q c r =  mkraw (record { op = Sum-rec-op {Γ} A B C d p e q c r
                                                ; ext = λ x y pf → <<>> (Sum-rec-ext {Γ} A B C d p e q c r x y pf) })
 
 
 
 
- 
-Sum-rec-cong-lm2 : {Γ : ctx}   
+
+Sum-rec-cong-lm2 : {Γ : ctx}
        -> (A B A' B' : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (C' : ty (Γ ▷ (Sum A' B')))
@@ -583,14 +583,14 @@ Sum-rec-cong-lm2 {Γ} A B A' B' C C' d d' p p' e e' q q' Aq Bq Cq dq eq x (inl a
      let lm = pj2 (apel p (x , a))
          lm' = pj2 (apel p' (x , a'))
          lm3 = aprex _ _ dq (x , a)
-         lm4 = inl-inj-gen (apt A x) (apt B x) (apt A' x) (apt B' x) a a' pf      
+         lm4 = inl-inj-gen (apt A x) (apt B x) (apt A' x) (apt B' x) a a' pf
          lm7 :  apt A' x ‣ (ap (κ-Fam ±± ape Aq x) a) ≐ apt A x ‣ a
          lm7 = symV (e+prop (>><< (ape Aq x)) a)
          lm6 :  < κ (Γ ▷ A') >
               ap (subst.cmap (subst-trp (ext-eq' A A' Aq))) (x , a) ~ (x , a')
          lm6 = tra (ext-eq-lm A A' Aq x a) (<> (pairV-ext (refV _) (traV lm7 lm4)))
          lm5 : apr (d' [ subst-trp (ext-eq' A A' Aq) ]) (x , a) ≐  apr d' (x , a')
-         lm5 = >><< (extensionality1 (raw.rawterm d') 
+         lm5 = >><< (extensionality1 (raw.rawterm d')
                      (ap (subst.cmap (subst-trp (ext-eq' A A' Aq))) (x , a)) (x , a') lm6)
          lm2 : apr d (x , a) ≐  apr d' (x , a')
          lm2 = traV lm3 lm5
@@ -598,20 +598,20 @@ Sum-rec-cong-lm2 {Γ} A B A' B' C C' d d' p p' e e' q q' Aq Bq Cq dq eq x (inl a
                 apt C' (x , inl a') ‣ pj1 (apel p' (x , a'))
          main = traV (symV lm) (traV lm2 lm')
      in main
-Sum-rec-cong-lm2 {Γ} A B A' B' C C' d d' p p' e e' q q' Aq Bq Cq dq eq x (inl a) (inr b)  pf = exfalso _  (inl-inr-dis (apt A x) (apt B x) (apt A' x) (apt B' x) a b pf) 
+Sum-rec-cong-lm2 {Γ} A B A' B' C C' d d' p p' e e' q q' Aq Bq Cq dq eq x (inl a) (inr b)  pf = exfalso _  (inl-inr-dis (apt A x) (apt B x) (apt A' x) (apt B' x) a b pf)
 Sum-rec-cong-lm2 {Γ} A B A' B' C C' d d' p p' e e' q q' Aq Bq Cq dq eq x (inr b) (inl a)  pf = exfalso _  (inr-inl-dis (apt A x) (apt B x) (apt A' x) (apt B' x) a b pf)
-Sum-rec-cong-lm2 {Γ} A B A' B' C C' d d' p p' e e' q q' Aq Bq Cq dq eq x (inr b) (inr b')  pf = 
+Sum-rec-cong-lm2 {Γ} A B A' B' C C' d d' p p' e e' q q' Aq Bq Cq dq eq x (inr b) (inr b')  pf =
      let lm = pj2 (apel q (x , b))
          lm' = pj2 (apel q' (x , b'))
          lm3 = aprex _ _ eq (x , b)
-         lm4 = inr-inj-gen (apt A x) (apt B x) (apt A' x) (apt B' x) b b' pf      
+         lm4 = inr-inj-gen (apt A x) (apt B x) (apt A' x) (apt B' x) b b' pf
          lm7 :  apt B' x ‣ (ap (κ-Fam ±± ape Bq x) b) ≐ apt B x ‣ b
          lm7 = symV (e+prop (>><< (ape Bq x)) b)
          lm6 :  < κ (Γ ▷ B') >
               ap (subst.cmap (subst-trp (ext-eq' B B' Bq))) (x , b) ~ (x , b')
          lm6 = tra (ext-eq-lm B B' Bq x b) (<> (pairV-ext (refV _) (traV lm7 lm4)))
          lm5 : apr (e' [ subst-trp (ext-eq' B B' Bq) ]) (x , b) ≐  apr e' (x , b')
-         lm5 = >><< (extensionality1 (raw.rawterm e') 
+         lm5 = >><< (extensionality1 (raw.rawterm e')
                      (ap (subst.cmap (subst-trp (ext-eq' B B' Bq))) (x , b)) (x , b') lm6)
          lm2 : apr e (x , b) ≐  apr e' (x , b')
          lm2 = traV lm3 lm5
@@ -620,7 +620,7 @@ Sum-rec-cong-lm2 {Γ} A B A' B' C C' d d' p p' e e' q q' Aq Bq Cq dq eq x (inr b
          main = traV (symV lm) (traV lm2 lm')
      in main
 
-Sum-rec-cong-lm : {Γ : ctx}   
+Sum-rec-cong-lm : {Γ : ctx}
        -> (A B A' B' : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (C' : ty (Γ ▷ (Sum A' B')))
@@ -652,8 +652,8 @@ Sum-rec-cong-lm {Γ} A B A' B' C C' d d' p p' e e' q q' c c' r r' Aq Bq Cq dq eq
    in lm
 
 
- 
-Sum-rec-cong' : {Γ : ctx}   
+
+Sum-rec-cong' : {Γ : ctx}
        -> (A B A' B' : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (C' : ty (Γ ▷ (Sum A' B')))
@@ -684,7 +684,7 @@ Sum-rec-cong' {Γ} A B A' B' C C' d d' p p' e e' q q' c c' r r' Aq Bq Cq dq eq c
 
 
 Sum-rec-sub-lm2 : {Δ Γ : ctx}
-       -> (f : subst Δ Γ)   
+       -> (f : subst Δ Γ)
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -715,52 +715,52 @@ Sum-rec-sub-lm2 : {Δ Γ : ctx}
        ->  Sum-rec-op-aux {Γ} A B C d p e q (aps f x) u ≐
            Sum-rec-op-aux {Δ} (A [[ f ]]) (B [[ f ]]) (C [[ ↑ (Sum A B) f ]])
                      (d [ ↑ A f ]) p' (e [ ↑ B f ]) q'  x v
-Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x (inl u) (inl v) t =    
+Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x (inl u) (inl v) t =
        let lm1 =  pj2 (apel p (aps f x , u))
-           lm2 =  pj2 (apel p' (x , v))  
+           lm2 =  pj2 (apel p' (x , v))
            lmt : (apt A (aps f x)) ‣ u ≐  (apt (A [[ f ]]) x) ‣ v
-           lmt = inl-inj-gen (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) u v t  
+           lmt = inl-inj-gen (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) u v t
            lm3 :  < κ (Γ ▷ A) > aps f x , u ~ (aps f x , v)
            lm3 = <> (pairV-ext (refV _) lmt)
            lm3b : apr d (aps f x , u) ≐ apr d (aps f x , v)
            lm3b = >><< (extensionality1 (raw.rawterm d) (aps f x , u) (aps f x , v) lm3)
            lm3c : apr d (aps f x , v) ≐ apr (d [ ↑ A f ]) (x , v)
-           lm3c = symV (traV (sub-apply d (↑ A f) (x , v)) 
+           lm3c = symV (traV (sub-apply d (↑ A f) (x , v))
                    (>><< (extensionality1 (raw.rawterm d) (aps (↑ A f) (x , v)) (aps f x , v) (qq-eq A f x v))))
            lm4 : apr d (aps f x , u) ≐ apr (d [ ↑ A f ]) (x , v)
            lm4 = traV lm3b lm3c
            main : apt C (aps f x , inl u) ‣ pj1 (apel p (aps f x , u)) ≐
                   apt (C [[ ↑ (Sum A B) f ]]) (x , inl v) ‣ pj1 (apel p' (x , v))
            main = traV (symV lm1) (traV lm4 lm2)
-       in main 
+       in main
 
 
-Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x (inl u) (inr v) t = 
-     exfalso _  (inl-inr-dis (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) u v t) 
-Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x (inr u) (inl v) t =   
-     exfalso _  (inr-inl-dis (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) v u t) 
-Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x (inr u) (inr v) t =  
+Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x (inl u) (inr v) t =
+     exfalso _  (inl-inr-dis (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) u v t)
+Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x (inr u) (inl v) t =
+     exfalso _  (inr-inl-dis (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) v u t)
+Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x (inr u) (inr v) t =
        let lm1 =  pj2 (apel q (aps f x , u))
-           lm2 =  pj2 (apel q' (x , v))  
+           lm2 =  pj2 (apel q' (x , v))
            lmt : (apt B (aps f x)) ‣ u ≐  (apt (B [[ f ]]) x) ‣ v
-           lmt = inr-inj-gen (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) u v t  
+           lmt = inr-inj-gen (apt A (aps f x)) (apt B (aps f x)) (apt (A [[ f ]]) x) (apt (B [[ f ]]) x) u v t
            lm3 :  < κ (Γ ▷ B) > aps f x , u ~ (aps f x , v)
            lm3 = <> (pairV-ext (refV _) lmt)
            lm3b : apr e (aps f x , u) ≐ apr e (aps f x , v)
            lm3b = >><< (extensionality1 (raw.rawterm e) (aps f x , u) (aps f x , v) lm3)
            lm3c : apr e (aps f x , v) ≐ apr (e [ ↑ B f ]) (x , v)
-           lm3c =  symV (traV (sub-apply e (↑ B f) (x , v)) 
+           lm3c =  symV (traV (sub-apply e (↑ B f) (x , v))
                    (>><< (extensionality1 (raw.rawterm e) (aps (↑ B f) (x , v)) (aps f x , v) (qq-eq B f x v))))
            lm4 : apr e (aps f x , u) ≐ apr (e [ ↑ B f ]) (x , v)
-           lm4 = traV lm3b lm3c  
+           lm4 = traV lm3b lm3c
            main :  apt C (aps f x , inr u) ‣ pj1 (apel q (aps f x , u)) ≐
                    apt (C [[ ↑ (Sum A B) f ]]) (x , inr v) ‣ pj1 (apel q' (x , v))
 
-           main = traV (symV lm1) (traV lm4 lm2)   
-       in main 
-   
+           main = traV (symV lm1) (traV lm4 lm2)
+       in main
+
 Sum-rec-sub-lm : {Δ Γ : ctx}
-       -> (f : subst Δ Γ)   
+       -> (f : subst Δ Γ)
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -783,16 +783,16 @@ Sum-rec-sub-lm : {Δ Γ : ctx}
                 (Sum-sub-rg {Δ} (_[[_]] {Δ} {Γ} A f) (_[[_]] {Δ} {Γ} B f)))
        -> (r' : Δ ==> c [ f ] :: Sum (A [[ f ]]) (B [[ f ]]))
        -> (x  : || κ Δ ||)
-       ->  
+       ->
            raw.rawterm (Sum-rec A B C d p e q c r [ f ]) • x ≐
            (raw.rawterm
            (Sum-rec (A [[ f ]]) (B [[ f ]]) (C [[ ↑ (Sum A B) f ]])
             (d [ ↑ A f ]) p' (e [ ↑ B f ]) q' (c [ f ]) r')
            • x)
-Sum-rec-sub-lm {Δ} {Γ} f A B C d p e q c r p' q' r' x = 
+Sum-rec-sub-lm {Δ} {Γ} f A B C d p e q c r p' q' r' x =
    let lm1 = (pj2 (apel r (aps f x)))
        lm2 = (pj2 (apel r' x))
-       lm3 : apr (c [ f ]) x ≐ apr c (aps f x) 
+       lm3 : apr (c [ f ]) x ≐ apr c (aps f x)
        lm3 = refV _
        lk1 = (pj1 (apel r (aps f x)))
        lk2 = (pj1 (apel r' x))
@@ -802,11 +802,11 @@ Sum-rec-sub-lm {Δ} {Γ} f A B C d p e q c r p' q' r' x =
                 Sum-rec-op-aux {Δ} (A [[ f ]]) (B [[ f ]]) (C [[ ↑ (Sum A B) f ]])
                      (d [ ↑ A f ]) p' (e [ ↑ B f ]) q'  x (pj1 (apel r' x))
        main = Sum-rec-sub-lm2 {Δ} {Γ} f A B C d p e q c r p' q' r' x lk1 lk2 eq
-    in main 
+    in main
 
 
 Sum-rec-sub' : {Δ Γ : ctx}
-       -> (f : subst Δ Γ)   
+       -> (f : subst Δ Γ)
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -829,17 +829,17 @@ Sum-rec-sub' : {Δ Γ : ctx}
                 (Sum-sub-rg {Δ} (_[[_]] {Δ} {Γ} A f) (_[[_]] {Δ} {Γ} B f)))
        -> (r' : Δ ==> c [ f ] :: Sum (A [[ f ]]) (B [[ f ]]))
        -> << Raw Δ >> ((Sum-rec {Γ} A B C d p e q c r) [ f ])
-                      ~  (Sum-rec {Δ} (A [[ f ]]) (B [[ f ]]) (C [[ ↑ {Δ} {Γ} (Sum A B) f ]]) 
+                      ~  (Sum-rec {Δ} (A [[ f ]]) (B [[ f ]]) (C [[ ↑ {Δ} {Γ} (Sum A B) f ]])
                                     (d [ ↑  A f ]) p' (e [ ↑ B f ]) q' (c [ f ]) r')
-Sum-rec-sub' {Δ} {Γ} f A B C d p e q c r p' q' r' = 
+Sum-rec-sub' {Δ} {Γ} f A B C d p e q c r p' q' r' =
     let main :  << Raw Δ >> ((Sum-rec {Γ} A B C d p e q c r) [ f ])
-                      ~ (Sum-rec {Δ} (A [[ f ]]) (B [[ f ]]) (C [[ ↑ {Δ} {Γ} (Sum A B) f ]]) 
+                      ~ (Sum-rec {Δ} (A [[ f ]]) (B [[ f ]]) (C [[ ↑ {Δ} {Γ} (Sum A B) f ]])
                                     (d [ ↑  A f ]) p' (e [ ↑ B f ]) q' (c [ f ]) r')
         main = <<>> (<<>> (λ x → <<>> (Sum-rec-sub-lm {Δ} {Γ} f A B C d p e q c r p' q' r' x )))
     in main
 
 
-Sum-e : {Γ : ctx}   
+Sum-e : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -852,7 +852,7 @@ Sum-e : {Γ : ctx}
 Sum-e {Γ} A B C d p e q c r = mk-elt (λ x → Sum-rec-op-aux-lm {Γ} A B C d p e q x (pj1 (apel r x)))
 
 
-Sum-c1-lm : {Γ : ctx}   
+Sum-c1-lm : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -864,7 +864,7 @@ Sum-c1-lm : {Γ : ctx}
        -> (r' : Γ ==> (lf {Γ} A B a r) :: Sum A B)
        -> (x  : || κ Γ ||)
        -> apr (Sum-rec A B C d p e q (lf A B a r) r') x ≐  apr (d [ els r ]) x
-Sum-c1-lm {Γ} A B C d p e q a r r' x = 
+Sum-c1-lm {Γ} A B C d p e q a r r' x =
   let lm1 = pj2 (apel r x)
       lm2 :  apr (lf A B a r) x ≐ apt (Sum A B) x ‣ pj1 (apel r' x)
       lm2 = pj2 (apel r' x)
@@ -876,13 +876,13 @@ Sum-c1-lm {Γ} A B C d p e q a r r' x =
       main' = symV lm4
       lm6 :  Sum-rec-op-aux {Γ} A B C d p e q x (inl ( pj1 (apel r x))) ≐
              Sum-rec-op-aux {Γ} A B C d p e q x (pj1 (apel r' x))
-      lm6 =  Sum-rec-ext-lm {Γ} A B C d p e q x x (<> (refV _)) (inl ( pj1 (apel r x))) (pj1 (apel r' x)) 
-                    lm2 
+      lm6 =  Sum-rec-ext-lm {Γ} A B C d p e q x x (<> (refV _)) (inl ( pj1 (apel r x))) (pj1 (apel r' x))
+                    lm2
       main : Sum-rec-op-aux {Γ} A B C d p e q x (pj1 (apel r' x)) ≐ apr (d [ els r ]) x
-      main = traV (symV lm6) main' 
+      main = traV (symV lm6) main'
   in main
 
-Sum-c1-lm2 : {Γ : ctx}   
+Sum-c1-lm2 : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (a : raw Γ)
@@ -892,7 +892,7 @@ Sum-c1-lm2 : {Γ : ctx}
        -> (κ (Γ ▷ Sum A B) setoid.∼
             ap (subst.cmap (Sum-sub-lf A B)) (ap (subst.cmap (els r)) x))
            (ap (subst.cmap (els r')) x)
-Sum-c1-lm2 {Γ} A B C a r r' x = 
+Sum-c1-lm2 {Γ} A B C a r r' x =
    let lm1 = pj2 (apel r' x)
        lm2 = pj2 (apel r x)
        lm3 :  apt A (aps (↓ A) (ap (subst.cmap (els r)) x)) ‣
@@ -903,7 +903,7 @@ Sum-c1-lm2 {Γ} A B C a r r' x =
 
 
 
-Sum-c1 : {Γ : ctx}   
+Sum-c1 : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -914,7 +914,7 @@ Sum-c1 : {Γ : ctx}
        -> (r : Γ ==> a :: A)
        -> (r' : Γ ==> (lf {Γ} A B a r) :: Sum A B)
        -> Γ ==> Sum-rec A B C d p e q (lf {Γ} A B a r) r' == d [ els r ] :: C [[ els r' ]]
-Sum-c1 {Γ} A B C d p e q a r r' = 
+Sum-c1 {Γ} A B C d p e q a r r' =
     let lm2 : Γ  ==> d [ els r ] :: C [[ Sum-sub-lf A B ]] [[ els r ]]
         lm2 = elt-subst (els r) p
         lm3 : Γ  ==>  C [[ Sum-sub-lf A B ]] [[ els r ]] ==  C [[ els r' ]]
@@ -922,11 +922,11 @@ Sum-c1 {Γ} A B C d p e q a r r' =
         lm : Γ ==> d [ els r ] :: C [[ els r' ]]
         lm = elttyeq lm2 lm3
     in  pair (Sum-c1-lm {Γ} A B C d p e q a r r')
-             (pair (Sum-e {Γ} A B C d p e q  (lf A B a r) r') 
+             (pair (Sum-e {Γ} A B C d p e q  (lf A B a r) r')
                    lm)
- 
 
-Sum-c2-lm : {Γ : ctx}   
+
+Sum-c2-lm : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -938,7 +938,7 @@ Sum-c2-lm : {Γ : ctx}
        -> (r' : Γ ==> (rg {Γ} A B b r) :: Sum A B)
        -> (x  : || κ Γ ||)
        -> apr (Sum-rec A B C d p e q (rg A B b r) r') x ≐ apr (e [ els r ]) x
-Sum-c2-lm {Γ} A B C d p e q b r r' x = 
+Sum-c2-lm {Γ} A B C d p e q b r r' x =
   let lm1 = pj2 (apel r x)
       lm2 :  apr (rg A B b r) x ≐ apt (Sum A B) x ‣ pj1 (apel r' x)
       lm2 = pj2 (apel r' x)
@@ -950,13 +950,13 @@ Sum-c2-lm {Γ} A B C d p e q b r r' x =
       main' = symV lm4
       lm6 :  Sum-rec-op-aux {Γ} A B C d p e q x (inr ( pj1 (apel r x))) ≐
              Sum-rec-op-aux {Γ} A B C d p e q x (pj1 (apel r' x))
-      lm6 =  Sum-rec-ext-lm {Γ} A B C d p e q x x (<> (refV _)) (inr ( pj1 (apel r x))) (pj1 (apel r' x)) 
+      lm6 =  Sum-rec-ext-lm {Γ} A B C d p e q x x (<> (refV _)) (inr ( pj1 (apel r x))) (pj1 (apel r' x))
                     lm2
       main : Sum-rec-op-aux {Γ} A B C d p e q x (pj1 (apel r' x)) ≐ apr (e [ els r ]) x
       main = traV (symV lm6) main'
   in main
 
-Sum-c2-lm2 : {Γ : ctx}   
+Sum-c2-lm2 : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (b : raw Γ)
@@ -966,7 +966,7 @@ Sum-c2-lm2 : {Γ : ctx}
        -> (κ (Γ ▷ Sum A B) setoid.∼
             ap (subst.cmap (Sum-sub-rg A B)) (ap (subst.cmap (els r)) x))
            (ap (subst.cmap (els r')) x)
-Sum-c2-lm2 {Γ} A B C b r r' x = 
+Sum-c2-lm2 {Γ} A B C b r r' x =
    let lm1 = pj2 (apel r' x)
        lm2 = pj2 (apel r x)
        lm3 :  apt B (aps (↓ B) (ap (subst.cmap (els r)) x)) ‣
@@ -975,7 +975,7 @@ Sum-c2-lm2 {Γ} A B C b r r' x =
        lm3 = refV _
    in pairV-ext (refV _) (traV (pairV-ext (refV _) lm3 ) lm1)
 
-Sum-c2 : {Γ : ctx}   
+Sum-c2 : {Γ : ctx}
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -986,7 +986,7 @@ Sum-c2 : {Γ : ctx}
        -> (r : Γ ==> b :: B)
        -> (r' : Γ ==> (rg {Γ} A B b r) :: Sum A B)
        -> Γ ==> Sum-rec A B C d p e q (rg {Γ} A B b r) r' == e [ els r ] :: C [[ els r'  ]]
-Sum-c2 {Γ} A B C d p e q b r r' = 
+Sum-c2 {Γ} A B C d p e q b r r' =
   let   lm2 : Γ  ==> e [ els r ] :: C [[ Sum-sub-rg A B ]] [[ els r ]]
         lm2 = elt-subst (els r) q
         lm3 : Γ  ==>  C [[ Sum-sub-rg A B ]] [[ els r ]] ==  C [[ els r' ]]
@@ -994,12 +994,12 @@ Sum-c2 {Γ} A B C d p e q b r r' =
         lm : Γ ==> e [ els r ] :: C [[ els r' ]]
         lm =  elttyeq lm2 lm3
   in
-                pair (Sum-c2-lm {Γ} A B C d p e q b r r') 
-                     (pair (Sum-e {Γ} A B C d p e q  (rg A B b r) r') 
+                pair (Sum-c2-lm {Γ} A B C d p e q b r r')
+                     (pair (Sum-e {Γ} A B C d p e q  (rg A B b r) r')
                            lm)
 
 
-Sum-rec-cong : {Γ : ctx}   
+Sum-rec-cong : {Γ : ctx}
        -> (A B A' B' : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (C' : ty (Γ ▷ (Sum A' B')))
@@ -1018,11 +1018,11 @@ Sum-rec-cong : {Γ : ctx}
        -> (Aq : Γ ==> A == A')
        -> (Bq : Γ ==> B == B')
        -> (Γ ▷ (Sum A B)  ==> C == C' [[  subst-trp (ext-eq' {Γ} (Sum A B) (Sum A' B') (Sum-cong A A' B B' Aq Bq)) ]])
-       -> ((Γ ▷ A) ==> d == (d' [ subst-trp (ext-eq' {Γ} A A' Aq) ]) :: C [[ Sum-sub-lf A B ]]) 
-       -> ((Γ ▷ B) ==> e == (e' [ subst-trp (ext-eq' {Γ} B B' Bq) ]) :: C [[ Sum-sub-rg A B ]]) 
-       -> (Γ ==> c == c' :: Sum A B) 
+       -> ((Γ ▷ A) ==> d == (d' [ subst-trp (ext-eq' {Γ} A A' Aq) ]) :: C [[ Sum-sub-lf A B ]])
+       -> ((Γ ▷ B) ==> e == (e' [ subst-trp (ext-eq' {Γ} B B' Bq) ]) :: C [[ Sum-sub-rg A B ]])
+       -> (Γ ==> c == c' :: Sum A B)
        -> Γ ==>  Sum-rec {Γ} A B C d p e q c r == Sum-rec {Γ} A' B' C' d' p' e' q' c' r' :: C [[ els r ]]
-Sum-rec-cong {Γ} A B A' B' C C' d d' p p' e e' q q' c c' r r' Aq Bq Cq dq eq cq = 
+Sum-rec-cong {Γ} A B A' B' C C' d d' p p' e e' q q' c c' r r' Aq Bq Cq dq eq cq =
      let dq' : << Raw (Γ ▷ A) >> d ~ (d' [ subst-trp (ext-eq' {Γ} A A' Aq) ])
          dq' = Raw-lm2 (prj1 dq)
          eq' : << Raw (Γ ▷ B) >> e ~ (e' [ subst-trp (ext-eq' {Γ} B B' Bq) ])
@@ -1031,12 +1031,12 @@ Sum-rec-cong {Γ} A B A' B' C C' d d' p p' e e' q q' c c' r r' Aq Bq Cq dq eq cq
          cq' = Raw-lm2 (prj1 cq)
          lm = Sum-rec-cong' {Γ} A B A' B' C C' d d' p p' e e' q q' c c' r r' Aq Bq Cq dq' eq' cq'
      in
-          pair (Raw-lm lm) 
+          pair (Raw-lm lm)
                (pair (Sum-e A B C d p e q c r) (subj-red _ _ (Sum-e A B C d p e q c r) lm))
 
 
 Sum-rec-sub : {Δ Γ : ctx}
-       -> (h : subst Δ Γ)   
+       -> (h : subst Δ Γ)
        -> (A B : ty Γ)
        -> (C : ty (Γ ▷ (Sum A B)))
        -> (d : raw (Γ ▷ A))
@@ -1059,14 +1059,14 @@ Sum-rec-sub : {Δ Γ : ctx}
                 (Sum-sub-rg {Δ} (_[[_]] {Δ} {Γ} A h) (_[[_]] {Δ} {Γ} B h)))
        -> (r' : Δ ==> c [ h ] :: Sum (A [[ h ]]) (B [[ h ]]))
        ->  Δ ==> ((Sum-rec {Γ} A B C d p e q c r) [ h ])
-                     ==  (Sum-rec {Δ} (A [[ h ]]) (B [[ h ]]) (C [[ ↑ {Δ} {Γ} (Sum A B) h ]]) 
-                                    (d [ ↑  A h ]) p' (e [ ↑ B h ]) q' (c [ h ]) r') 
+                     ==  (Sum-rec {Δ} (A [[ h ]]) (B [[ h ]]) (C [[ ↑ {Δ} {Γ} (Sum A B) h ]])
+                                    (d [ ↑  A h ]) p' (e [ ↑ B h ]) q' (c [ h ]) r')
                        ::  C [[ els r ]] [[ h ]]
 Sum-rec-sub {Δ} {Γ} h A B C d p e q c r p' q' r' =
   let lm = Sum-rec-sub' {Δ} {Γ} h A B C d p e q c r p' q' r'
 
-  in  pair (Raw-lm lm) 
-           (pair (elt-subst h (Sum-e A B C d p e q c r)) 
+  in  pair (Raw-lm lm)
+           (pair (elt-subst h (Sum-e A B C d p e q c r))
                  (subj-red _ _ (elt-subst h (Sum-e A B C d p e q c r))
                                lm))
 
@@ -1074,7 +1074,7 @@ Sum-rec-sub {Δ} {Γ} h A B C d p e q c r p' q' r' =
 -- Raw-lm2  : {Γ : ctx} -> {a b : raw Γ}
 --       -> ((x : || κ Γ ||) -> (apr a x) ≐ (apr b x))
 --       -> (<< Raw Γ >> a ~ b)
-pair (Raw-lm (rg-sub' {Δ} {Γ} h A B b p p')) 
+pair (Raw-lm (rg-sub' {Δ} {Γ} h A B b p p'))
                                     (pair (elt-subst h (rg-pf A B b p))
                                           (subj-red _ _ (elt-subst h (rg-pf A B b p)) (rg-sub' {Δ} {Γ} h A B b p p')))
 --}

--- a/MLTT-and-setoids/V-model-pt14.agda
+++ b/MLTT-and-setoids/V-model-pt14.agda
@@ -28,9 +28,9 @@ open import V-model-pt6         -- 842 lines
 open import V-model-pt7         --  66 lines
 open import V-model-pt8         -- 134 lines
 open import V-model-pt9         -- 441 lines
-open import V-model-pt10  
-open import V-model-pt13         
-                     
+open import V-model-pt10
+open import V-model-pt13
+
 -- universe operator
 
 -- experimental version of the universe axiom
@@ -53,19 +53,19 @@ T-n-Russell-eq :  {Γ : ctx}  -> (I : ty Γ) -> (F : ty (Γ ▷ I)) -> (A : raw 
 T-n-Russell-eq {Γ} I F A p = {!!}
 
 
-U-n-ix : {Γ : ctx}  -> (I : ty Γ) -> (F : ty (Γ ▷ I)) 
+U-n-ix : {Γ : ctx}  -> (I : ty Γ) -> (F : ty (Γ ▷ I))
 -- ------------------------------
      -> (Γ ==> I :: U-n Γ I F)
 --
-U-n-ix {Γ} i F = {!!} 
+U-n-ix {Γ} i F = {!!}
 
 U-n-fm : {Γ : ctx}  -> (I : ty Γ) -> (F : ty (Γ ▷ I))
--- 
+--
      -> (i : raw Γ)
      -> (p : Γ ==> i :: I)
 -- -------------------------------------
      -> (Γ ==> F [ els p ] :: U-n Γ I F)
-U-n-fm {Γ} i F = {!!} 
+U-n-fm {Γ} i F = {!!}
 
 
 -- constant type
@@ -93,12 +93,12 @@ U-f-sub Δ Γ f = mk-eqty (λ x → <<>> (refV _))
 
 
 natU : (Γ : ctx) -> raw Γ
-natU Γ = mkraw (record { op = λ x → natV 
-                       ; ext = λ x y p → refl' _ _  
+natU Γ = mkraw (record { op = λ x → natV
+                       ; ext = λ x y p → refl' _ _
                        })
 
 
-U-f-nat : (Γ : ctx) 
+U-f-nat : (Γ : ctx)
 -- -----------------------------------
     -> Γ ==> natU Γ :: U-f Γ
 --
@@ -108,14 +108,14 @@ T-f-nat : (Γ : ctx)
 -- ------------------------------------------------------
       -> Γ ==> T-f (natU Γ) (U-f-nat Γ) == Nat Γ
 --
-T-f-nat Γ = mk-eqty (λ x → <<>> (traV (easy-eqV _ _ _ (λ y → symV (nat-sV-V y))) emb-nat)) 
+T-f-nat Γ = mk-eqty (λ x → <<>> (traV (easy-eqV _ _ _ (λ y → symV (nat-sV-V y))) emb-nat))
 
 
-U-f-Russell-nat : (Γ : ctx) 
+U-f-Russell-nat : (Γ : ctx)
 -- -----------------------------------
     -> Γ ==> Nat Γ :: U-f Γ
 --
-U-f-Russell-nat Γ = mk-elt (λ x → natV-in-uV)  
+U-f-Russell-nat Γ = mk-elt (λ x → natV-in-uV)
 
 
 {--
@@ -128,40 +128,40 @@ natV-in-uV = nat-sV , symV emb-nat
 -- sigma-sV
 
 
-U-f-Russell-sigma-lm : {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-f-Russell-sigma-lm : {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U-f Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U-f Γ [[ ↓ A ]])
     ->  (x :  || κ Γ ||)
     ->  apr (Σ-f A B) x ∈ uV
-U-f-Russell-sigma-lm {Γ} A p B q x = 
+U-f-Russell-sigma-lm {Γ} A p B q x =
   let lm : (apt (Σ-f A B) x) ≐ sigmaV (apt A x) (mk-Par-op-Fx A B x)
       lm = Σ-f-exp1 {Γ} A B x
       lm2 : sigmaV (apt A x) (mk-Par-op-Fx A B x) ∈ uV
-      lm2 = sigmaV-reflection (apt A x) (mk-Par-op-Fx A B x) 
+      lm2 = sigmaV-reflection (apt A x) (mk-Par-op-Fx A B x)
                   (apel p x) (λ y → apel q (x , y))
       main : apr (Σ-f A B) x ∈ uV
       main = memV-left-ext (apr (Σ-f A B) x)  _ uV  lm lm2
   in main
 
-U-f-Russell-sigma : {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-f-Russell-sigma : {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U-f Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U-f Γ [[ ↓ A ]])
     ->  Γ ==> Σ-f A B :: U-f Γ
-U-f-Russell-sigma {Γ} A p B q  
+U-f-Russell-sigma {Γ} A p B q
     = mk-elt (U-f-Russell-sigma-lm {Γ} A p B q)
 
 {--
 
-sigmaV-reflection : (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (a ∈ uV) 
+sigmaV-reflection : (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (a ∈ uV)
     -> ((x : || κ a ||) -> ap1 g x ∈ uV)
     -> sigmaV a g ∈ uV
 
-Σ-f-exp1 :  {Γ : ctx} 
+Σ-f-exp1 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        ->  (apt (Σ-f A B)  u) ≐ sigmaV (apt A u) (mk-Par-op-Fx A B u)
@@ -169,25 +169,25 @@ sigmaV-reflection : (a : V) -> (g :  setoidmap1 (κ a) VV)
 
 --}
 
-U-f-Russell-pi-lm : {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-f-Russell-pi-lm : {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U-f Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U-f Γ [[ ↓ A ]])
     ->  (x :  || κ Γ ||)
     ->  apr (Π-f A B) x ∈ uV
-U-f-Russell-pi-lm {Γ} A p B q x = 
+U-f-Russell-pi-lm {Γ} A p B q x =
   let lm : (apt (Π-f A B) x) ≐ piV (apt A x) (mk-Par-op-Fx A B x)
       lm = Π-f-exp1 {Γ} A B x
       lm2 : piV (apt A x) (mk-Par-op-Fx A B x) ∈ uV
-      lm2 = piV-reflection (apt A x) (mk-Par-op-Fx A B x) 
+      lm2 = piV-reflection (apt A x) (mk-Par-op-Fx A B x)
                   (apel p x) (λ y → apel q (x , y))
       main : apr (Π-f A B) x ∈ uV
       main = memV-left-ext (apr (Π-f A B) x)  _ uV  lm lm2
   in main
 
-U-f-Russell-pi : {Γ : ctx} 
-    ->  (A : ty Γ) 
+U-f-Russell-pi : {Γ : ctx}
+    ->  (A : ty Γ)
     ->  (p : Γ ==> A :: U-f Γ)
     ->  (B : ty (Γ ▷ A))
     ->  (q : (Γ ▷ A) ==> B :: U-f Γ [[ ↓ A ]])
@@ -230,7 +230,7 @@ U-f-Russell-ID : {Γ : ctx}
      -> (a : raw Γ)
      -> (qa : Γ ==> a :: A)
      -> (b : raw Γ)
-     -> (qb : Γ ==> b :: A)    
+     -> (qb : Γ ==> b :: A)
      -> Γ ==> ID A a qa b qb :: U-f Γ
 U-f-Russell-ID {Γ} A p a qa b qb = mk-elt (U-f-Russell-ID-lm {Γ} A p a qa b qb)
 
@@ -238,13 +238,13 @@ U-f-Russell-N0 : {Γ : ctx}
       -> Γ ==> N0 Γ :: U-f Γ
 U-f-Russell-N0 {Γ} = mk-elt (λ x →  zeroV-reflection)
 
-U-f-Russell-Sum-lm : {Γ : ctx} 
-    ->  (A B : ty Γ) 
+U-f-Russell-Sum-lm : {Γ : ctx}
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U-f Γ)
     ->  (q : Γ ==> B :: U-f Γ)
     ->  (x :  || κ Γ ||)
     ->  apr (Sum A B) x ∈ uV
-U-f-Russell-Sum-lm {Γ} A B p q x = 
+U-f-Russell-Sum-lm {Γ} A B p q x =
   let  lm : (apt (Sum A B) x) ≐ sumV (apt A x) (apt B x)
        lm = refV _
        lm2 : sumV (apt A x) (apt B x) ∈ uV
@@ -253,10 +253,10 @@ U-f-Russell-Sum-lm {Γ} A B p q x =
        main = memV-left-ext (apr (Sum A B) x)  _ uV  lm lm2
   in main
 
-U-f-Russell-Sum : {Γ : ctx} 
-    ->  (A B : ty Γ) 
+U-f-Russell-Sum : {Γ : ctx}
+    ->  (A B : ty Γ)
     ->  (p : Γ ==> A :: U-f Γ)
     ->  (q : Γ ==> B :: U-f Γ)
     ->  Γ ==> Sum A B :: U-f Γ
-U-f-Russell-Sum {Γ} A B p q  
+U-f-Russell-Sum {Γ} A B p q
     = mk-elt (U-f-Russell-Sum-lm {Γ} A B p q)

--- a/MLTT-and-setoids/V-model-pt15.agda
+++ b/MLTT-and-setoids/V-model-pt15.agda
@@ -29,12 +29,12 @@ open import V-model-pt6         -- 842 lines
 open import V-model-pt7         --  66 lines
 open import V-model-pt8         -- 134 lines
 open import V-model-pt9         -- 441 lines
-open import V-model-pt10  
-open import V-model-pt13         
+open import V-model-pt10
+open import V-model-pt13
 open import V-model-pt11
 
 
--- Bracket type former 
+-- Bracket type former
 -- Awodey and Bauer 2014
 
 Br-op : {Γ : ctx}
@@ -60,159 +60,159 @@ br :  {Γ : ctx} -> (a : raw Γ) -> raw Γ
 br {Γ} a = const zeroV Γ
 
 
-Br-intro :  {Γ : ctx} 
+Br-intro :  {Γ : ctx}
 --
-    -> (A : ty Γ) 
+    -> (A : ty Γ)
     -> (a : raw Γ)
     -> Γ ==> a :: A
 --
     -> Γ ==> br a :: Br A
-Br-intro {Γ} A a p = 
-     mk-elt (λ x → 
+Br-intro {Γ} A a p =
+     mk-elt (λ x →
                  let px = apel p x
                      px1 = pj1 px
                      px2 = pj2 px
                  in  px1 , refV _ )
 
 
-Br-eqty-lm2 :  {Γ : ctx} 
-    -> (A : ty Γ) 
+Br-eqty-lm2 :  {Γ : ctx}
+    -> (A : ty Γ)
     -> (a : raw Γ)
     -> Γ ==> a :: Br A
     -> (x : || κ Γ ||)
     -> apr a x ≐ zeroV
-Br-eqty-lm2 {Γ} A a p x = 
+Br-eqty-lm2 {Γ} A a p x =
    let lm2 : apr a x ≐ apt (Br A) x ‣ pj1 (apel p x)
        lm2 = pj2 (apel p x)
        lm3 : apt (Br A) x ‣ pj1 (apel p x) ≐ zeroV
        lm3 = refV _
    in traV lm2 lm3
 
-Br-eqty-lm :  {Γ : ctx} 
-    -> (A : ty Γ) 
+Br-eqty-lm :  {Γ : ctx}
+    -> (A : ty Γ)
     -> (a b : raw Γ)
     -> Γ ==> a :: Br A
     -> Γ ==> b :: Br A
     -> (x : || κ Γ ||)
     -> apr a x ≐ apr b x
-Br-eqty-lm {Γ} A a b p q x = traV (Br-eqty-lm2 {Γ} A a p x) (symV (Br-eqty-lm2 {Γ} A b q x)) 
-  
-Br-eqty :  {Γ : ctx} 
+Br-eqty-lm {Γ} A a b p q x = traV (Br-eqty-lm2 {Γ} A a p x) (symV (Br-eqty-lm2 {Γ} A b q x))
+
+Br-eqty :  {Γ : ctx}
 --
-    -> (A : ty Γ) 
+    -> (A : ty Γ)
     -> (a b : raw Γ)
     -> Γ ==> a :: Br A
     -> Γ ==> b :: Br A
 -- -----------------------
     ->  Γ ==> a == b :: Br A
-Br-eqty {Γ} A a b p q = 
+Br-eqty {Γ} A a b p q =
        pair (Br-eqty-lm {Γ} A a b p q) (pair p q)
 
 
 
 
-Br-sub-lm : {Δ Γ : ctx} 
+Br-sub-lm : {Δ Γ : ctx}
 --
-    -> (A : ty Γ) 
-    -> (f : subst Δ Γ) 
+    -> (A : ty Γ)
+    -> (f : subst Δ Γ)
     -> (x : || κ Δ ||)
     ->  (type (Br A [[ f ]]) • x) ≐ (type (Br (A [[ f ]])) • x)
 Br-sub-lm {Δ} {Γ} A f x = easy-eqV _ _ _ (λ x₁ → refV _)
 
 
-Br-sub : {Δ Γ : ctx} 
+Br-sub : {Δ Γ : ctx}
 --
-    -> (A : ty Γ) 
-    -> (f : subst Δ Γ) 
--- --------------------------------    
+    -> (A : ty Γ)
+    -> (f : subst Δ Γ)
+-- --------------------------------
     ->  Δ ==> (Br A) [[ f ]] == (Br (A [[ f ]]))
 Br-sub {Δ} {Γ} A f =  mk-eqty (λ x → <<>> (Br-sub-lm {Δ} {Γ} A f x) )
 
 
-br-sub-lm : {Δ Γ : ctx} 
+br-sub-lm : {Δ Γ : ctx}
 --
-    -> (A : ty Γ) 
-    -> (f : subst Δ Γ) 
+    -> (A : ty Γ)
+    -> (f : subst Δ Γ)
     -> (a : raw Γ)
     -> Γ ==> a :: A
-    -> << Raw Δ >> (br a) [ f ] ~ (br (a [ f ])) 
+    -> << Raw Δ >> (br a) [ f ] ~ (br (a [ f ]))
 br-sub-lm {Δ} {Γ} A f a p = <<>> (<<>> (λ x → <<>> (refV _)))
 
-br-sub : {Δ Γ : ctx} 
+br-sub : {Δ Γ : ctx}
 --
-    -> (A : ty Γ) 
-    -> (f : subst Δ Γ) 
+    -> (A : ty Γ)
+    -> (f : subst Δ Γ)
     -> (a : raw Γ)
     -> Γ ==> a :: A
--- --------------------------------    
+-- --------------------------------
     ->  Δ ==> (br a) [ f ] == (br (a [ f ])) :: (Br A) [[ f ]]
 br-sub {Δ} {Γ} A f a p = pair (Raw-lm (br-sub-lm {Δ} {Γ} A f a p))
-                              (pair (elt-subst f (Br-intro {Γ} A a p)) 
+                              (pair (elt-subst f (Br-intro {Γ} A a p))
                                    (subj-red _ _ (elt-subst f (Br-intro {Γ} A a p)) (br-sub-lm {Δ} {Γ} A f a p)))
 
 
-pr-x : {Γ : ctx} 
+pr-x : {Γ : ctx}
     -> (A : ty Γ)
     ->  subst  (Γ ▷ A ▷ (A [[ ↓ A ]]))  (Γ ▷ A)
 pr-x {Γ} A = ↓ (A [[ ↓ A ]])
 
-pr-x-lm : {Γ : ctx} 
+pr-x-lm : {Γ : ctx}
     -> (A : ty Γ)
-    -> (u : || κ Γ ||) 
-    -> (x y : ||  κ (apt A u) ||) 
+    -> (u : || κ Γ ||)
+    -> (x y : ||  κ (apt A u) ||)
     -> < κ (Γ ▷ A) > aps (pr-x A) ((u , x) , y) ~ (u , x)
 pr-x-lm {Γ} A u x y = <> (refV _)
 
 
--- should be in pt0: 
+-- should be in pt0:
 
-apr-ext : {Γ : ctx}  
+apr-ext : {Γ : ctx}
      -> (a : raw Γ)  -> (x y : || κ Γ ||)
-     -> < κ Γ > x ~ y 
+     -> < κ Γ > x ~ y
      -> apr a x ≐ apr a y
 apr-ext a x y p = >><<  (extensionality1 (raw.rawterm a) x y p)
 
 
--- should be in pt1: 
+-- should be in pt1:
 
 
-eq-on-ext-lm : {Γ : ctx} 
+eq-on-ext-lm : {Γ : ctx}
     -> (A : ty Γ)
-    -> (u : || κ Γ ||) 
+    -> (u : || κ Γ ||)
     -> (x : || κ (apt A u) ||)
-    -> (v : || κ Γ ||) 
+    -> (v : || κ Γ ||)
     -> (p : < κ Γ > u  ~ v)
     -> (type A • u) ‣ x ≐ (type A • v) ‣ ap (κ° (type A) ± p) x
 eq-on-ext-lm {Γ} A u x v p = κ°-trp-prop (type A) u v p x
 
 
-eq-on-ext : {Γ : ctx} 
+eq-on-ext : {Γ : ctx}
     -> (A : ty Γ)
-    -> (u : || κ Γ ||) 
+    -> (u : || κ Γ ||)
     -> (x : || κ (apt A u) ||)
-    -> (v : || κ Γ ||) 
+    -> (v : || κ Γ ||)
     -> (y : || κ (apt A v) ||)
     -> (p : < κ Γ > u  ~ v)
     -> < κ (apt A v) > (ap (κ° (ty.type A) ± p) x)  ~ y
     -> < κ (Γ ▷ A) > (u , x) ~ (v , y)
-eq-on-ext {Γ} A u x v y p q = 
+eq-on-ext {Γ} A u x v y p q =
    let lm : (type A • v) ‣ ap (κ° (type A) ± p) x ≐  (type A • v) ‣ y
        lm = >< q
        lm3 :  (type A • u)  ≐ (type A • v)
        lm3 = >><< (extensionality1 (type A) u v p)
        lm2 : (type A • u) ‣ x  ≐ (type A • v) ‣ ap (κ° (type A) ± p) x
-       lm2 = eq-on-ext-lm {Γ} A u x v p 
+       lm2 = eq-on-ext-lm {Γ} A u x v p
    in sigmaV-eq-lm2  Γ (ty.type A) (u , x) (v , y) (>< p) (traV lm2 lm)
 
-eq-on-ext-rev-lm : {Γ : ctx} 
+eq-on-ext-rev-lm : {Γ : ctx}
     -> (A : ty Γ)
-    -> (u : || κ Γ ||) 
+    -> (u : || κ Γ ||)
     -> (x : || κ (apt A u) ||)
-    -> (v : || κ Γ ||) 
+    -> (v : || κ Γ ||)
     -> (y : || κ (apt A v) ||)
     -> < κ (Γ ▷ A) > (u , x) ~ (v , y)
-    -> < κ Γ > u ~ v 
-eq-on-ext-rev-lm {Γ} A u x v y q = 
+    -> < κ Γ > u ~ v
+eq-on-ext-rev-lm {Γ} A u x v y q =
   let  lm : (Γ ▷ A)  ‣  (u , x)  ≐ (Γ ▷ A)  ‣ (v , y)
        lm = >< q
        lm2 : < Γ ‣ u , ((ty.type A) • u) ‣ x >  ≐ < Γ ‣ v , ((ty.type A) • v) ‣ y >
@@ -222,36 +222,36 @@ eq-on-ext-rev-lm {Γ} A u x v y q =
   in <> lm3
 
 
-eq-on-ext-rev : {Γ : ctx} 
+eq-on-ext-rev : {Γ : ctx}
     -> (A : ty Γ)
-    -> (u : || κ Γ ||) 
+    -> (u : || κ Γ ||)
     -> (x : || κ (apt A u) ||)
-    -> (v : || κ Γ ||) 
+    -> (v : || κ Γ ||)
     -> (y : || κ (apt A v) ||)
     -> (q : < κ (Γ ▷ A) > (u , x) ~ (v , y))
     -> < κ (apt A v) > (ap (κ° (ty.type A) ± (eq-on-ext-rev-lm {Γ} A u x v y q)) x)  ~ y
-eq-on-ext-rev {Γ} A u x v y q = 
+eq-on-ext-rev {Γ} A u x v y q =
   let  lm : (Γ ▷ A)  ‣  (u , x)  ≐ (Γ ▷ A)  ‣ (v , y)
        lm = >< q
        lm2 : < Γ ‣ u , ((ty.type A) • u) ‣ x >  ≐ < Γ ‣ v , ((ty.type A) • v) ‣ y >
        lm2 = lm
        lm3 : Γ  ‣ u  ≐  Γ  ‣ v
-       lm3 = prj1 (pairV-inv-1 lm2) 
+       lm3 = prj1 (pairV-inv-1 lm2)
        lm4 : (type A • u) ‣ x ≐ (type A • v) ‣ y
-       lm4 = prj2 (pairV-inv-1 lm2) 
+       lm4 = prj2 (pairV-inv-1 lm2)
        lm5 : (type A • v) ‣  (ap (κ° (ty.type A) ± (eq-on-ext-rev-lm {Γ} A u x v y q)) x) ≐ (type A • u) ‣ x
        lm5 = symV (eq-on-ext-lm {Γ} A u x v (<> lm3))
        main : (type A • v) ‣  (ap (κ° (ty.type A) ± (eq-on-ext-rev-lm {Γ} A u x v y q)) x) ≐ (type A • v) ‣ y
-       main = traV lm5 lm4 
+       main = traV lm5 lm4
   in <> main
 
 
 
 
-two-var-lm : {Γ : ctx} 
+two-var-lm : {Γ : ctx}
     -> (A : ty Γ)
 --     -> (b : raw (Γ ▷ A))
-    -> (u v : || κ Γ ||) 
+    -> (u v : || κ Γ ||)
     -> (x : || κ (apt A u) ||)
     -> (p : < κ Γ > u ~ v)
     -> < κ (Γ ▷ A) > (u , x) ~ (v , ap (κ° (type A) ± p) x )
@@ -266,24 +266,24 @@ b-up-lm :  {Δ Γ : ctx}  -> (h : subst Δ Γ)
 b-up-lm {Δ} {Γ} h A b x y = >><< (extensionality1 (raw.rawterm b) _ (((aps h x) , y)) (qq-eq {Δ} {Γ} A h x y ))
 
 
-pr-x-lm2 : {Γ : ctx} 
+pr-x-lm2 : {Γ : ctx}
     -> (A : ty Γ)
     -> (b : raw (Γ ▷ A))
-    -> (u : || κ Γ ||) 
-    -> (x y : ||  κ (apt A u) ||) 
+    -> (u : || κ Γ ||)
+    -> (x y : ||  κ (apt A u) ||)
     ->  apr (b [ pr-x A ]) ((u , x) , y) ≐ apr b (u , x)
-pr-x-lm2 {Γ} A  b u x y = traV (sub-apply b (pr-x A) ((u , x) , y)) 
+pr-x-lm2 {Γ} A  b u x y = traV (sub-apply b (pr-x A) ((u , x) , y))
                                (apr-ext b (aps (pr-x A) ((u , x) , y)) (u , x) (pr-x-lm A u x y) )
 
 
-pr-y : {Γ : ctx} 
+pr-y : {Γ : ctx}
     -> (A : ty Γ)
     ->  subst  (Γ ▷ A ▷ (A [[ ↓ A ]]))  (Γ ▷ A)
-pr-y {Γ} A = 
+pr-y {Γ} A =
   let lm : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> vv (A [[ ↓ A ]]) ::
                         (A [[ ↓ A ]]) [[ ↓ (A [[ ↓ A ]]) ]]
       lm = asm (A [[ ↓ A ]])
-      eq : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> 
+      eq : Γ ▷ A ▷ (A [[ ↓ A ]]) ==>
                         (A [[ ↓ A ]]) [[ ↓ (A [[ ↓ A ]]) ]]  == A [[ ↓ A ⌢ ↓ (A [[ ↓ A ]]) ]]
       eq = tysym (tysubst-com A (↓ A) ( ↓ (A [[ ↓ A ]])))
       lm2 : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> vv (A [[ ↓ A ]]) ::
@@ -292,12 +292,12 @@ pr-y {Γ} A =
 
   in ext A ((↓ A) ⌢ (↓ (A [[ ↓ A ]]))) (vv (A [[ ↓ A ]])) lm2
 
-pr-y-lm : {Γ : ctx} 
+pr-y-lm : {Γ : ctx}
     -> (A : ty Γ)
-    -> (u : || κ Γ ||) 
-    -> (x y : ||  κ (apt A u) ||) 
+    -> (u : || κ Γ ||)
+    -> (x y : ||  κ (apt A u) ||)
     -> < κ (Γ ▷ A) > aps (pr-y A) ((u , x) , y) ~ (u , y)
-pr-y-lm {Γ} A u x y = 
+pr-y-lm {Γ} A u x y =
      let lm : Γ ‣ aps (↓ A ⌢ ↓ (A [[ ↓ A ]])) ((u , x) , y) ≐ Γ ‣ u
          lm = refV (Γ ‣ u)
          q =  (>><<
@@ -314,18 +314,18 @@ pr-y-lm {Γ} A u x y =
      in   <> (pairV-ext lm lm3)
 
 
-pr-y-lm2 : {Γ : ctx} 
+pr-y-lm2 : {Γ : ctx}
     -> (A : ty Γ)
     -> (b : raw (Γ ▷ A))
-    -> (u : || κ Γ ||) 
-    -> (x y : ||  κ (apt A u) ||) 
+    -> (u : || κ Γ ||)
+    -> (x y : ||  κ (apt A u) ||)
     ->  apr (b [ pr-y A ]) ((u , x) , y) ≐ apr b (u , y)
-pr-y-lm2 {Γ} A b u x y = traV (sub-apply b (pr-y A) ((u , x) , y)) 
-       ( apr-ext b (aps (pr-y A) ((u , x) , y)) (u , y) (pr-y-lm A u x y)) 
+pr-y-lm2 {Γ} A b u x y = traV (sub-apply b (pr-y A) ((u , x) , y))
+       ( apr-ext b (aps (pr-y A) ((u , x) , y)) (u , y) (pr-y-lm A u x y))
 
 
-wh-lm-op :  {Γ : ctx} 
-    -> (A B : ty Γ) 
+wh-lm-op :  {Γ : ctx}
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
@@ -336,8 +336,8 @@ wh-lm-op :  {Γ : ctx}
 wh-lm-op {Γ} A B k b q r p x =  apr b (x , pj1 (apel q x))
 
 
-wh-lm-op-ext :  {Γ : ctx} 
-    -> (A B : ty Γ) 
+wh-lm-op-ext :  {Γ : ctx}
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
@@ -346,17 +346,17 @@ wh-lm-op-ext :  {Γ : ctx}
     -> (u v : || κ Γ ||)
     -> < κ Γ > u ~ v
     -> << VV >> wh-lm-op A B k b q r p u ~ wh-lm-op A B k b q r p v
-wh-lm-op-ext {Γ} A B k b q r p u v t = 
+wh-lm-op-ext {Γ} A B k b q r p u v t =
   let   lm1 : (z : || κ (Γ ▷ A ▷ (A [[ ↓ A ]])) ||) →
                       apr (b [ pr-x A ]) z ≐ apr (b [ pr-y A ]) z
-        lm1 = Raw-lm p 
+        lm1 = Raw-lm p
         lm2 : (u : || κ Γ ||) -> (x : ||  κ (apt A u) ||) -> (y : || κ (apt A u) ||) ->
                      apr (b [ pr-x A ]) (( u , x) , y) ≐ apr (b [ pr-y A ])  (( u , x) , y)
         lm2 = λ u x y → lm1  (( u , x) , y)
         lm3 : (u : || κ Γ ||) -> (x : ||  κ (apt A u) ||) -> (y : || κ (apt A u) ||) ->
                      apr b ( u , x)  ≐ apr b (u , y)
         lm3 = λ u x y → traV ( symV (pr-x-lm2 A  b u x y)) (traV (lm2 u x y) (pr-y-lm2 A b u x y))
-        lm4 : apr b (u , pj1 (apel q u)) ≐  apr b (v , ap (κ° (type A) ± t) (pj1 (apel q u))) 
+        lm4 : apr b (u , pj1 (apel q u)) ≐  apr b (v , ap (κ° (type A) ± t) (pj1 (apel q u)))
         lm4 = apr-ext b (u , pj1 (apel q u)) (v , ap (κ° (type A) ± t) (pj1 (apel q u)) )
               (two-var-lm A u v (pj1 (apel q u)) t)
 -- now use  u ~ v
@@ -365,19 +365,19 @@ wh-lm-op-ext {Γ} A B k b q r p u v t =
   in  <<>> lm
 
 
-wh-lm :  {Γ : ctx} 
-    -> (A B : ty Γ) 
+wh-lm :  {Γ : ctx}
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> << Raw (Γ ▷ A ▷ (A [[ ↓ A ]])) >> b [ pr-x A ] ~  (b [ pr-y A ])
     -> raw Γ
-wh-lm  {Γ} A B k b q r p = mkraw (record { op = wh-lm-op {Γ} A B k b q r p 
+wh-lm  {Γ} A B k b q r p = mkraw (record { op = wh-lm-op {Γ} A B k b q r p
                                          ; ext = wh-lm-op-ext {Γ} A B k b q r p })
 
-wh :  {Γ : ctx} 
-    -> (A B : ty Γ) 
+wh :  {Γ : ctx}
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
@@ -387,9 +387,9 @@ wh :  {Γ : ctx}
 wh {Γ} A B k b q r p = wh-lm  {Γ} A B k b q r (Raw-lm2 (prj1 p))
 
 
-Br-e-lm :  {Γ : ctx} 
+Br-e-lm :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
@@ -397,30 +397,30 @@ Br-e-lm :  {Γ : ctx}
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
     -> (x : || κ Γ ||)
     -> apr (wh A B k b q r p) x ∈ apt B x
-Br-e-lm {Γ} A B k b q r p x = 
+Br-e-lm {Γ} A B k b q r p x =
      let lm : apr (wh A B k b q r p) x ≐ apr b (x , pj1 (apel q x))
          lm = refV _
          lm2 : apr b (x , pj1 (apel q x))   ∈ apt B x
          lm2 = apel r (x , pj1 (apel q x))
      in memV-left-ext _ _ (apt B x) lm lm2
 
-Br-e :  {Γ : ctx} 
+Br-e :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
--- --------------------------------  
+-- --------------------------------
     -> Γ ==>  wh A B k b q r p :: B
 Br-e {Γ} A B k b q r p = mk-elt (Br-e-lm {Γ} A B k b q r p)
 
 
 
-Br-beta-raw-lm :  {Γ : ctx} 
+Br-beta-raw-lm :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (a : raw Γ)
     -> (b  : raw (Γ ▷ A))
     -> (t : Γ ==> a :: A)
@@ -432,63 +432,63 @@ Br-beta-raw-lm :  {Γ : ctx}
 Br-beta-raw-lm {Γ} A B a b t q r p x =
      let lm1 : (z : || κ (Γ ▷ A ▷ (A [[ ↓ A ]])) ||) →
                       apr (b [ pr-x A ]) z ≐ apr (b [ pr-y A ]) z
-         lm1 = prj1 p 
+         lm1 = prj1 p
          lm2 : (u : || κ Γ ||) -> (x : ||  κ (apt A u) ||) -> (y : || κ (apt A u) ||) ->
                      apr (b [ pr-x A ]) (( u , x) , y) ≐ apr (b [ pr-y A ])  (( u , x) , y)
          lm2 = λ u x y → lm1  (( u , x) , y)
          lm3 : (u : || κ Γ ||) -> (x : ||  κ (apt A u) ||) -> (y : || κ (apt A u) ||) ->
                      apr b ( u , x)  ≐ apr b (u , y)
          lm3 = λ u x y → traV ( symV (pr-x-lm2 A  b u x y)) (traV (lm2 u x y) (pr-y-lm2 A b u x y))
-       
+
          main :  apr b (x , pj1 (apel q x))  ≐  apr b (x , pj1 (apel t x))  -- (apr (b [ els t ])  x)
          main = lm3 x  (pj1 (apel q x))  (pj1 (apel t x))
      in main
 
-Br-beta-raw :  {Γ : ctx} 
+Br-beta-raw :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (a : raw Γ)
     -> (b  : raw (Γ ▷ A))
     -> (t : Γ ==> a :: A)
     -> (q : Γ ==> (br a) :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
--- --------------------------------  
-    -> << Raw Γ >>  (wh A B (br a) b q r p) ~ (b [ els t ]) 
+-- --------------------------------
+    -> << Raw Γ >>  (wh A B (br a) b q r p) ~ (b [ els t ])
 Br-beta-raw {Γ} A B a b t q r p = <<>> (<<>> (λ x → <<>> (Br-beta-raw-lm {Γ} A B a b t q r p x)))
 
-Br-beta :  {Γ : ctx} 
+Br-beta :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (a : raw Γ)
     -> (b  : raw (Γ ▷ A))
     -> (t : Γ ==> a :: A)
     -> (q : Γ ==> (br a) :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
--- --------------------------------  
+-- --------------------------------
     -> Γ ==>  (wh A B (br a) b q r p) == (b [ els t ]) :: B
-Br-beta {Γ} A B a b t q r p = pair (Raw-lm (Br-beta-raw {Γ} A B a b t q r p)) (pair (Br-e {Γ} A B (br a) b q r p ) 
-                                              (subj-red _ _ (Br-e {Γ} A B (br a) b q r p ) 
+Br-beta {Γ} A B a b t q r p = pair (Raw-lm (Br-beta-raw {Γ} A B a b t q r p)) (pair (Br-e {Γ} A B (br a) b q r p )
+                                              (subj-red _ _ (Br-e {Γ} A B (br a) b q r p )
                                                      (Br-beta-raw {Γ} A B a b t q r p)))
 
 
 
 
-br-sb : {Γ : ctx} 
-    -> (A  : ty Γ) 
+br-sb : {Γ : ctx}
+    -> (A  : ty Γ)
     -> subst (Γ ▷ A)  (Γ ▷ (Br A))
-br-sb {Γ} A = 
+br-sb {Γ} A =
   let lm = Br-intro  (A [[ ↓ A ]])  (vv A) (asm A)
     in ext (Br A ) (↓ A) (br (vv A)) lm
 
-br-sb-lm-raw-lm : {Γ : ctx} 
-    -> (A B : ty Γ) 
+br-sb-lm-raw-lm : {Γ : ctx}
+    -> (A B : ty Γ)
     -> (b : raw (Γ ▷ Br A))
-    -> (u : || κ Γ ||) 
-    -> (x y : ||  κ (apt A u) ||) 
+    -> (u : || κ Γ ||)
+    -> (x y : ||  κ (apt A u) ||)
     -> apr (b [ br-sb A ]) (u , x) ≐  apr (b [ br-sb A ]) (u , y)
-br-sb-lm-raw-lm {Γ} A B b u x y = 
+br-sb-lm-raw-lm {Γ} A B b u x y =
     let lm2 :  < κ (Γ ▷ Br A) > aps (br-sb A) (u , x) ~  aps (br-sb A) (u , y)
         lm2 = <> (pairV-ext (refV _) (refV _))
         lm : apr b (aps (br-sb A) (u , x)) ≐  apr b (aps (br-sb A) (u , y))
@@ -498,34 +498,34 @@ br-sb-lm-raw-lm {Γ} A B b u x y =
     in  main
 
 
-br-sb-lm-raw-lm2 : {Γ : ctx} 
-    -> (A B : ty Γ) 
+br-sb-lm-raw-lm2 : {Γ : ctx}
+    -> (A B : ty Γ)
     -> (b : raw (Γ ▷ Br A))
-    -> (z : || κ (Γ ▷ A ▷ (A [[ ↓ A ]])) ||) 
+    -> (z : || κ (Γ ▷ A ▷ (A [[ ↓ A ]])) ||)
     -> apr ((b [ br-sb A ]) [ pr-x A ]) z  ≐ apr  ((b [ br-sb A ]) [ pr-y A ]) z
-br-sb-lm-raw-lm2 {Γ} A B b (( u , x) , y) = 
+br-sb-lm-raw-lm2 {Γ} A B b (( u , x) , y) =
       let main :  apr ((b [ br-sb A ]) [ pr-x A ]) ((u , x) , y) ≐
                      apr ((b [ br-sb A ]) [ pr-y A ]) ((u , x) , y)
-          main = traV (pr-x-lm2 A (b [ br-sb A ]) u x y) 
+          main = traV (pr-x-lm2 A (b [ br-sb A ]) u x y)
                       (traV (br-sb-lm-raw-lm {Γ} A B b u x y) (symV (pr-y-lm2 A (b [ br-sb A ]) u x y)))
       in main
 
 
-br-sb-lm-raw : {Γ : ctx} 
-    -> (A B : ty Γ) 
+br-sb-lm-raw : {Γ : ctx}
+    -> (A B : ty Γ)
     -> (b : raw (Γ ▷ Br A))
     -> << Raw (Γ ▷ A ▷ (A [[ ↓ A ]])) >> (b [ br-sb A ]) [ pr-x A ] ~ ((b [ br-sb A ]) [ pr-y A ])
 br-sb-lm-raw {Γ} A B b  = Raw-lm2 (br-sb-lm-raw-lm2 {Γ} A B b )
 
 
 
-br-sb-lm : {Γ : ctx} 
-    -> (A B : ty Γ) 
+br-sb-lm : {Γ : ctx}
+    -> (A B : ty Γ)
     -> (b : raw (Γ ▷ Br A))
     -> (r : Γ ▷ (Br A) ==> b :: B [[ ↓ (Br A) ]])
     -> Γ ▷ A ▷ (A [[ ↓ A ]]) ==> (b [ br-sb A ]) [ pr-x A ] ==
              (b [ br-sb A ]) [ pr-y A ] :: (B [[ ↓ A ]]) [[ ↓ (A [[ ↓ A ]]) ]]
-br-sb-lm {Γ} A B b r = 
+br-sb-lm {Γ} A B b r =
    let lm = br-sb-lm-raw {Γ} A B b
        lm2 : Γ ▷ A ==> b  [ br-sb A ] :: B [[ ↓ (Br A) ]] [ br-sb A ]
        lm2 = elt-subst ( br-sb A) r
@@ -537,22 +537,22 @@ br-sb-lm {Γ} A B b r =
        lm3 = elttyeq lm4 lm5
    in pair (Raw-lm lm) (pair lm3 (subj-red _ _ lm3 lm))
 
-Br-eta-raw-lm :  {Γ : ctx} 
+Br-eta-raw-lm :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ Br A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ (Br A) ==> b :: B [[ ↓ (Br A) ]])
     -> (t :  Γ ▷ A ==> b [ br-sb A ] :: B [[ ↓ A ]])
     -> (x : || κ Γ ||)
-    -> apr (wh A B k (b [ br-sb A ]) q t (br-sb-lm A B b r)) x ≐ 
+    -> apr (wh A B k (b [ br-sb A ]) q t (br-sb-lm A B b r)) x ≐
           apr (b [ els q ]) x
 Br-eta-raw-lm {Γ} A B k b q r t x = refV _
 
-Br-eta-raw :  {Γ : ctx} 
+Br-eta-raw :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ Br A))
     -> (q : Γ ==> k :: Br A)
@@ -562,48 +562,48 @@ Br-eta-raw :  {Γ : ctx}
 Br-eta-raw  {Γ} A B k b q r t = <<>> (<<>> (λ x → <<>> (Br-eta-raw-lm {Γ} A B k b q r t x)))
 
 
-Br-eta :  {Γ : ctx} 
+Br-eta :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ Br A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ (Br A) ==> b :: B [[ ↓ (Br A) ]])
     -> (t :  Γ ▷ A ==> b [ br-sb A ] :: B [[ ↓ A ]])
--- --------------------------------  
+-- --------------------------------
     -> Γ ==>  wh A B k (b [ br-sb A ]) q t (br-sb-lm {Γ} A B b r) == (b [ els q ]) :: B
-Br-eta {Γ} A B k b q r t = 
+Br-eta {Γ} A B k b q r t =
   let lm =  Br-e {Γ} A B k (b [ br-sb A ]) q t (br-sb-lm {Γ} A B b r)
       lm2 = Br-eta-raw  {Γ} A B k b q r t
   in pair (Raw-lm lm2) (pair lm (subj-red _ _ lm lm2))
 
-Br-cong-lm : {Γ : ctx} 
+Br-cong-lm : {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> Γ ==> A == B
     -> (x : || κ Γ ||)
     -> type (Br A) • x ≐ type (Br B) • x
 Br-cong-lm {Γ} A B p x = sqV-ext (apt A x) (apt B x) (>><< (ape p x))
 -- sqV-ext : (a b : V) -> a ≐ b -> sqV a ≐ sqV b
 -- Br-op {Γ} A x = sqV (apt A x)
-Br-cong : {Γ : ctx} 
+Br-cong : {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> Γ ==> A == B
 -- -------------------
     -> Γ ==> Br A == Br B
 Br-cong {Γ} A B p = mk-eqty (λ x → <<>> (Br-cong-lm {Γ} A B p x))
 
 
-wh-cong-lm :  {Γ : ctx} 
+wh-cong-lm :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
-    -> (A' B' : ty Γ) 
+    -> (A' B' : ty Γ)
     -> (k'  : raw Γ)
     -> (b' : raw (Γ ▷ A'))
     -> (q' : Γ ==> k' :: Br A')
@@ -612,12 +612,12 @@ wh-cong-lm :  {Γ : ctx}
     -> (Aq : Γ ==> A == A')
     -> Γ ==> B == B'
     -> << Raw Γ >> k ~ k'
-    -> << Raw (Γ ▷ A) >> b ~ (b' [ subst-trp (ext-eq' {Γ} A A' Aq) ]) 
+    -> << Raw (Γ ▷ A) >> b ~ (b' [ subst-trp (ext-eq' {Γ} A A' Aq) ])
     -> (x  : || κ Γ ||)
     -> apr (wh A B k b q r p) x ≐ apr (wh A' B' k' b' q' r' p')  x
-wh-cong-lm {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq kq bq x = 
-   let 
-       b-eq = prj1 p' ((x ,  pj1 (apel q' x)) , ap (κ-Fam ±± ape Aq x) (pj1 (apel q x)))  
+wh-cong-lm {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq kq bq x =
+   let
+       b-eq = prj1 p' ((x ,  pj1 (apel q' x)) , ap (κ-Fam ±± ape Aq x) (pj1 (apel q x)))
        lm6 : apr b (x , pj1 (apel q x)) ≐
                 apr (b' [ subst-trp (ext-eq' A A' Aq) ]) (x , pj1 (apel q x))
        lm6 = Raw-lm bq (x ,  pj1 (apel q x))
@@ -627,27 +627,27 @@ wh-cong-lm {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq kq bq x =
                      ≐
              apr b' (aps (subst-trp (ext-eq' A A' Aq)) (x , pj1 (apel q x)))
        lm8 = traV (pr-y-lm2 A' b' x (pj1 (apel q' x)) (ap (κ-Fam ±± ape Aq x) (pj1 (apel q x)))) (symV (apr-ext b' _ _ lm9))
-    
+
        lm7 : apr (b' [ subst-trp (ext-eq' A A' Aq) ]) (x , pj1 (apel q x))
                  ≐ apr b' (x , pj1 (apel q' x))
-       lm7 = traV (sub-apply b' (subst-trp (ext-eq' A A' Aq)) (x , pj1 (apel q x))) (symV (traV b-eq lm8)) 
+       lm7 = traV (sub-apply b' (subst-trp (ext-eq' A A' Aq)) (x , pj1 (apel q x))) (symV (traV b-eq lm8))
 
 
        lm : apr b (x , pj1 (apel q x)) ≐  apr b' (x , pj1 (apel q' x))
        lm = traV lm6 lm7
-   in lm 
+   in lm
 
 
 
-wh-cong :  {Γ : ctx} 
+wh-cong :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
-    -> (A' B' : ty Γ) 
+    -> (A' B' : ty Γ)
     -> (k'  : raw Γ)
     -> (b' : raw (Γ ▷ A'))
     -> (q' : Γ ==> k' :: Br A')
@@ -656,22 +656,22 @@ wh-cong :  {Γ : ctx}
     -> (Aq : Γ ==> A == A')
     -> Γ ==> B == B'
     -> << Raw Γ >> k ~ k'
-    -> << Raw (Γ ▷ A) >> b ~ (b' [ subst-trp (ext-eq' {Γ} A A' Aq) ]) 
--- --------------------------------  
-    -> << Raw Γ >>  wh A B k b q r p ~  wh A' B' k' b' q' r' p' 
-wh-cong {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq kq bq  = 
+    -> << Raw (Γ ▷ A) >> b ~ (b' [ subst-trp (ext-eq' {Γ} A A' Aq) ])
+-- --------------------------------
+    -> << Raw Γ >>  wh A B k b q r p ~  wh A' B' k' b' q' r' p'
+wh-cong {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq kq bq  =
      <<>> (<<>> (λ x → <<>> (wh-cong-lm {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq kq bq x)))
 
 
-Br-e-cong :  {Γ : ctx} 
+Br-e-cong :  {Γ : ctx}
 --
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
     -> (r : Γ ▷ A ==> b :: B [[ ↓ A ]])
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
-    -> (A' B' : ty Γ) 
+    -> (A' B' : ty Γ)
     -> (k'  : raw Γ)
     -> (b' : raw (Γ ▷ A'))
     -> (q' : Γ ==> k' :: Br A')
@@ -681,19 +681,19 @@ Br-e-cong :  {Γ : ctx}
     -> Γ ==> B == B'
     -> Γ ==> k ==  k' :: Br A
     -> Γ ▷ A ==> b == (b' [ subst-trp (ext-eq' {Γ} A A' Aq) ]) ::  B [[ ↓ A ]]
--- --------------------------------  
+-- --------------------------------
     -> Γ ==>  wh A B k b q r p ==  wh A' B' k' b' q' r' p' :: B
-Br-e-cong {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq kq bq = 
-   let lm = wh-cong {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq (Raw-lm2 (prj1 kq)) (Raw-lm2 (prj1 bq)) 
+Br-e-cong {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq kq bq =
+   let lm = wh-cong {Γ} A B k b q r p A' B' k' b' q' r' p' Aq Bq (Raw-lm2 (prj1 kq)) (Raw-lm2 (prj1 bq))
        lm2 = Br-e A B k b q r p
    in pair (Raw-lm lm) (pair lm2 (subj-red _ _ lm2 lm))
 
 -- to do :  wh-sub
 
-Br-e-sub-raw-lm :  {Δ Γ : ctx} 
+Br-e-sub-raw-lm :  {Δ Γ : ctx}
 --
     -> (h : subst Δ Γ)
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
@@ -701,16 +701,16 @@ Br-e-sub-raw-lm :  {Δ Γ : ctx}
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
     -> (q' : Δ ==> k [ h ] :: Br (A [[ h ]]))
     -> (r' : Δ ▷ (A [[ h ]])  ==> (b [[ (↑ A  h) ]]) :: (B [[ h ]]) [[ ↓ (A [[ h ]]) ]])
-    -> (p' : Δ ▷ (A [[ h ]]) ▷ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) 
-             ==> (b [[ (↑ A h) ]]) [ pr-x (A [[ h ]])  ] ==  (b [[ (↑ A  h) ]]) [ pr-y (A [[ h ]]) ] 
+    -> (p' : Δ ▷ (A [[ h ]]) ▷ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]])
+             ==> (b [[ (↑ A h) ]]) [ pr-x (A [[ h ]])  ] ==  (b [[ (↑ A  h) ]]) [ pr-y (A [[ h ]]) ]
                   :: (B [[ h ]])  [[ ↓ (A [[ h ]]) ]] [[ ↓ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) ]])
-    -> (z : || κ Δ ||) 
+    -> (z : || κ Δ ||)
     -> apr ((wh A B k b q r p) [ h ]) z ≐ apr  (wh (A [[ h ]]) (B [[ h ]]) (k [ h ]) (b [[ (↑ A h) ]]) q' r' p') z
-Br-e-sub-raw-lm {Δ} {Γ} h A B k b q r p q' r' p' z = 
-  let  
+Br-e-sub-raw-lm {Δ} {Γ} h A B k b q r p q' r' p' z =
+  let
       lm1 : (z : || κ (Γ ▷ A ▷ (A [[ ↓ A ]])) ||) →
                       apr (b [ pr-x A ]) z ≐ apr (b [ pr-y A ]) z
-      lm1 = prj1 p 
+      lm1 = prj1 p
       lm2 : (u : || κ Γ ||) -> (x : ||  κ (apt A u) ||) -> (y : || κ (apt A u) ||) ->
                      apr (b [ pr-x A ]) (( u , x) , y) ≐ apr (b [ pr-y A ])  (( u , x) , y)
       lm2 = λ u x y → lm1  (( u , x) , y)
@@ -727,10 +727,10 @@ Br-e-sub-raw-lm {Δ} {Γ} h A B k b q r p q' r' p' z =
   in traV (sub-apply (wh A B k b q r p) h z) main
 
 
-Br-e-sub-raw :  {Δ Γ : ctx} 
+Br-e-sub-raw :  {Δ Γ : ctx}
 --
     -> (h : subst Δ Γ)
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
@@ -738,16 +738,16 @@ Br-e-sub-raw :  {Δ Γ : ctx}
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
     -> (q' : Δ ==> k [ h ] :: Br (A [[ h ]]))
     -> (r' : Δ ▷ (A [[ h ]])  ==> (b [[ (↑ A  h) ]]) :: (B [[ h ]]) [[ ↓ (A [[ h ]]) ]])
-    -> (p' : Δ ▷ (A [[ h ]]) ▷ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) 
-             ==> (b [[ (↑ A h) ]]) [ pr-x (A [[ h ]])  ] ==  (b [[ (↑ A  h) ]]) [ pr-y (A [[ h ]]) ] 
+    -> (p' : Δ ▷ (A [[ h ]]) ▷ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]])
+             ==> (b [[ (↑ A h) ]]) [ pr-x (A [[ h ]])  ] ==  (b [[ (↑ A  h) ]]) [ pr-y (A [[ h ]]) ]
                   :: (B [[ h ]])  [[ ↓ (A [[ h ]]) ]] [[ ↓ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) ]])
     -> << Raw Δ >> (wh A B k b q r p) [ h ] ~ (wh (A [[ h ]]) (B [[ h ]]) (k [ h ]) (b [[ (↑ A h) ]]) q' r' p')
-Br-e-sub-raw {Δ} {Γ} h A B k b q r p q' r' p' = Raw-lm2 (Br-e-sub-raw-lm {Δ} {Γ} h A B k b q r p q' r' p') 
+Br-e-sub-raw {Δ} {Γ} h A B k b q r p q' r' p' = Raw-lm2 (Br-e-sub-raw-lm {Δ} {Γ} h A B k b q r p q' r' p')
 
-Br-e-sub :  {Δ Γ : ctx} 
+Br-e-sub :  {Δ Γ : ctx}
 --
     -> (h : subst Δ Γ)
-    -> (A B : ty Γ) 
+    -> (A B : ty Γ)
     -> (k  : raw Γ)
     -> (b : raw (Γ ▷ A))
     -> (q : Γ ==> k :: Br A)
@@ -755,13 +755,13 @@ Br-e-sub :  {Δ Γ : ctx}
     -> (p : Γ ▷ A ▷ (A [[ ↓ A ]]) ==> b [ pr-x A  ] ==  b [ pr-y A ] :: B  [[ ↓ A ]] [[ ↓ (A [[ ↓ A ]]) ]])
     -> (q' : Δ ==> k [ h ] :: Br (A [[ h ]]))
     -> (r' : Δ ▷ (A [[ h ]])  ==> (b [[ (↑ A  h) ]]) :: (B [[ h ]]) [[ ↓ (A [[ h ]]) ]])
-    -> (p' : Δ ▷ (A [[ h ]]) ▷ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) 
-             ==> (b [[ (↑ A h) ]]) [ pr-x (A [[ h ]])  ] ==  (b [[ (↑ A  h) ]]) [ pr-y (A [[ h ]]) ] 
+    -> (p' : Δ ▷ (A [[ h ]]) ▷ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]])
+             ==> (b [[ (↑ A h) ]]) [ pr-x (A [[ h ]])  ] ==  (b [[ (↑ A  h) ]]) [ pr-y (A [[ h ]]) ]
                   :: (B [[ h ]])  [[ ↓ (A [[ h ]]) ]] [[ ↓ ((A [[ h ]]) [[ ↓ (A [[ h ]]) ]]) ]])
 
--- --------------------------------  
+-- --------------------------------
     -> Δ ==>  (wh A B k b q r p) [ h ] == (wh (A [[ h ]]) (B [[ h ]]) (k [ h ]) (b [[ (↑ A h) ]]) q' r' p') :: B [[ h ]]
-Br-e-sub {Δ} {Γ} h A B k b q r p  q' r' p' = 
+Br-e-sub {Δ} {Γ} h A B k b q r p  q' r' p' =
   let lm : Δ ==>  (wh A B k b q r p) [ h ] :: B [[ h ]]
       lm = elt-subst h (Br-e {Γ} A B k b q r p)
       lm2 = Br-e-sub-raw {Δ} {Γ} h A B k b q r p q' r' p'
@@ -770,9 +770,9 @@ Br-e-sub {Δ} {Γ} h A B k b q r p  q' r' p' =
 
 -- closure under bracket types
 
-U-br- :   (k : N) -> {Γ : ctx} 
+U-br- :   (k : N) -> {Γ : ctx}
 --
-    ->  (A : ty Γ) 
+    ->  (A : ty Γ)
     ->  (q : Γ  ==> A :: U- k Γ)
 -- --------------------------------------------
     ->  Γ ==> Br A :: U- k Γ

--- a/MLTT-and-setoids/V-model-pt16.agda
+++ b/MLTT-and-setoids/V-model-pt16.agda
@@ -29,15 +29,15 @@ open import V-model-pt6         -- 842 lines
 open import V-model-pt7         --  66 lines
 open import V-model-pt8         -- 134 lines
 open import V-model-pt9         -- 441 lines
-open import V-model-pt10  
-open import V-model-pt13         
+open import V-model-pt10
+open import V-model-pt13
 open import V-model-pt11
 open import V-model-pt15
 
-              
+
 binrel-is-extensional : (A B : setoid) -> (R :  || A ||  -> || B || -> Set) -> Set
-binrel-is-extensional A B R = (x x' :  || A ||) -> (y y' :  || B ||) 
-                          -> < A > x ~ x' -> < B > y ~ y' -> R x y -> R x' y' 
+binrel-is-extensional A B R = (x x' :  || A ||) -> (y y' :  || B ||)
+                          -> < A > x ~ x' -> < B > y ~ y' -> R x y -> R x' y'
 
 ext-binrel-on :  (α : V) -> (R :  || κ α ||  -> || κ α || -> Set) -> Set
 ext-binrel-on α R = binrel-is-extensional (κ α) (κ α) R
@@ -50,12 +50,12 @@ ext-binrel-on α R = binrel-is-extensional (κ α) (κ α) R
 Q-set :  (α : V) -> (R :  || κ α ||  -> || κ α || -> Set) ->  V
 Q-set α R =
       sup (# α)
-          (\x -> sup (Σ (|| κ α ||) (\y ->  R x y)) 
+          (\x -> sup (Σ (|| κ α ||) (\y ->  R x y))
                      (\u -> α ‣ (pj1 u)))
 
 
 
-Q-map-op : (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)                            
+Q-map-op : (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
                    -> || κ α || ->  || κ (Q-set α R) ||
 Q-map-op α R x  = x
 
@@ -67,8 +67,8 @@ Q-map-ext :  (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
                              -> (y : || κ α ||)
                              -> < κ α > x ~ y
                              -> < κ (Q-set α R) > Q-map-op α R x ~ Q-map-op α R y
-Q-map-ext α R q x y r = <> (eqV-unexpand' _ _ 
-                                       (λ u → (pj1 u , q _ _ _ _ r (refl _ (pj1 u)) (pj2 u)) , refV _) 
+Q-map-ext α R q x y r = <> (eqV-unexpand' _ _
+                                       (λ u → (pj1 u , q _ _ _ _ r (refl _ (pj1 u)) (pj2 u)) , refV _)
                                        (λ v → (pj1 v , q _ _ _ _ (sym r) (refl _ (pj1 v)) (pj2 v)) , refV _)
                          )
 
@@ -88,13 +88,13 @@ Q-map-prop1 : (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
                              -> (x y :  || κ α ||)
                              -> R x y
                              ->  < κ (Q-set α R) > ap (Q-map α R e) x ~ ap (Q-map α R e) y
-Q-map-prop1 α R e q x y p = 
+Q-map-prop1 α R e q x y p =
   let  lm : (Q-set α R) ‣ x ≐  (Q-set α R) ‣ y
-       lm = eqV-unexpand' (Q-set α R ‣ x) (Q-set α R ‣ y) 
-                (λ u → let  z = pj1 u 
+       lm = eqV-unexpand' (Q-set α R ‣ x) (Q-set α R ‣ y)
+                (λ u → let  z = pj1 u
                             lm = pj2 u
-                       in  (z , (prj2 (prj2 q) _ _ _  (prj1 (prj2 q) x y p) lm)) , (refV _)) 
-                (λ u →  let  z = pj1 u 
+                       in  (z , (prj2 (prj2 q) _ _ _  (prj1 (prj2 q) x y p) lm)) , (refV _))
+                (λ u →  let  z = pj1 u
                              lm = pj2 u
                         in (z ,  (prj2 (prj2 q) _ _ _  p lm)) , refV _)
        main : < κ (Q-set α R) > x ~ y
@@ -109,7 +109,7 @@ Q-map-prop2 : (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
                              -> (x y :  || κ α ||)
                              -> < κ (Q-set α R) > ap (Q-map α R e) x ~ ap (Q-map α R e) y
                              -> R x y
-Q-map-prop2 α R e q x y p = 
+Q-map-prop2 α R e q x y p =
      let rfl : R y y
          rfl = prj1 q y
          u :  Σ (Σ || κ α || (R (Q-map-op α R x)))
@@ -120,9 +120,9 @@ Q-map-prop2 α R e q x y p =
          u2 = pj2 (pj1 u)
          u3 : α ‣ u1 ≐ α ‣ y
          u3 = pj2 u
-        
-     in  e x x _ _ (refl _ x) (<> u3) u2 
- 
+
+     in  e x x _ _ (refl _ x) (<> u3) u2
+
 
 
 un-Q  : (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
@@ -140,8 +140,8 @@ Q-map-prop3 α R e u = refl (κ (Q-set α R)) u
 
 
 Q-lift-op :   (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
-                -> (β : V) 
-                -> (f : setoidmap (κ α) (κ β)) 
+                -> (β : V)
+                -> (f : setoidmap (κ α) (κ β))
                 -> || κ  (Q-set α R) ||
                 -> || κ β ||
 Q-lift-op α R β f u = ap f (un-Q α R u)
@@ -150,13 +150,13 @@ Q-lift-op α R β f u = ap f (un-Q α R u)
 Q-lift-ext :   (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
                 -> ext-binrel-on α R
                 -> Eqrel (|| κ α ||) R
-                -> (β : V) 
-                -> (f : setoidmap (κ α) (κ β)) 
+                -> (β : V)
+                -> (f : setoidmap (κ α) (κ β))
                 -> ((x y :  || κ α ||) ->  (R x y) ->  < κ β > (ap f x) ~ (ap f y))
                 -> (u v  : || κ (Q-set α R) ||)
                 -> < κ (Q-set α R) > u ~ v
                 -> < κ β > Q-lift-op α R β f u ~ Q-lift-op α R β f v
-Q-lift-ext α R e q β f p u v t = 
+Q-lift-ext α R e q β f p u v t =
         let lm3 : R u v
             lm3 = Q-map-prop2 α R e q u v t
             main : < κ β > (ap f u) ~ (ap f v)
@@ -167,34 +167,34 @@ Q-lift-ext α R e q β f p u v t =
 Q-lift : (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
                 -> ext-binrel-on α R
                 -> Eqrel (|| κ α ||) R
-                -> (β : V) 
-                -> (f : setoidmap (κ α) (κ β)) 
+                -> (β : V)
+                -> (f : setoidmap (κ α) (κ β))
                 -> ((x y :  || κ α ||) ->  R x y ->  < κ β > (ap f x) ~ (ap f y))
                 -> setoidmap (κ (Q-set α R)) (κ β)
-Q-lift α R e q β f p = record { op = Q-lift-op α R β f 
+Q-lift α R e q β f p = record { op = Q-lift-op α R β f
                               ; ext = Q-lift-ext α R e q β f p }
 
 
 Q-lift-Prop1 : (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
                 -> (e : ext-binrel-on α R)
                 -> (q : Eqrel (|| κ α ||) R)
-                -> (β : V) 
-                -> (f : setoidmap (κ α) (κ β)) 
+                -> (β : V)
+                -> (f : setoidmap (κ α) (κ β))
                 -> (p : ((x y :  || κ α ||) ->  R x y ->  < κ β > (ap f x) ~ (ap f y)))
-                -> (z : || κ α ||) 
+                -> (z : || κ α ||)
                 ->  < κ β > (ap f z)  ~ (ap (Q-lift α R e q β f p) (ap (Q-map α R e) z))
 Q-lift-Prop1 α R e q β f p x = <> (refV _)
 
 Q-lift-Prop2 : (α : V) -> (R :  || κ α ||  -> || κ α || -> Set)
                 -> (e : ext-binrel-on α R)
                 -> (q : Eqrel (|| κ α ||) R)
-                -> (β : V) 
-                -> (f : setoidmap (κ α) (κ β)) 
+                -> (β : V)
+                -> (f : setoidmap (κ α) (κ β))
                 -> (p : ((x y :  || κ α ||) ->  R x y ->  < κ β > (ap f x) ~ (ap f y)))
                 -> (k : setoidmap (κ (Q-set α R)) (κ β))
                 -> ((z : || κ α ||)  -> < κ β >  (ap k (ap (Q-map α R e) z)) ~ (ap f z))
                 -> ((u : || κ (Q-set α R) ||)  -> < κ β > (ap k u)  ~ ap (Q-lift α R e q β f p) u)
-Q-lift-Prop2 α R e q β f p k m u = m u 
+Q-lift-Prop2 α R e q β f p k m u = m u
 
 
 
@@ -234,7 +234,7 @@ quot : {Γ : ctx}
    -> (a : raw Γ)
    -> (p : Γ ==> a :: A)
    -> raw Γ
-quot {Γ} A R a p = {!!}  
+quot {Γ} A R a p = {!!}
 
 Quot-i : {Γ : ctx}
    -> (A : ty Γ)
@@ -267,7 +267,7 @@ Quot-ID-exd : {Γ : ctx}
    -> (p' : Γ ==> a' :: A)
    -> (r : raw Γ)
    -> (q : Γ ==> r :: R [[ els2 p p' ]])
-   -> Γ ==> omicron {Γ} A R a a' p p' r q 
+   -> Γ ==> omicron {Γ} A R a a' p p' r q
         :: ID (Quot {Γ} A R) (quot {Γ} A R a p) (Quot-i {Γ} A R a p)
                              (quot {Γ} A R a' p') (Quot-i {Γ} A R a' p')
 Quot-ID-exd {Γ} A R a a' p p' r q = {!!}
@@ -287,12 +287,12 @@ QE-op : {Γ : ctx}
        -> (p : Γ ▷ A ==> d :: P [[ quot-subst A R ]])
        -> (e : raw (Γ ▷ A ▷ (A [[ ↓ A ]]) ▷ R))
        -- need transport here
-       -> (q : Γ ▷ A ▷ (A [[ ↓ A ]]) ▷ R ==> 
+       -> (q : Γ ▷ A ▷ (A [[ ↓ A ]]) ▷ R ==>
                  e :: ID (P [[ quot-subst A R ]] [[ ↓ (A [[ ↓ A ]]) ]] [[ ↓ R ]] )
                         ( d  [ ↓ (A [[ ↓ A ]]) ] [ ↓ R ] ) {!!} {!!} {!!})
        -> (c : raw Γ)
        -> (r : Γ ==> c :: (Quot {Γ} A R))
-       -> raw Γ 
+       -> raw Γ
 QE-op = {!!}
 
 Quot-e  : {Γ : ctx}

--- a/MLTT-and-setoids/V-model-pt2.agda
+++ b/MLTT-and-setoids/V-model-pt2.agda
@@ -20,32 +20,32 @@ open import V-model-pt1
 
 --
 
-mk--Fx-op : {Γ : ctx} 
+mk--Fx-op : {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> || κ-Fam §§ (apt A u) ||
        -> ||| VV |||
 mk--Fx-op A B u z = apt B (u , z)
 
-mk-Par-op-Fx-op : {Γ : ctx} 
+mk-Par-op-Fx-op : {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> || κ-Fam §§ (apt A u) ||
        -> V
 mk-Par-op-Fx-op A B u z =  apt B (u , z)
 
-mk-Par-op-Fx-ext : {Γ : ctx} 
+mk-Par-op-Fx-ext : {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> (x y : || κ-Fam §§ (apt A u) ||)
        ->  < κ-Fam §§ (apt A u) > x ~ y
        ->  << VV >> mk-Par-op-Fx-op A B u x ~ mk-Par-op-Fx-op A B u y
-mk-Par-op-Fx-ext A B u x y p =  extensionality1 (ty.type B) (u , x) (u , y) (<> (pairV-ext (refV _) (>< p))) 
+mk-Par-op-Fx-ext A B u x y p =  extensionality1 (ty.type B) (u , x) (u , y) (<> (pairV-ext (refV _) (>< p)))
 
 
 
 
-mk-Par-op-Fx : {Γ : ctx} 
+mk-Par-op-Fx : {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> setoidmap1 (κ-Fam §§ (apt A u)) VV
@@ -53,7 +53,7 @@ mk-Par-op-Fx A B u = record { op = mk-Par-op-Fx-op A B u
                             ; ext = mk-Par-op-Fx-ext A B u }
 
 
-mk-Par-op : {Γ : ctx} 
+mk-Par-op : {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> || κ Γ || ->  ||| Par VV κ-Fam |||
 mk-Par-op  A B u = record { Ix = (apt A u)
@@ -77,7 +77,7 @@ mk-Par-ext {Γ} A B x y p =
                            << VV >> Fxx (mk-Par-op A B x) • x₁ ~
                                     (Fxx (mk-Par-op A B y) • ap (κ-Fam ±± p₁) x₁))
               main = lm1 , (λ z → let eq3 :  < κ (Γ ▷ A) > (x , z) ~  (y , ap (κ-Fam ±± lm1) z)
-                                      eq3 = <> (pairV-ext (>< p) (e+prop (>><< lm1) z))                                                                              
+                                      eq3 = <> (pairV-ext (>< p) (e+prop (>><< lm1) z))
                                       eq2 : << VV >> (apt B (x , z))  ~ (apt B (y , (ap (κ-Fam ±±
                                                                          (extensionality1 (ty.type A) x y p))
                                                                           z)))
@@ -88,13 +88,13 @@ mk-Par-ext {Γ} A B x y p =
 
                                       eq : << VV >> Fxx (mk-Par-op A B x) • z ~
                                               (Fxx (mk-Par-op A B y) • ap (κ-Fam ±± (extensionality1 (ty.type A) x y p)) z)
-                                      eq = eq2 
+                                      eq = eq2
                                   in eq)
           in <<>> main
 
 
 
-mk-Par :  {Γ : ctx} 
+mk-Par :  {Γ : ctx}
        -> (A : ty Γ)  -> (B : ty (Γ ▷ A))
        -> setoidmap1 (κ Γ)  (Par VV κ-Fam)
 mk-Par  A B = record { op = mk-Par-op A B
@@ -102,20 +102,20 @@ mk-Par  A B = record { op = mk-Par-op A B
 
 
 
-subsetoids-VV-inj : (A B : ||| subsetoids VV |||)  
+subsetoids-VV-inj : (A B : ||| subsetoids VV |||)
          -> (q :  << VV >>  ap11 subsetoids-VV A ~ ap11 subsetoids-VV B)
          -> << subsetoids VV >> A ~ B
-subsetoids-VV-inj A B q = tra' 
-                               (sym' (VV-subsetoids-inv-left A)) 
-                               (tra' (extensionality11 VV-subsetoids 
-                                                      (ap11 subsetoids-VV A) 
-                                                      (ap11 subsetoids-VV B) 
-                                                      q) 
+subsetoids-VV-inj A B q = tra'
+                               (sym' (VV-subsetoids-inv-left A))
+                               (tra' (extensionality11 VV-subsetoids
+                                                      (ap11 subsetoids-VV A)
+                                                      (ap11 subsetoids-VV B)
+                                                      q)
                                      (VV-subsetoids-inv-left B))
 
 
 
-κ-Fam-aux5 : (A B : ||| subsetoids VV |||)  
+κ-Fam-aux5 : (A B : ||| subsetoids VV |||)
          -> (q :  << VV >>  ap11 subsetoids-VV A ~  ap11 subsetoids-VV B)
          -> (v : || δ A ||)
          -> (ap1 (ι B) (ap (κ-Fam ±± q) v)) ≐ (ap1 (ι A) v)
@@ -131,33 +131,33 @@ subsetoids-VV-inj A B q = tra'
 -- Pi- formation rule
 
 
-Π-f :  {Γ : ctx} 
+Π-f :  {Γ : ctx}
 --
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
 --     ---------------------------------------
        -> ty Γ
--- 
+--
 Π-f A B = ty.tyy (comp01 piVV (mk-Par A  B))
 
 
 
--- equalities expanding  (Π-f {Γ} A B) ‣ h  etc 
+-- equalities expanding  (Π-f {Γ} A B) ‣ h  etc
 
 
-Π-f-exp1 :  {Γ : ctx} 
+Π-f-exp1 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        ->  (apt (Π-f A B)  u) ≐ piV (apt A u) (mk-Par-op-Fx A B u)
 Π-f-exp1 A B u = refV _
 
-Π-f-exp2 :  {Γ : ctx} 
+Π-f-exp2 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        ->  (apt (Π-f A B)  u) ≐ sup (piV-iV (apt A u) (mk-Par-op-Fx A B u))
-                                    (piV-bV (apt A u) (mk-Par-op-Fx A B u))  
+                                    (piV-bV (apt A u) (mk-Par-op-Fx A B u))
 Π-f-exp2 A B u = refV _
 
-Π-f-exp3 :  {Γ : ctx} 
+Π-f-exp3 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> (h : # (apt (Π-f {Γ} A B)  u))
@@ -166,7 +166,7 @@ subsetoids-VV-inj A B q = tra'
 
 
 
-Π-f-exp3a :  {Γ : ctx} 
+Π-f-exp3a :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> (h : # (apt (Π-f {Γ} A B)  u))
@@ -174,14 +174,14 @@ subsetoids-VV-inj A B q = tra'
        -> ((apt (Π-f {Γ} A B)  u) ‣ h) ‣ x ≐  < (apt A u) ‣ x , (apt B  (u ,  x)) ‣ ((pj1 h) x) >
 Π-f-exp3a  A B u h x = refV _
 
-Π-f-exp3b :  {Γ : ctx} 
+Π-f-exp3b :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> (h : # (apt (Π-f {Γ} A B)  u))
        -> (x y : # (apt A u))
        ->  (apt A u) ‣ x ≐  (apt A u) ‣ y
        ->  (apt B  (u ,  x)) ‣ ((pj1 h) x)  ≐ (apt B  (u ,  y)) ‣ ((pj1 h) y)
-Π-f-exp3b {Γ} A B u h x y p = 
+Π-f-exp3b {Γ} A B u h x y p =
     let  eq : < κ (Γ ▷ A) > (u , x) ~ (u , y)
          eq = <> (pairV-ext (refV (Γ ‣ u)) p)
          eq1 : (apt B  (u ,  x)) ≐ (apt B  (u ,  y))
@@ -195,90 +195,90 @@ subsetoids-VV-inj A B q = tra'
 
 
 
-Π-f-exp4 :  {Γ : ctx} 
+Π-f-exp4 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u v : || κ Γ ||)
        -> (h : # (apt (Π-f A B) u))
-       -> (k : # (apt (Π-f A B)  v))     
+       -> (k : # (apt (Π-f A B)  v))
        -> (apt (Π-f A B)  u) ‣ h ≐  (apt (Π-f A B)  v) ‣ k
-       -> and ((x : (# (apt A u))) -> Σ (# (apt A v)) (\y -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) > 
+       -> and ((x : (# (apt A u))) -> Σ (# (apt A v)) (\y -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) >
                                                       ≐  < (apt A v) ‣ y , (apt B (v ,  y)) ‣ ((pj1 k) y) >))
-              ((y : (# (apt A v))) -> Σ (# (apt A u)) (\x -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) > 
-                                                      ≐  < (apt A v) ‣ y , (apt B (v ,  y)) ‣ ((pj1 k) y) >)) 
+              ((y : (# (apt A v))) -> Σ (# (apt A u)) (\x -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) >
+                                                      ≐  < (apt A v) ‣ y , (apt B (v ,  y)) ‣ ((pj1 k) y) >))
 Π-f-exp4  A B u v h k p = p
 
 
 
-Π-f-exp5 :  {Γ : ctx} 
+Π-f-exp5 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u v : || κ Γ ||)
        -> (h : # (apt (Π-f A B) u))
-       -> (k : # (apt (Π-f A B)  v))     
-       -> and ((x : (# (apt A u))) -> Σ (# (apt A v)) (\y -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) > 
+       -> (k : # (apt (Π-f A B)  v))
+       -> and ((x : (# (apt A u))) -> Σ (# (apt A v)) (\y -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) >
                                                       ≐  < (apt A v) ‣ y , (apt B (v ,  y)) ‣ ((pj1 k) y) >))
-              ((y : (# (apt A v))) -> Σ (# (apt A u)) (\x -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) > 
-                                                      ≐  < (apt A v) ‣ y , (apt B (v ,  y)) ‣ ((pj1 k) y) >)) 
+              ((y : (# (apt A v))) -> Σ (# (apt A u)) (\x -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) >
+                                                      ≐  < (apt A v) ‣ y , (apt B (v ,  y)) ‣ ((pj1 k) y) >))
        -> (apt (Π-f A B)  u) ‣ h ≐  (apt (Π-f A B)  v) ‣ k
 Π-f-exp5  A B u v h k p = p
 
 
 
-Π-f-exp5b :  {Γ : ctx} 
+Π-f-exp5b :  {Γ : ctx}
        -> (A : ty Γ)   -> (B B' : ty (Γ ▷ A))
        -> (u v : || κ Γ ||)
        -> (h : # (apt (Π-f A B) u))
-       -> (k : # (apt (Π-f A B') v))     
-       -> and ((x : (# (apt A u))) -> Σ (# (apt A v)) (\y -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) > 
+       -> (k : # (apt (Π-f A B') v))
+       -> and ((x : (# (apt A u))) -> Σ (# (apt A v)) (\y -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) >
                                                       ≐  < (apt A v) ‣ y , (apt B' (v ,  y)) ‣ ((pj1 k) y) >))
-              ((y : (# (apt A v))) -> Σ (# (apt A u)) (\x -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) > 
-                                                      ≐  < (apt A v) ‣ y , (apt B' (v ,  y)) ‣ ((pj1 k) y) >)) 
+              ((y : (# (apt A v))) -> Σ (# (apt A u)) (\x -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) >
+                                                      ≐  < (apt A v) ‣ y , (apt B' (v ,  y)) ‣ ((pj1 k) y) >))
        -> (apt (Π-f A B)  u) ‣ h ≐  (apt (Π-f A B')  v) ‣ k
-Π-f-exp5b  A B B' u v h k p = 
+Π-f-exp5b  A B B' u v h k p =
     pair (λ x → (pj1 (prj1 p x)) , (pairV-ext (prj1 (pairV-inv-1 (pj2 (prj1 p x)))) ((prj2 (pairV-inv-1 (pj2 (prj1 p x)))))))
          (λ y → (pj1 (prj2 p y)) , (pairV-ext (prj1 (pairV-inv-1 (pj2 (prj2 p y)))) (prj2 (pairV-inv-1 (pj2 (prj2 p y))))))
 
 
 
-Π-f-exp6 :  {Γ : ctx} 
+Π-f-exp6 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> (h k : # (apt (Π-f A B) u))
-       -> ((x : (# (apt A u))) -> 
-              ((apt B (u ,  x)) ‣ ((pj1 h) x)  
+       -> ((x : (# (apt A u))) ->
+              ((apt B (u ,  x)) ‣ ((pj1 h) x)
             ≐  (apt B (u ,  x)) ‣ ((pj1 k) x)))
        -> (apt (Π-f A B)  u) ‣ h ≐  (apt (Π-f A B)  u) ‣ k
-Π-f-exp6 A B u h k p = Π-f-exp5 A B u u h k 
-                          (pair (λ x → x , pairV-ext (refV _) (p x)) 
+Π-f-exp6 A B u h k p = Π-f-exp5 A B u u h k
+                          (pair (λ x → x , pairV-ext (refV _) (p x))
                                 (λ x → x , pairV-ext (refV _) (p x)))
 
 
-Π-f-exp7 :  {Γ : ctx} 
+Π-f-exp7 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> (h : # (apt (Π-f A B) u))
-       -> (k : # (apt (Π-f A B) u))     
+       -> (k : # (apt (Π-f A B) u))
        -> (apt (Π-f A B)  u) ‣ h ≐  (apt (Π-f A B)  u) ‣ k
-       -> and ((x : (# (apt A u))) -> Σ (# (apt A u)) (\y -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) > 
+       -> and ((x : (# (apt A u))) -> Σ (# (apt A u)) (\y -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) >
                                                           ≐  < (apt A u) ‣ y , (apt B (u ,  y)) ‣ ((pj1 k) y) >))
-              ((y : (# (apt A u))) -> Σ (# (apt A u)) (\x -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) > 
-                                                          ≐  < (apt A u) ‣ y , (apt B (u ,  y)) ‣ ((pj1 k) y) >)) 
+              ((y : (# (apt A u))) -> Σ (# (apt A u)) (\x -> < (apt A u) ‣ x , (apt B (u ,  x)) ‣ ((pj1 h) x) >
+                                                          ≐  < (apt A u) ‣ y , (apt B (u ,  y)) ‣ ((pj1 k) y) >))
 Π-f-exp7  A B u h k p = p
 
-Π-f-exp3c :  {Γ : ctx} 
+Π-f-exp3c :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        -> (h k : # (apt (Π-f {Γ} A B)  u))
-       -> (apt (Π-f A B)  u) ‣ h ≐  (apt (Π-f A B)  u) ‣ k 
+       -> (apt (Π-f A B)  u) ‣ h ≐  (apt (Π-f A B)  u) ‣ k
        -> (x : # (apt A u))
        -> (apt B  (u ,  x)) ‣ ((pj1 h) x)  ≐ (apt B  (u ,  x)) ‣ ((pj1 k) x)
-Π-f-exp3c {Γ} A B u h k p x = 
+Π-f-exp3c {Γ} A B u h k p x =
     let  lm = (prj1 (Π-f-exp7 A B u h k p)) x
          t = pj1 lm
          eq : < apt A u ‣ x , apt B (u , x) ‣ pj1 h x > ≐  < apt A u ‣ t , apt B (u , t) ‣ pj1 k t >
          eq = pj2 lm
          eq1 : apt A u ‣ x ≐  apt A u ‣ t
          eq1 = prj1 (pairV-inv-1 eq)
-         eq2 :  apt B (u , x) ‣ pj1 h x  ≐  apt B (u , t) ‣ pj1 k t 
+         eq2 :  apt B (u , x) ‣ pj1 h x  ≐  apt B (u , t) ‣ pj1 k t
          eq2 = prj2 (pairV-inv-1 eq)
          lm2 :  apt B (u , t) ‣ (ap (κ° (Fxx (ap1 (mk-Par A B) u)) ± (<> eq1)) (pj1 k x)) ≐ apt B (u , t) ‣ pj1 k t
          lm2 = >< (pj2 k x t (<> eq1))
@@ -298,7 +298,7 @@ subsetoids-VV-inj A B q = tra'
 
 -- should be moved to iterative-sets-**
 
-irr22-lm : (u z z' v : V)       
+irr22-lm : (u z z' v : V)
            -> (p : u ≐ z)
            -> (q : z ≐ v)
            -> (r : u ≐ z')
@@ -307,7 +307,7 @@ irr22-lm : (u z z' v : V)
            v ‣ ap (κ-Fam ±± (<<>> q)) (ap (κ-Fam ±± (<<>> p)) x)
                            ≐
            v ‣  ap (κ-Fam ±± (<<>> t)) (ap (κ-Fam ±± (<<>> r)) x)
-irr22-lm u z z' v p q r t x = traV (irr2-lm u z v p q (traV p q) x) 
+irr22-lm u z z' v p q r t x = traV (irr2-lm u z v p q (traV p q) x)
                                    (symV (irr2-lm u z' v r t (traV p q) x))
 
 
@@ -326,7 +326,7 @@ irr22-lm u z z' v p q r t x = traV (irr2-lm u z v p q (traV p q) x)
               ap (κ° (Fxx (ap1 (mk-Par A B') x)) ± q)
               (e+ (>><< (ape p (x , u))) (pj1 f u))
               ~ e+ (>><< (ape p (x , v))) (pj1 f v))
-Π-f-rcong-half-map-ext {Γ} A B B' p x f u v q = 
+Π-f-rcong-half-map-ext {Γ} A B B' p x f u v q =
     let lm : < κ (apt B (x , v))  >  -- < κ° (Fxx (ap1 (mk-Par A B) x)) § v >
              ap (κ° (Fxx (ap1 (mk-Par A B) x)) ± q)
                 (pj1 f u)
@@ -338,10 +338,10 @@ irr22-lm u z z' v p q r t x = traV (irr2-lm u z v p q (traV p q) x)
               ~ e+ (>><< (ape p (x , v))) (pj1 f v)
         lm' = <> (e+ext (>><< (ape p (x , v))) _ _ (>< lm))
 
-        lm2 : (apt B' (x , v)) ‣ (ap (κ° (Fxx (ap1 (mk-Par A B') x)) ± q) (e+ (>><< (ape p (x , u))) (pj1 f u))) 
+        lm2 : (apt B' (x , v)) ‣ (ap (κ° (Fxx (ap1 (mk-Par A B') x)) ± q) (e+ (>><< (ape p (x , u))) (pj1 f u)))
               ≐ (apt B' (x , v)) ‣ (e+ (>><< (ape p (x , v))) (ap (κ° (Fxx (ap1 (mk-Par A B) x)) ± q)
-                                                 (pj1 f u))) 
-        lm2 = (irr22-lm (apt B (x , u)) (apt B' (x , u)) (apt B (x , v)) (apt B' (x , v))  _ _ _ _  (pj1 f u))  
+                                                 (pj1 f u)))
+        lm2 = (irr22-lm (apt B (x , u)) (apt B' (x , u)) (apt B (x , v)) (apt B' (x , v))  _ _ _ _  (pj1 f u))
     in <> (traV lm2 (>< lm'))
 
 
@@ -354,14 +354,14 @@ irr22-lm u z z' v p q r t x = traV (irr2-lm u z v p q (traV p q) x)
           -> (x : || κ Γ ||)
           -> (f : # (ty.type (Π-f A B) • x))
           -> (# (ty.type (Π-f A B') • x))
-Π-f-rcong-half-map {Γ} A B B' p x f = 
+Π-f-rcong-half-map {Γ} A B B' p x f =
           ((\y -> e+ (>><< (ape p (x , y))) (pj1 f y))) , Π-f-rcong-half-map-ext {Γ} A B B' p x f
 Π-f-rcong-half : {Γ : ctx}
           -> (A : ty Γ)   -> (B B' : ty (Γ ▷ A))
           -> (Γ ▷ A ==> B == B')
           -> (x : || κ Γ ||)
           -> ty.type (Π-f A B) • x ≤ (ty.type (Π-f A B') • x)
-Π-f-rcong-half {Γ} A B B' p x f = 
+Π-f-rcong-half {Γ} A B B' p x f =
        Π-f-rcong-half-map {Γ} A B B' p x f  ,  Π-f-exp5b A B B' x x f (Π-f-rcong-half-map A B B' p x f)
               (pair (λ u → u , (pairV-ext (refV _) (e+prop (>><< (ape p (x , u))) (pj1 f u))))
                     (λ v → v , (pairV-ext (refV _) (e+prop (>><< (ape p (x , v))) (pj1 f v)))))
@@ -370,17 +370,17 @@ irr22-lm u z z' v p q r t x = traV (irr2-lm u z v p q (traV p q) x)
 
 -- a congruence rule for Pi-formation
 
-Π-f-rcong :  {Γ : ctx} 
+Π-f-rcong :  {Γ : ctx}
 --
        -> (A : ty Γ)   -> (B B' : ty (Γ ▷ A))
        ->  (Γ ▷ A ==> B == B')
 --     ---------------------------------------
        -> (Γ  ==>  Π-f A B == Π-f A B')
--- 
-Π-f-rcong {Γ} A B B' p = 
-     mk-eqty (λ x 
-    → <<>> (extensional-eqV (ty.type (Π-f A B) • x) (ty.type (Π-f A B') • x)                
-            (half-eqV-to-inclusion _ _ (Π-f-rcong-half A B B' p x)) 
+--
+Π-f-rcong {Γ} A B B' p =
+     mk-eqty (λ x
+    → <<>> (extensional-eqV (ty.type (Π-f A B) • x) (ty.type (Π-f A B') • x)
+            (half-eqV-to-inclusion _ _ (Π-f-rcong-half A B B' p x))
             (half-eqV-to-inclusion _ _ ((Π-f-rcong-half A B' B (tysym p) x)))))
 
 
@@ -388,36 +388,36 @@ irr22-lm u z z' v p q r t x = traV (irr2-lm u z v p q (traV p q) x)
 
 -- lambda abstraction
 
-lambda-op  :  {Γ : ctx} 
+lambda-op  :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
        -> || κ Γ || -> V
 lambda-op A B b x = sup (# (apt A x))
                             (λ y → pairV ((apt A x) ‣ y) (apr b ( x , y )))
 
-lambda-ext  :  {Γ : ctx} 
+lambda-ext  :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
-       -> (u v : || κ Γ ||) 
-       -> < κ Γ > u ~ v 
+       -> (u v : || κ Γ ||)
+       -> < κ Γ > u ~ v
        -> << VV >> lambda-op A B b u ~ lambda-op A B b v
-lambda-ext A B b u v p = 
+lambda-ext A B b u v p =
         let eq :  (apt A u) ≐ (apt A v)
             eq = >><< (extensionality1 (ty.type A) u v p)
             p' = >< p
-        in  <<>> (eqV-unexpand (lambda-op A B b u) (lambda-op  A B b v) 
-                         (λ x →  (e+ eq x) , 
+        in  <<>> (eqV-unexpand (lambda-op A B b u) (lambda-op  A B b v)
+                         (λ x →  (e+ eq x) ,
                                  pairV-ext (e+prop eq x)
-                                           (>><< (extensionality1 (raw.rawterm b) 
-                                                (u , x) 
-                                                (v , e+ (>><< (extensionality1 (ty.type A) u v p)) x) 
+                                           (>><< (extensionality1 (raw.rawterm b)
+                                                (u , x)
+                                                (v , e+ (>><< (extensionality1 (ty.type A) u v p)) x)
                                                 (<> (pairV-ext p' (e+prop eq x)))))
                                  )
                          (λ y →  e+ (symV eq) y ,
-                                 pairV-ext (symV (e+prop (symV eq) y)) 
+                                 pairV-ext (symV (e+prop (symV eq) y))
                                            (>><< (extensionality1 (raw.rawterm b)
                                                  (u , e+ (symV (>><< (extensionality1 (ty.type A) u v p))) y)
-                                                 (v , y) 
+                                                 (v , y)
                                                  (<> (pairV-ext p' (symV (e+prop (symV eq) y))))))
                                  )
                  )
@@ -425,11 +425,11 @@ lambda-ext A B b u v p =
 
 
 
-lambda  :  {Γ : ctx} 
+lambda  :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
        -> raw Γ
-lambda A B b = mkraw (record { op = lambda-op A B b 
+lambda A B b = mkraw (record { op = lambda-op A B b
                              ; ext = lambda-ext A B b })
 
 
@@ -438,15 +438,15 @@ lambda A B b = mkraw (record { op = lambda-op A B b
 
 -- towards Pi-introduction rule
 
-Π-i-aux2 : {Γ : ctx} 
+Π-i-aux2 : {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
        -> (p : Γ ▷ A ==> b :: B)
        -> (u : || κ Γ ||)
-       -> (x y : # (apt A u)) 
-       -> (q : < κ (apt A u) > x ~ y) 
+       -> (x y : # (apt A u))
+       -> (q : < κ (apt A u) > x ~ y)
        -> < (κ° (mk-Par-op-Fx A B u)) § y > (ap (κ° (mk-Par-op-Fx A B u) ± q) (pj1 (apel p (u , x))))  ~  pj1 (apel p (u , y))
-Π-i-aux2 {Γ} A B b p u x y q = 
+Π-i-aux2 {Γ} A B b p u x y q =
     let  lmx : (apr b  (u , x)) ∈  (apt B (u , x))
          lmx = apel p (u , x)
          lmx2 : (apr b (u , x)) ≐ (apt B (u , x)) ‣ pj1 (apel p (u , x))
@@ -461,12 +461,12 @@ lambda A B b = mkraw (record { op = lambda-op A B b
          lmq2 = extensionality1 (raw.rawterm b) (u , x) (u , y) lmq
          lmq3 : << VV >> (apt B (u , x)) ~ (apt B (u , y))
          lmq3 = extensionality1 (ty.type B) (u , x) (u , y) lmq
- 
+
 
          main :   (apt B  (u , y)) ‣ (ap (κ° (mk-Par-op-Fx A B u) ± q) (pj1 (apel p (u , x))))
                   ≐ ((mk-Par-op-Fx A B u • y) ‣ pj1 (apel p (u , y)))
          main = traV (traV (traV (symV (e+prop (>><< lmq3) (pj1 (apel p (u , x))) )) (symV lmx2)) (>><< lmq2)) lmy2
-    in  <> main 
+    in  <> main
 
 
 
@@ -479,54 +479,54 @@ lambda A B b = mkraw (record { op = lambda-op A B b
        -> Γ ▷ A ==> b :: B
        -> (u : || κ Γ ||)
        -> piV-iV (apt A u) (mk-Par-op-Fx A B u)
-Π-i-aux A B b p u = 
+Π-i-aux A B b p u =
     let h : (x : # (apt A u)) ->  # ((mk-Par-op-Fx A B u) • x)
         h = λ z → pj1 (apel p (u , z))
-        hx :  (x y : # (apt A u)) 
-              -> (p : < κ (apt A u) > x ~ y) 
+        hx :  (x y : # (apt A u))
+              -> (p : < κ (apt A u) > x ~ y)
               -> < (κ° (mk-Par-op-Fx A B u))  § y > (ap (κ° (mk-Par-op-Fx A B u) ± p) (h x))  ~ h y
-        hx = Π-i-aux2 A B b p u 
+        hx = Π-i-aux2 A B b p u
     in h , hx
 
 
 -- Pi-introduction
 
-Π-i  :  {Γ : ctx} 
+Π-i  :  {Γ : ctx}
        -> (A : ty Γ)   -> {B : ty (Γ ▷ A)}
        -> {b : raw (Γ ▷ A)}
        -> Γ ▷ A ==> b :: B
 --  -----------------------------------------
         -> Γ ==> lambda A B b :: Π-f A B
--- 
+--
 Π-i {Γ} A {B} {b} p =   mk-elt (\x ->
     let h : piV-iV (apt A x) (mk-Par-op-Fx A B x)
-        h =  Π-i-aux A B b p x 
+        h =  Π-i-aux A B b p x
 
         lm2 : sup (# (apt A  x))
                             (λ y → pairV ((apt A x) ‣ y) (apr b ( x , y )))
-              ≐ sup (# (apt A x)) 
+              ≐ sup (# (apt A x))
                             (\y ->  < (apt A x) ‣ y , ((mk-Par-op-Fx A B x) • y) ‣ ((pj1 h) y) >)
-        lm2 = pair (λ t → t , pairV-ext (refV _) (pj2 (apel p (x , t)))) 
-                   (λ t → t , pairV-ext (refV _) (pj2 (apel p (x , t)))) 
+        lm2 = pair (λ t → t , pairV-ext (refV _) (pj2 (apel p (x , t))))
+                   (λ t → t , pairV-ext (refV _) (pj2 (apel p (x , t))))
 
-        lm1 : apr (lambda A B b) x ≐ piV-bV (apt A x) (mk-Par-op-Fx A B x) h 
-        lm1 = lm2 
-        lm : apr (lambda A B b) x ∈ piV (apt A x) (mk-Par-op-Fx A B x) 
-        lm = h , lm1 
+        lm1 : apr (lambda A B b) x ≐ piV-bV (apt A x) (mk-Par-op-Fx A B x) h
+        lm1 = lm2
+        lm : apr (lambda A B b) x ∈ piV (apt A x) (mk-Par-op-Fx A B x)
+        lm = h , lm1
         main : apr (lambda A B b) x ∈ ap11 piVV (mk-Par A B • x)
-        main = lm 
+        main = lm
     in main)
 
 
 
 -- towards a xi-rule for lambda
 
-Π-xi-raw  :  {Γ : ctx} 
+Π-xi-raw  :  {Γ : ctx}
        -> (A : ty Γ)   -> {B : ty (Γ ▷ A)}
        -> (b : raw (Γ ▷ A))
        -> (b' : raw (Γ ▷ A))
        -> (<< Raw (Γ ▷ A) >> b ~ b')
-       ->  (x : || κ Γ ||) 
+       ->  (x : || κ Γ ||)
        ->  apr (lambda A B b) x ≐ apr (lambda A B b') x
 Π-xi-raw  A {B} b b' p x =
          let  p' = >><< (>><< p)
@@ -535,7 +535,7 @@ lambda A B b = mkraw (record { op = lambda-op A B b
                     ≐
                     sup (# (apt A x))
                             (λ y → pairV ((apt A x) ‣ y) (apr b' ( x , y )))
-              eq = easy-eqV (# (apt A x)) _ _ 
+              eq = easy-eqV (# (apt A x)) _ _
                      (λ y → pairV-ext (refV _) (>><< (p'  (x ,  y))))
          in eq
 
@@ -543,19 +543,18 @@ lambda A B b = mkraw (record { op = lambda-op A B b
 
 
 
-Π-xi  :  {Γ : ctx} 
+Π-xi  :  {Γ : ctx}
        -> (A : ty Γ)   -> {B : ty (Γ ▷ A)}
        -> {b : raw (Γ ▷ A)}
        -> {b' : raw (Γ ▷ A)}
        -> (r : Γ ▷ A ==> b == b' :: B)
 --  -----------------------------------------
         -> Γ ==> lambda A B b ==  lambda A B b' :: Π-f A B
--- 
-Π-xi {Γ} A {B} {b} {b'} r = 
+--
+Π-xi {Γ} A {B} {b} {b'} r =
                       let r1 = (prj1 r)
                       in
                           pair (Π-xi-raw {Γ} A {B} b b' (<<>> (<<>> (λ x → <<>> (r1 x)))))
-                                 (pair (Π-i A {B} {b} (prj1 (prj2 r))) 
+                                 (pair (Π-i A {B} {b} (prj1 (prj2 r)))
                                        (Π-i A {B} {b'} (prj2 (prj2 r))))
-
 

--- a/MLTT-and-setoids/V-model-pt3.agda
+++ b/MLTT-and-setoids/V-model-pt3.agda
@@ -22,7 +22,7 @@ open import V-model-pt2
 
 -- towards application operation and Pi-elimination
 
-app-op :  {Γ : ctx} 
+app-op :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (Γ ==> c :: Π-f A B)
@@ -33,22 +33,22 @@ app-op :  {Γ : ctx}
 app-op A B c p a q u =  (apt B (u , pj1 (apel q u))) ‣ (pj1 (pj1 (apel p u)) (pj1 (apel q u)))
 
 
-app-ext :  {Γ : ctx} 
+app-ext :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
     -> (a : raw Γ)
     -> (q : Γ ==> a :: A)
     -> (x y : || κ Γ ||)
-    -> < κ Γ > x ~ y 
+    -> < κ Γ > x ~ y
     -> << VV >> app-op A B c p a q x ~ app-op A B c p a q y
-app-ext {Γ} A B c p a q x y r = 
+app-ext {Γ} A B c p a q x y r =
 
    let eqC :  (apt (Π-f A B) x) ≐ (apt (Π-f A B) y)
        eqC = >><< (extensionality1 (ty.type (Π-f A B)) x y r)
        ec : << VV >> (apr c x) ~ (apr c y)
        ec = extensionality1 (raw.rawterm c) x y r
-       eqA : (apt A x) ≐ (apt A y) 
+       eqA : (apt A x) ≐ (apt A y)
        eqA = >><< (extensionality1 (ty.type A) x y r)
        ea  : << VV >> (apr a x) ~ (apr a y)
        ea = extensionality1 (raw.rawterm a) x y r
@@ -56,13 +56,13 @@ app-ext {Γ} A B c p a q x y r =
        px2  : (apr c x) ≐ (apt (Π-f A B) x) ‣ pj1 (apel p x)
        px2 = pj2 (apel p x)
        px11 : (x₁ : # (apt A x)) →
-                # (apt B (x , x₁))    
+                # (apt B (x , x₁))
        px11 = pj1 (pj1 (apel p x))
 
        px12 : (x₁ y₁ : # (apt A x)) ->
              (p₁ : < κ (apt A x) > x₁ ~ y₁) →
               < κ  (apt B (x , y₁)) >
-                    (ap (κ-Fam ±± (extensionality1 (Fxx (ap1 (mk-Par A B) x)) x₁ y₁ p₁)) (pj1 (pj1 (apel p x)) x₁)) 
+                    (ap (κ-Fam ±± (extensionality1 (Fxx (ap1 (mk-Par A B) x)) x₁ y₁ p₁)) (pj1 (pj1 (apel p x)) x₁))
                      ~
                     (pj1 (pj1 (apel p x)) y₁)
        px12 = pj2 (pj1 (apel p x))
@@ -78,9 +78,9 @@ app-ext {Γ} A B c p a q x y r =
                < κ (apt B (y , y₁)) >
                  (ap (κ-Fam ±± (extensionality1 (Fxx (ap1 (mk-Par A B) y)) x₁ y₁ p₁)) (pj1 (pj1 (apel p y)) x₁))
                   ~
-                 pj1 (pj1 (apel p y)) y₁  
+                 pj1 (pj1 (apel p y)) y₁
        py12 = pj2 (pj1 (apel p y))
-    
+
 
        qx2  : (apr a x) ≐ (apt A x) ‣ pj1 (apel q x)
        qx2 = pj2 (apel q x)
@@ -91,13 +91,13 @@ app-ext {Γ} A B c p a q x y r =
        qxy2 : (apt A x) ‣ pj1 (apel q x) ≐ (apt A y) ‣ pj1 (apel q y)
        qxy2 = traV (symV qx2) (traV (>><< ea) qy2)
 
-      
+
        eqc :  (apt (Π-f A B) x) ‣ pj1 (apel p x) ≐  (apt (Π-f A B) y) ‣ pj1 (apel p y)  -- main c equality
        eqc = traV (symV px2) (traV (>><< ec) py2)
-     
+
        lmC :  (apt (Π-f A B) x) ‣ pj1 (apel p x) ≐ (apt (Π-f A B) y) ‣ (e+ eqC (pj1 (apel p x)))
-       lmC = e+prop eqC (pj1 (apel p x)) 
-       
+       lmC = e+prop eqC (pj1 (apel p x))
+
        pe : (apt (Π-f  A B) y) ‣ (e+ eqC (pj1 (apel p x))) ≐  (apt (Π-f A B) y) ‣ pj1 (apel p y)
        pe = traV (symV lmC) eqc
 
@@ -105,7 +105,7 @@ app-ext {Γ} A B c p a q x y r =
        eqa = traV (symV qx2) (traV (>><< ea) qy2)
 
        lmA :  (apt A  x) ‣ pj1 (apel q x) ≐ (apt A y) ‣ (e+ eqA (pj1 (apel q x)))
-       lmA = e+prop eqA (pj1 (apel q x)) 
+       lmA = e+prop eqA (pj1 (apel q x))
 
        p₁ : < κ (apt A y) >  (e+ eqA (pj1 (apel q x))) ~ (pj1 (apel q y))
        p₁ = <> (traV (symV lmA) eqa)
@@ -113,15 +113,15 @@ app-ext {Γ} A B c p a q x y r =
               ap (κ-Fam ±±  extensionality1 (Fxx (ap1 (mk-Par A B) y)) (e+ eqA (pj1 (apel q x))) (pj1 (apel q y)) p₁)
                             (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x))))
               ~ pj1 (pj1 (apel p y)) (pj1 (apel q y))
-       py12b = py12 (e+ eqA (pj1 (apel q x))) (pj1 (apel q y)) p₁ 
+       py12b = py12 (e+ eqA (pj1 (apel q x))) (pj1 (apel q y)) p₁
 
-       exp4a  : 
+       exp4a  :
          Σ (# (apt A  y))
          (λ y₁ →
             < (apt A  x) ‣ (pj1 (apel q x)) , (apt B  (x , (pj1 (apel q x)))) ‣ pj1 (pj1 (apel p x)) (pj1 (apel q x)) > ≐
             < (apt A y) ‣ y₁ , (apt B  (y , y₁)) ‣ pj1 (pj1 (apel p y)) y₁ >)
        exp4a = prj1 (Π-f-exp4  A B x y  (pj1 (apel p x)) (pj1 (apel p y)) eqc) (pj1 (apel q x))
-  
+
        exp4b  :
           Σ (# (apt A x))
          (λ x₁ →
@@ -142,17 +142,17 @@ app-ext {Γ} A B c p a q x y r =
        try = traV (symV exp4a21) qxy2
        try2 : < κ (Γ ▷ A) > (y , y1) ~ (y , pj1 (apel q y))
        try2 =  <> (pairV-ext (refV _) try)
-       try3 : (apt B (y , y1)) ≐  (apt B  (y , pj1 (apel q y))) 
+       try3 : (apt B (y , y1)) ≐  (apt B  (y , pj1 (apel q y)))
        try3 = >><< (extensionality1 (ty.type B) (y , y1) (y , pj1 (apel q y)) try2)
        try4 : (apt A y) ‣ y1 ≐ (apt A y) ‣ (e+ eqA (pj1 (apel q x)))
        try4 = traV (symV exp4a21)  lmA
-       
+
        pty12q' = py12 (e+ eqA (pj1 (apel q x)))  y1 (<> (symV try4))
 
        pty12q : (apt B (y , y1)) ‣ (ap (κ-Fam ±± (extensionality1 (Fxx (ap1 (mk-Par A B) y))
-                                                        (e+ eqA (pj1 (apel q x))) 
-                                                        y1 
-                                                        (<> (symV try4)))) 
+                                                        (e+ eqA (pj1 (apel q x)))
+                                                        y1
+                                                        (<> (symV try4))))
                                      (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x)))))
                    ≐
                 (apt B (y , y1)) ‣ (pj1 (pj1 (apel p y)) y1)
@@ -162,38 +162,38 @@ app-ext {Γ} A B c p a q x y r =
 
 --}
 
-       pty12r : (apt B (y ,  pj1 (apel q y))) ‣ (e+ try3  (ap (κ-Fam ±± (extensionality1 (Fxx (ap1 (mk-Par A B) y)) 
+       pty12r : (apt B (y ,  pj1 (apel q y))) ‣ (e+ try3  (ap (κ-Fam ±± (extensionality1 (Fxx (ap1 (mk-Par A B) y))
                                       (e+ eqA (pj1 (apel q x))) y1 (<> (symV try4)))) (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x))))))
                    ≐
                 (apt B (y ,  pj1 (apel q y))) ‣ (e+ try3 (pj1 (pj1 (apel p y)) y1))
        pty12r = e+ext try3 _ _ pty12q
 
 
-       llm4 :  (apt B (y ,  pj1 (apel q y))) ‣ (e+ try3  (ap (κ-Fam ±± (extensionality1 (Fxx (ap1 (mk-Par A B) y)) 
-                                                        (e+ eqA (pj1 (apel q x))) y1 (<> (symV try4)))) 
+       llm4 :  (apt B (y ,  pj1 (apel q y))) ‣ (e+ try3  (ap (κ-Fam ±± (extensionality1 (Fxx (ap1 (mk-Par A B) y))
+                                                        (e+ eqA (pj1 (apel q x))) y1 (<> (symV try4))))
                                          (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x))))
-                                             ))                
-                  ≐ 
+                                             ))
+                  ≐
                (apt B (y , pj1 (apel q y))) ‣ (e+ (>><< (extensionality1 (Fxx (ap1 (mk-Par A B) y)) (e+ eqA (pj1 (apel q x))) (pj1 (apel q y)) p₁))
                                          (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x))))
                                              )
        llm4 = e+fun _ try3 (>><< (extensionality1 (Fxx (ap1 (mk-Par A B) y)) (e+ eqA (pj1 (apel q x))) (pj1 (apel q y)) p₁)) (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x))))
        llm3 :   (apt B (y , pj1 (apel q y))) ‣ (e+ try3  (pj1 (pj1 (apel p y)) y1))
-                 ≐ 
+                 ≐
                 (apt B (y , pj1 (apel q y))) ‣ (e+ (>><< (extensionality1 (Fxx (ap1 (mk-Par A B) y)) (e+ eqA (pj1 (apel q x))) (pj1 (apel q y)) p₁))
                                               (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x)))))
        llm3 = traV (symV pty12r) llm4
 
 
-       llm2' :  (apt B (y , y1)) ‣ pj1 (pj1 (apel p y)) y1 ≐ 
+       llm2' :  (apt B (y , y1)) ‣ pj1 (pj1 (apel p y)) y1 ≐
                 (apt B (y , pj1 (apel q y))) ‣ (e+ (>><< (extensionality1 (Fxx (ap1 (mk-Par A B) y)) (e+ eqA (pj1 (apel q x))) (pj1 (apel q y)) p₁))
                                              (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x)))))
 
-       llm2' = traV (e+prop try3 (pj1 (pj1 (apel p y)) y1)) llm3 
-      
+       llm2' = traV (e+prop try3 (pj1 (pj1 (apel p y)) y1)) llm3
 
 
-       llm2 :  (apt B  (y , y1)) ‣ pj1 (pj1 (apel p y)) y1 ≐ 
+
+       llm2 :  (apt B  (y , y1)) ‣ pj1 (pj1 (apel p y)) y1 ≐
                (apt B  (y , pj1 (apel q y))) ‣ (ap (κ-Fam ±±  extensionality1 (Fxx (ap1 (mk-Par A B) y)) (e+ eqA (pj1 (apel q x))) (pj1 (apel q y)) p₁)
                              (pj1 (pj1 (apel p y)) (e+ eqA (pj1 (apel q x)))))
        llm2 = llm2'
@@ -210,14 +210,14 @@ app-ext {Γ} A B c p a q x y r =
 
 
 
-app :  {Γ : ctx} 
+app :  {Γ : ctx}
     -> (A : ty Γ)  -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (Γ ==> c :: Π-f {Γ} A B)
     -> (a : raw Γ)
     -> (Γ ==> a :: A)
     -> raw Γ
-app A B c p a q = mkraw (record { op = app-op A B c p a q 
+app A B c p a q = mkraw (record { op = app-op A B c p a q
                                 ; ext = app-ext A B c p a q })
 
 -- app-op A B c p a q u =  (apt B (u , pj1 (apel q u))) ‣ (pj1 (pj1 (apel p u)) (pj1 (apel q u)))
@@ -225,7 +225,7 @@ app A B c p a q = mkraw (record { op = app-op A B c p a q
 
 
 
-app-cong1-raw :  {Γ : ctx} 
+app-cong1-raw :  {Γ : ctx}
     -> (A : ty Γ)  -> (B : ty (Γ ▷ A))
     -> (c c' : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -234,10 +234,10 @@ app-cong1-raw :  {Γ : ctx}
     -> (a : raw Γ)
     -> (q : Γ ==> a :: A)
     -> << Raw Γ >>  app A B c p a q ~ app A B c' p' a q
-app-cong1-raw {Γ} A B c c' p p' r a q = 
- <<>> (<<>> 
+app-cong1-raw {Γ} A B c c' p p' r a q =
+ <<>> (<<>>
 
-   (\ x -> 
+   (\ x ->
    let lm3 : apr c x ≐ apt (Π-f A B) x ‣ pj1 (apel p x)
        lm3 = pj2 (apel p x)
        lm4 : apr c' x ≐ apt (Π-f A B) x ‣ pj1 (apel p' x)
@@ -262,29 +262,29 @@ app-cong1-raw {Γ} A B c c' p p' r a q =
           < apt A x ‣ pj1 (apel q x) ,
           apt B (x , pj1 (apel q x)) ‣ pj1 (pj1 (apel p' x)) (pj1 (apel q x))  >
        eq2 = pj2 lm7b
-       
 
-       eq :  (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p  x)) (pj1 (apel q x))) ≐ 
+
+       eq :  (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p  x)) (pj1 (apel q x))) ≐
              (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p' x)) (pj1 (apel q x)))
-       eq = Π-f-exp3c A B x (pj1 (apel p x)) (pj1 (apel p' x)) lm5 (pj1 (apel q x))     
-   in <<>> eq 
+       eq = Π-f-exp3c A B x (pj1 (apel p x)) (pj1 (apel p' x)) lm5 (pj1 (apel q x))
+   in <<>> eq
    ))
 
 
- 
 
 
 
-app-irr1 :  {Γ : ctx} 
+
+app-irr1 :  {Γ : ctx}
     -> (A : ty Γ)  -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p p' : Γ ==> c :: Π-f {Γ} A B)
     -> (a : raw Γ)
     -> (q : Γ ==> a :: A)
     -> << Raw Γ >>  app A B c p a q ~ app A B c p' a q
-app-irr1 {Γ} A B c p p' a q  = 
-  <<>> (<<>> 
-   (\ x -> 
+app-irr1 {Γ} A B c p p' a q  =
+  <<>> (<<>>
+   (\ x ->
    let lm3 : apr c x ≐ apt (Π-f A B) x ‣ pj1 (apel p x)
        lm3 = pj2 (apel p x)
        lm4 : apr c x ≐ apt (Π-f A B) x ‣ pj1 (apel p' x)
@@ -307,17 +307,17 @@ app-irr1 {Γ} A B c p p' a q  =
           < apt A x ‣ pj1 (apel q x) ,
           apt B (x , pj1 (apel q x)) ‣ pj1 (pj1 (apel p' x)) (pj1 (apel q x))  >
        eq2 = pj2 lm7b
-       
 
-       eq :  (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p  x)) (pj1 (apel q x))) ≐ 
+
+       eq :  (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p  x)) (pj1 (apel q x))) ≐
              (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p' x)) (pj1 (apel q x)))
-       eq = Π-f-exp3c A B x (pj1 (apel p x)) (pj1 (apel p' x)) lm5 (pj1 (apel q x))     
+       eq = Π-f-exp3c A B x (pj1 (apel p x)) (pj1 (apel p' x)) lm5 (pj1 (apel q x))
    in (<<>> eq)
    ))
 
 
 
-app-cong2-raw :  {Γ : ctx} 
+app-cong2-raw :  {Γ : ctx}
     -> (A : ty Γ)  -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -327,8 +327,8 @@ app-cong2-raw :  {Γ : ctx}
     -> (Γ ==> a == a' :: A)
     -> << Raw Γ >>  app A B c p a q ~ app A B c p a' q'
 app-cong2-raw {Γ} A B c p a a' q q' r =
- <<>> (<<>> 
-   (\ x ->  
+ <<>> (<<>>
+   (\ x ->
   let  lm1 : apr a x ≐ apt A x ‣ pj1 (apel q x)
        lm1 = pj2 (apel q x)
        lm2 : apr a' x ≐ apt A x ‣ pj1 (apel q' x)
@@ -337,7 +337,7 @@ app-cong2-raw {Γ} A B c p a a' q q' r =
        lm2b = prj1 r x
        lm3 : apt A x ‣ pj1 (apel q x) ≐ apt A x ‣ pj1 (apel q' x)
        lm3 = traV (symV lm1) (traV lm2b lm2)
-       main : (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p x)) (pj1 (apel q x))) ≐ 
+       main : (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p x)) (pj1 (apel q x))) ≐
               (apt B (x , pj1 (apel q' x))) ‣ (pj1 (pj1 (apel p x)) (pj1 (apel q' x)))
        main = Π-f-exp3b A B x (pj1 (apel p x)) (pj1 (apel q x)) (pj1 (apel q' x)) lm3
   in <<>> main
@@ -346,7 +346,7 @@ app-cong2-raw {Γ} A B c p a a' q q' r =
 
 
 
-app-irr2 :  {Γ : ctx} 
+app-irr2 :  {Γ : ctx}
     -> (A : ty Γ)  -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -354,15 +354,15 @@ app-irr2 :  {Γ : ctx}
     -> (q q' : Γ ==> a :: A)
     -> << Raw Γ >>  app A B c p a q ~ app A B c p a q'
 app-irr2 {Γ} A B c p a q q'  =
-  <<>> (<<>> 
-   (\ x ->   
+  <<>> (<<>>
+   (\ x ->
       let lm1 : apr a x ≐ apt A x ‣ pj1 (apel q x)
           lm1 = pj2 (apel q x)
           lm2 : apr a x ≐ apt A x ‣ pj1 (apel q' x)
           lm2 = pj2 (apel q' x)
           lm3 : apt A x ‣ pj1 (apel q x) ≐ apt A x ‣ pj1 (apel q' x)
           lm3 = traV (symV lm1) lm2
-          main : (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p x)) (pj1 (apel q x))) ≐ 
+          main : (apt B (x , pj1 (apel q x))) ‣ (pj1 (pj1 (apel p x)) (pj1 (apel q x))) ≐
                  (apt B (x , pj1 (apel q' x))) ‣ (pj1 (pj1 (apel p x)) (pj1 (apel q' x)))
           main = Π-f-exp3b A B x (pj1 (apel p x)) (pj1 (apel q x)) (pj1 (apel q' x)) lm3
       in <<>> main
@@ -370,7 +370,7 @@ app-irr2 {Γ} A B c p a q q'  =
 
 
 
-app-cong-raw :  {Γ : ctx} 
+app-cong-raw :  {Γ : ctx}
     -> (A : ty Γ)  -> (B : ty (Γ ▷ A))
     -> (c c' : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -391,20 +391,20 @@ app-cong-raw {Γ} A B c c' p p' r a a' q q' t =
 
 
 
-app-irr :  {Γ : ctx} 
+app-irr :  {Γ : ctx}
     -> (A : ty Γ)  -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p p' : Γ ==> c :: Π-f {Γ} A B)
     -> (a : raw Γ)
     -> (q q' : Γ ==> a :: A)
     -> << Raw Γ >>  app A B c p a q ~ app A B c p' a q'
-app-irr {Γ} A B c p p' a q q' = 
+app-irr {Γ} A B c p p' a q q' =
     let lm1 : << Raw Γ >>  app A B c p a q ~ app A B c p' a q
         lm1 = app-irr1 {Γ} A B c p p' a q
         lm2 : << Raw Γ >>  app A B c p' a q ~ app A B c p' a q'
         lm2 = app-irr2 {Γ} A B c p' a q q'
     in tra' lm1 lm2
-  
+
 
 {--
 
@@ -415,7 +415,7 @@ app-irr {Γ} A B c p p' a q q' =
 -- Pi-elimination
 
 
-Π-e :  {Γ : ctx} 
+Π-e :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -440,7 +440,7 @@ app-irr {Γ} A B c p p' a q q' =
 
 
 
-Π-e-cong :  {Γ : ctx} 
+Π-e-cong :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c c' : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -452,28 +452,28 @@ app-irr {Γ} A B c p p' a q q' =
     -> (Γ ==> a == a' :: A)
 --  -----------------------------------------
     ->  Γ ==> app A B c p a q == app A B c' p' a' q'  :: B [[ els q ]]
-Π-e-cong {Γ} A B c c' p p' p'' a a' q q' q'' = 
+Π-e-cong {Γ} A B c c' p p' p'' a a' q q' q'' =
    let rm = >><< (app-cong-raw {Γ} A B c c' p p' p'' a a' q q' q'')
    in
-       pair (λ x → >><< (>><< rm x))  
-            (pair (Π-e A B c p a q) 
+       pair (λ x → >><< (>><< rm x))
+            (pair (Π-e A B c p a q)
                   (elttyeq  (Π-e A B c' p' a' q')  (tyeq-subst2 B (els q') (els q) (els-cong q' q  (tmsym _ _ _ q'')))))
 
 
 
 -- towards the beta-rule
 
-Π-beta-raw :  {Γ : ctx} 
+Π-beta-raw :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
        -> (p : Γ ▷ A ==> b :: B)
        -> (a : raw Γ)
        -> (q : Γ ==> a :: A)
        -> (x : || κ Γ ||)
-       ->  apr (app A B (lambda A B b) (Π-i A {B} {b} p) a q)  x ≐  apr (b [ els q ]) x  
-Π-beta-raw {Γ} A B b p a q x = 
+       ->  apr (app A B (lambda A B b) (Π-i A {B} {b} p) a q)  x ≐  apr (b [ els q ]) x
+Π-beta-raw {Γ} A B b p a q x =
       let  lm1 : Γ ==> b [ els q ] :: B [[ els q ]]
-           lm1 = elt-subst (els q) p 
+           lm1 = elt-subst (els q) p
            lm1x : apr (b [ ext-el {Γ} A a q ]) x ∈ (apt (B [[ els q ]]) x)
            lm1x = apel lm1 x
            beq = pj2 lm1x
@@ -488,22 +488,22 @@ app-irr {Γ} A B c p p' a q q' =
 
 
 
-Π-beta :  {Γ : ctx} 
+Π-beta :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
        -> (p : Γ ▷ A ==> b :: B)
        -> (a : raw Γ)
        -> (q : Γ ==> a :: A)
 --  -----------------------------------------
-       ->  Γ ==> app A B (lambda A B b) (Π-i A {B} {b} p) a q  
+       ->  Γ ==> app A B (lambda A B b) (Π-i A {B} {b} p) a q
              ==  b [ els q ] :: B [[ els q ]]
-Π-beta A B b p a q = pair (Π-beta-raw A B b p a q) 
+Π-beta A B b p a q = pair (Π-beta-raw A B b p a q)
                             (pair (Π-e A B (lambda A B b) (Π-i A {B} {b} p) a q)
                                   (elt-subst (els q) p ))
 
 
 
-Π-beta-gen :  {Γ : ctx} 
+Π-beta-gen :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (b : raw (Γ ▷ A))
        -> (p : Γ ▷ A ==> b :: B)
@@ -511,19 +511,18 @@ app-irr {Γ} A B c p p' a q q' =
        -> (a : raw Γ)
        -> (q : Γ ==> a :: A)
 --  -----------------------------------------
-       ->  Γ ==> app A B (lambda A B b) r a q  
+       ->  Γ ==> app A B (lambda A B b) r a q
              ==  b [ els q ] :: B [[ els q ]]
-Π-beta-gen {Γ} A B b p r a q = 
-   let lm :  Γ ==> app A B (lambda A B b) (Π-i A {B} {b} p) a q  
+Π-beta-gen {Γ} A B b p r a q =
+   let lm :  Γ ==> app A B (lambda A B b) (Π-i A {B} {b} p) a q
              ==  b [ els q ] :: B [[ els q ]]
        lm = Π-beta A B b p a q
-       lm2 : << Raw Γ >> (app A B (lambda A B b) r a q)  ~ (app A B (lambda A B b) (Π-i A {B} {b} p) a q) 
+       lm2 : << Raw Γ >> (app A B (lambda A B b) r a q)  ~ (app A B (lambda A B b) (Π-i A {B} {b} p) a q)
        lm2 = app-irr A B (lambda A B b) r (Π-i A {B} {b} p) a q q
-   in pair (λ x → traV (>><< (>><< (>><< lm2) x)) ((prj1 lm) x)) 
-           (pair (mk-elt (λ x →  memV-left-ext (apr (app A B (lambda A B b) r a q) x) 
+   in pair (λ x → traV (>><< (>><< (>><< lm2) x)) ((prj1 lm) x))
+           (pair (mk-elt (λ x →  memV-left-ext (apr (app A B (lambda A B b) r a q) x)
                                                 (apr (app A B (lambda A B b) (Π-i A {B} {b} p) a q) x) (apt (B [[ els q ]]) x)
-                                                 (>><< (>><< (>><< lm2) x)) 
-                                                 (apel (prj1 (prj2 lm)) x))) 
+                                                 (>><< (>><< (>><< lm2) x))
+                                                 (apel (prj1 (prj2 lm)) x)))
                  (prj2 (prj2 lm)))
-
 

--- a/MLTT-and-setoids/V-model-pt4.agda
+++ b/MLTT-and-setoids/V-model-pt4.agda
@@ -23,45 +23,45 @@ open import V-model-pt3
 
 -- towards the more general congruence for Pi-formation
 
--- 
+--
 
 
 
-mk-Par-eq-right :  {Γ : ctx} 
+mk-Par-eq-right :  {Γ : ctx}
     -> (A : ty Γ)   -> (B C : ty (Γ ▷ A))
-    ->  Γ ▷ A ==>  B ==  C 
+    ->  Γ ▷ A ==>  B ==  C
     -> (x : || κ Γ ||)
     -> (y : || κ-Fam §§ Ixx (ap1 (mk-Par A B) x) ||)
     -> Fxx (ap1 (mk-Par A C) x) •  ap (κ-Fam ±± (<<>> (refV (apt A x)))) y
       ≐ apt C (x , y)
-mk-Par-eq-right  {Γ} A B C p x y  = 
-  let lm : << VV >> apt C (x , ap (κ-Fam ±± (<<>> (refV (apt A x)))) y) 
+mk-Par-eq-right  {Γ} A B C p x y  =
+  let lm : << VV >> apt C (x , ap (κ-Fam ±± (<<>> (refV (apt A x)))) y)
             ~
            apt C (x , y)
-      lm = extensionality1 (ty.type C) 
-                    (x , ap (κ-Fam ±± (<<>> (refV (apt A x)))) y) 
+      lm = extensionality1 (ty.type C)
+                    (x , ap (κ-Fam ±± (<<>> (refV (apt A x)))) y)
                     (x , y)
-              (<> (pairV-ext (refV (Γ ‣ x)) (symV (e+prop (refV (apt A x)) y)))) 
+              (<> (pairV-ext (refV (Γ ‣ x)) (symV (e+prop (refV (apt A x)) y))))
   in >><< lm
-  
 
 
-mk-Par-eq :  {Γ : ctx} 
+
+mk-Par-eq :  {Γ : ctx}
     -> (A : ty Γ)   -> (B C : ty (Γ ▷ A))
-    ->  Γ ▷ A ==>  B ==  C 
+    ->  Γ ▷ A ==>  B ==  C
     -> (x : || κ Γ ||)
     ->  << Par VV κ-Fam >> (ap1 (mk-Par A B) x) ~ (ap1 (mk-Par A C) x)
 mk-Par-eq  A B C p x  =
-   <<>> (( <<>> (refV _) ) , ((λ y → <<>> (traV (>><< (ape p (x , y))) (symV (mk-Par-eq-right  A B C p x y )))))) 
+   <<>> (( <<>> (refV _) ) , ((λ y → <<>> (traV (>><< (ape p (x , y))) (symV (mk-Par-eq-right  A B C p x y ))))))
 
 
 
-Π-cong-lm2 :  {Γ : ctx} 
+Π-cong-lm2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B C : ty (Γ ▷ A))
-    ->  Γ ▷ A ==>  B ==  C 
+    ->  Γ ▷ A ==>  B ==  C
     -> (x : || κ Γ ||)
     ->  << VV >> piV-op (ap1 (mk-Par A B) x) ~ piV-op (ap1 (mk-Par A C) x)
-Π-cong-lm2  A B C p x  = 
+Π-cong-lm2  A B C p x  =
      let lm : << Par VV κ-Fam >> (ap1 (mk-Par A B) x) ~ (ap1 (mk-Par A C) x)
          lm = (mk-Par-eq A B C p x)
          main : << VV >> piV-op (ap1 (mk-Par A B) x) ~ piV-op (ap1 (mk-Par A C) x)
@@ -69,21 +69,21 @@ mk-Par-eq  A B C p x  =
      in main
 
 
-Π-cong-lm :  {Γ : ctx} 
+Π-cong-lm :  {Γ : ctx}
     -> (A : ty Γ) -> (B C : ty (Γ ▷ A))
-    ->  Γ ▷ A ==>  B ==  C 
+    ->  Γ ▷ A ==>  B ==  C
     -> (x : || κ Γ ||)
     ->  << VV >> apt (Π-f A B) x ~ (apt (Π-f A C) x)
 Π-cong-lm A B C p x = Π-cong-lm2 A B C p x
 
 
 
-Π-cong :  {Γ : ctx} 
+Π-cong :  {Γ : ctx}
     -> (A : ty Γ)   -> (B C : ty (Γ ▷ A))
-     ->  Γ ▷ A ==>  B ==  C 
+     ->  Γ ▷ A ==>  B ==  C
 -- ------------------------------------
-    ->  Γ ==>  Π-f A B ==  Π-f A C 
--- 
+    ->  Γ ==>  Π-f A B ==  Π-f A C
+--
 Π-cong A B C p  = mk-eqty (λ x → Π-cong-lm A B C p x)
 
 
@@ -94,15 +94,15 @@ mk-Par-eq  A B C p x  =
 -- towards substitution rules for Pi
 
 
-mk-Par-sub-lm :  {Δ Γ : ctx} 
-       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ) 
+mk-Par-sub-lm :  {Δ Γ : ctx}
+       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ)
        -> (u : || κ Δ ||)
        -> (x : || κ-Fam §§ Ixx (ap1 (mk-Par A B) (aps h u)) ||)
        -> << VV >> Fxx (ap1 (mk-Par A B) (aps h u)) • x ~
            (Fxx (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) u) •
-            ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x)      
-mk-Par-sub-lm {Δ} {Γ} A B h u x 
-        = let 
+            ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x)
+mk-Par-sub-lm {Δ} {Γ} A B h u x
+        = let
               lm4 :  Γ ‣ (aps h u) ≐
                    Γ ‣  aps (h ⌢ ↓ (A [[ h ]]))
                            (u , ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x)
@@ -115,13 +115,13 @@ mk-Par-sub-lm {Δ} {Γ} A B h u x
               lm3-5 = refV (apt A  (aps h u))
 
               lm3-6 = elttyeq-lm  (asm (A [[ h ]]))
-                                  (tyeq-from-eq 
+                                  (tyeq-from-eq
                                     ((A [[ h ]]) [[ pp (A [[ h ]]) ]])
                                     (A [[ h ⌢ pp (A [[ h ]]) ]])
-                                    (Sub-comp-prop-sym {(Δ ▷ (A [[ h ]]))} {Δ} {Γ} A h ( ↓ (A [[ h ]]))) 
+                                    (Sub-comp-prop-sym {(Δ ▷ (A [[ h ]]))} {Δ} {Γ} A h ( ↓ (A [[ h ]])))
                                     )
                                   (u , ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x)
-             
+
 
               lm3-7 :  (apt A  (pj1 (aps (↑ A h)
                               (u ,  ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x))))
@@ -133,12 +133,12 @@ mk-Par-sub-lm {Δ} {Γ} A B h u x
                                           ‣
                                             (pj2
                                           (aps
-                                            (↑ A 
+                                            (↑ A
                                              h)
                                            (u , ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x)))
-              lm3-7 = traV (refV _) lm3-6 
+              lm3-7 = traV (refV _) lm3-6
 
-                       
+
               lm3 : (apt A (aps h u)) ‣ x
                  ≐ (apt A  (pj1 (aps (↑ A h)
                               (u ,  ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x))))
@@ -148,14 +148,14 @@ mk-Par-sub-lm {Δ} {Γ} A B h u x
                              (u , ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x))
 
 
-              lm3 = traV 
+              lm3 = traV
                    (e+prop
                    {apt A (aps h u)}
                    {apt A  (pj1 (aps (↑ A h)
                               (u ,  ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x)))}
                    lm3-5 x)
                     lm3-7
-                    
+
 
 
 
@@ -164,19 +164,19 @@ mk-Par-sub-lm {Δ} {Γ} A B h u x
                                     (u , ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x)
 
               lm2 = <> (pairV-ext lm4 lm3)
-              lm : << VV >> apt B ((aps h u) , x) 
+              lm : << VV >> apt B ((aps h u) , x)
                           ~ apt (B [[ ↑ A h ]]) (u ,  (ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x))
-              lm = extensionality1 (ty.type B) 
-                                   (aps h u , x) 
-                                   (aps (↑ A h)  (u , ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x)) 
+              lm = extensionality1 (ty.type B)
+                                   (aps h u , x)
+                                   (aps (↑ A h)  (u , ap (κ-Fam ±± (<<>> (refV (apt A (aps h u))))) x))
                                    lm2
           in lm
 
 
 
 
-mk-Par-sub :  {Δ Γ : ctx} 
-       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ) 
+mk-Par-sub :  {Δ Γ : ctx}
+       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ)
        -> (u : || κ Δ ||)
        -> << Par VV κ-Fam >> (ap1 (mk-Par A B) (aps h u)) ~ (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]]) ) u)
 mk-Par-sub {Δ} {Γ} A B h u = <<>> ( (<<>> (refV (apt A (aps h u)))) , (λ x → mk-Par-sub-lm {Δ} {Γ} A B h u x))
@@ -186,17 +186,17 @@ mk-Par-sub {Δ} {Γ} A B h u = <<>> ( (<<>> (refV (apt A (aps h u)))) , (λ x �
 -- substituting into a Pi-type
 
 
-Π-f-sub :  {Δ Γ : ctx} 
+Π-f-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ) 
+       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ)
 --     ---------------------------------------
-       -> Δ ==>  (Π-f A B) [[ h ]] ==  Π-f (A [[ h ]]) (B [[ ↑ A h ]]) 
+       -> Δ ==>  (Π-f A B) [[ h ]] ==  Π-f (A [[ h ]]) (B [[ ↑ A h ]])
 Π-f-sub {Δ} {Γ} A B h = mk-eqty (\u ->
-    let lm :  << VV >> ap11 piVV (ap1 (mk-Par A B) (aps h u)) ~ 
-                      ap11 piVV (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]]) ) u) 
-        lm = extensionality11 piVV 
-                              (ap1 (mk-Par A B) (aps h u)) 
-                              (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) u) 
+    let lm :  << VV >> ap11 piVV (ap1 (mk-Par A B) (aps h u)) ~
+                      ap11 piVV (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]]) ) u)
+        lm = extensionality11 piVV
+                              (ap1 (mk-Par A B) (aps h u))
+                              (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) u)
                               (mk-Par-sub {Δ} {Γ} A B h u)
     in lm)
 
@@ -205,20 +205,20 @@ mk-Par-sub {Δ} {Γ} A B h u = <<>> ( (<<>> (refV (apt A (aps h u)))) , (λ x �
 
 -- towards substitution rules for lambda
 
-lambda-sub-raw  :  {Δ Γ : ctx} 
+lambda-sub-raw  :  {Δ Γ : ctx}
        -> (A : ty Γ)   -> {B : ty (Γ ▷ A)}
        -> {b : raw (Γ ▷ A)}
        -> (h : subst Δ Γ)
        -> Γ ▷ A ==> b :: B
-       -> (x : || κ Δ ||) 
+       -> (x : || κ Δ ||)
        -> apr (lambda A B b [ h ]) x ≐ apr (lambda (A [[ h ]]) (B [[ ↑ A h ]]) (b [ ↑ A h ])) x
-lambda-sub-raw {Δ} {Γ} A {B} {b} h p x = 
-    easy-eqV _ _ _ (\y -> pairV-ext (refV _) (symV (traV (sub-apply b ( ↑ A h ) (x , y)) 
+lambda-sub-raw {Δ} {Γ} A {B} {b} h p x =
+    easy-eqV _ _ _ (\y -> pairV-ext (refV _) (symV (traV (sub-apply b ( ↑ A h ) (x , y))
                  (>><< (extensionality1 (raw.rawterm b) _ _ (qq-eq A h x y))))))
- 
 
 
-lambda-sub  :  {Δ Γ : ctx} 
+
+lambda-sub  :  {Δ Γ : ctx}
        -> (A : ty Γ)   -> {B : ty (Γ ▷ A)}
        -> {b : raw (Γ ▷ A)}
        -> (h : subst Δ Γ)
@@ -227,5 +227,5 @@ lambda-sub  :  {Δ Γ : ctx}
        -> Δ ==> (lambda A B b) [ h ] == (lambda (A [[ h ]]) (B [[ ↑ A h ]]) (b [ ↑ A h ]))  :: (Π-f A B) [[ h ]]
 lambda-sub {Δ} {Γ} A {B} {b} h p = pair (lambda-sub-raw {Δ} {Γ} A {B} {b} h p)
                                         (pair (elt-subst {Δ} {Γ} {lambda A B b} {Π-f A B} h (Π-i {Γ} A {B} {b} p))
-                                             (elttyeq {Δ} (Π-i (A [[ h ]]) {B [[ ↑ A h ]]} {(b [ ↑ A h ])}  
+                                             (elttyeq {Δ} (Π-i (A [[ h ]]) {B [[ ↑ A h ]]} {(b [ ↑ A h ])}
                                                                (elt-subst  (↑ A h) p)) (tysym (Π-f-sub A B h)) ))

--- a/MLTT-and-setoids/V-model-pt5-mod.agda
+++ b/MLTT-and-setoids/V-model-pt5-mod.agda
@@ -24,16 +24,16 @@ open import V-model-pt4
 
 -- towards verifying extensional Pi-axioms
 
-Π-extensionality-prop :  {Γ : ctx} 
+Π-extensionality-prop :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (u y :  # (apt A  x))
     -> (q : < κ (apt A x) > u ~ y)
-    ->  < κ (apt B (x , y)) >  
-           ap (κ-Fam ±±  (extensionality1 (ty.type B) (x , u) (x , y) (<> (pairV-ext (refV _) (>< q))))) 
-              (pj1 (pj1 (apel p x)) u) 
+    ->  < κ (apt B (x , y)) >
+           ap (κ-Fam ±±  (extensionality1 (ty.type B) (x , u) (x , y) (<> (pairV-ext (refV _) (>< q)))))
+              (pj1 (pj1 (apel p x)) u)
               ~
               pj1 (pj1 (apel p x)) y
 Π-extensionality-prop {Γ} A B c p x u y q =  pj2 (pj1 (apel p x)) u y q
@@ -42,7 +42,7 @@ open import V-model-pt4
 
 
 
-Π-eta-aux-lm :  {Γ : ctx} 
+Π-eta-aux-lm :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
@@ -53,7 +53,7 @@ open import V-model-pt4
 
 
 
-Π-eta-aux-lm2 :  {Γ : ctx} 
+Π-eta-aux-lm2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
@@ -65,17 +65,17 @@ open import V-model-pt4
 
 
 
-Π-ext3 : {Γ : ctx} 
+Π-ext3 : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
     -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
-    ->  || κ (apt B (x , y)) ||   
+    ->  || κ (apt B (x , y)) ||
 Π-ext3 {Γ} A B c p x y = pj1 (pj1 (apel p x)) y
 
 
-Π-ext2b : {Γ : ctx} 
+Π-ext2b : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c d : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
@@ -83,19 +83,19 @@ open import V-model-pt4
     -> ((x : || κ Γ ||) -> (y : || κ (apt A x) ||) -> < κ (apt B (x , y)) > pj1 (pj1 (apel p x)) y ~ pj1 (pj1 (apel q x)) y)
     -> (x : || κ Γ ||)
     -> apr c x ≐ apr d x
-Π-ext2b {Γ} A B c d p q r x = 
+Π-ext2b {Γ} A B c d p q r x =
     let lm1 : apr c x ≐ apt (Π-f A B) x ‣ pj1 (apel p x)
         lm1 = pj2 (apel p x)
         lm2 : apr d x ≐ apt (Π-f A B) x ‣ pj1 (apel q x)
         lm2 = pj2 (apel q x)
         lm3 : apt (Π-f A B) x ‣ pj1 (apel p x) ≐ apt (Π-f A B) x ‣ pj1 (apel q x)
-        lm3 = Π-f-exp6 A B x (pj1 (apel p x)) (pj1 (apel q x)) (\ y -> (>< (r x y))) 
+        lm3 = Π-f-exp6 A B x (pj1 (apel p x)) (pj1 (apel q x)) (\ y -> (>< (r x y)))
     in traV lm1 (traV lm3 (symV lm2))
 
 
 
 
-Π-ext2 : {Γ : ctx} 
+Π-ext2 : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c d : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
@@ -106,266 +106,266 @@ open import V-model-pt4
 
 
 
-Π-ext-eq3-lm :  {Γ : ctx} 
+Π-ext-eq3-lm :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
-   ->  (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣ 
-                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+   ->  (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣
+                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y))
        ≐  (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
-Π-ext-eq3-lm {Γ} A B c p x y = 
+Π-ext-eq3-lm {Γ} A B c p x y =
    let eq : < κ (apt A x) > (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y) ~ y
        eq = κ-trp-id (>><< (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y
- 
-       eq3 = Π-f-exp3b A B x (pj1 (apel p x)) y (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+
+       eq3 = Π-f-exp3b A B x (pj1 (apel p x)) y (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y) (symV (>< eq))
-      
+
    in symV eq3
 
 
 
-Π-ext-eq4 :  {Γ : ctx} 
+Π-ext-eq4 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
     ->  (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y)) ‣
-                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) 
-                                        ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y))
+                                        ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)))
-                                
+
                ≐
-             (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣ 
-                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+             (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣
+                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y))
 
-Π-ext-eq4 {Γ} A B c p x y = symV (e+prop (>><< (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+Π-ext-eq4 {Γ} A B c p x y = symV (e+prop (>><< (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y)) ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)) )
 
 
 
 
-Π-ext-eq3 :  {Γ : ctx} 
+Π-ext-eq3 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
     -> (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣
-                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) 
-                                        ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y))
+                                        ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)))
-                                
+
                ≐  (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
-Π-ext-eq3 {Γ} A B c p x y = 
-  let lm1  :  (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣ 
-                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+Π-ext-eq3 {Γ} A B c p x y =
+  let lm1  :  (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣
+                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y))
              ≐  (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
       lm1 = Π-ext-eq3-lm {Γ} A B c p x y
 
       lm2 : (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y)) ‣
-                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) 
-                                        ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y))
+                                        ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)))
-                                
+
                ≐
-             (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣ 
-                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+             (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣
+                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y))
       lm2 = Π-ext-eq4 {Γ} A B c p x y
 
       main : (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y)) ‣
-                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) 
-                                        ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y))
+                                        ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)))
-                                
+
                ≐  (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
       main = traV lm2 lm1
   in main
 
 
 
-Π-ext-eq2 :  {Γ : ctx} 
+Π-ext-eq2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
-    ->  (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣  
-                      (pj1 
+    ->  (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣
+                      (pj1
                          (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y))) (pj1 (apel p x)))
                          y)
         ≐ (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
-Π-ext-eq2 {Γ} A B c p x y = Π-ext-eq3 {Γ} A B c p x y 
+Π-ext-eq2 {Γ} A B c p x y = Π-ext-eq3 {Γ} A B c p x y
 
 
 
 -- Here is a detour we take to try solve some performance issues of Agda regarding unification
 
-Π-ext-eq1b :  {Γ : ctx} 
+Π-ext-eq1b :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
-    ->         (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+    ->         (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))) (pj1 (apel (asm A) (x , y)))))
                ≐
-              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
-Π-ext-eq1b {Γ} A B c p x y  = 
-   let lm = pj2 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+Π-ext-eq1b {Γ} A B c p x y  =
+   let lm = pj2 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))
-       lm1 :  (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+       lm1 :  (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))) (pj1 (apel (asm A) (x , y)))))
                ≐
-              (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
+              (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
               (pj1 (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y)))
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
        lm1 = refV _
 
        tst : apt (Π-f A B [[ ↓ A ]]) (x , y) ≐ apt (Π-f (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y)
         --  tst = (>><< (ape (Π-f-sub A B (↓ A)) (x , y)))
-       {-- tst =     >><<    (extensionality11 piVV 
-                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))) 
-                              (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)) 
+       {-- tst =     >><<    (extensionality11 piVV
+                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))
+                              (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))
                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y))) --}
-   {--    tst =     >><<    (piV-ext 
-                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))) 
-                              (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)) 
+   {--    tst =     >><<    (piV-ext
+                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))
+                              (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))
                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y)))
    --}
-       tst =     (extensional-eqV (piV-op (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))) 
-                                  (piV-op (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))) 
-                                  (piV-half-ext (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))) 
-                                             (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)) 
-                                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y)))  
-                                  (piV-half-ext (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)) 
-                                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))) 
+       tst =     (extensional-eqV (piV-op (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))))
+                                  (piV-op (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)))
+                                  (piV-half-ext (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))
+                                             (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))
+                                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y)))
+                                  (piV-half-ext (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))
+                                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))
                                               (sym' {Par VV κ-Fam}
                                                    {(ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))}
-                                                   {(ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))} 
+                                                   {(ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))}
                                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y)))))
 
 
-       lm2 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
+       lm2 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
               (pj1 (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y)))
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
               ≐
-             (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (e+ tst 
+             (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (e+ tst
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
        lm2 = refV _ --  refV _
- 
-       lm4 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (e+ tst 
+
+       lm4 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (e+ tst
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
                ≐
-              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
        lm4 = refV _
- 
-       lm3 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
+
+       lm3 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
               (pj1 (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y)))
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
               ≐
-              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
-       lm3 =  traV (refV _) lm4 -- refV _  
+       lm3 =  traV (refV _) lm4 -- refV _
 
    in  traV lm1 lm3 --  (traV lm1 lm3)
 
 {--
 
-Π-ext-eq1 :  {Γ : ctx} 
+Π-ext-eq1 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
     -> apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A)) (x , y) ≐
-       (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣  
-                      (pj1 
+       (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣
+                      (pj1
                          (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y))) (pj1 (apel p x)))
                          y)
 Π-ext-eq1 {Γ} A B c p x y  =
   let lm : apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A)) (x , y) ≐
-           (apt  (B [[ ↑ A (↓ A) ]]) ((x , y) , 
-            (pj1 (apel (asm A) (x , y)))) ‣ 
+           (apt  (B [[ ↑ A (↓ A) ]]) ((x , y) ,
+            (pj1 (apel (asm A) (x , y)))) ‣
               (pj1 (pj1 (apel (Π-eta-aux-lm A B c p) (x , y))) (pj1 (apel (asm A) (x , y)))))
       lm = refV _
-      lm0 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
+      lm0 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
               (pj1 (pj1 (apel (Π-eta-aux-lm {Γ} A B c p) (x , y))) (pj1 (apel (asm A) (x , y)))))  ≐
-            (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+            (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))) (pj1 (apel (asm A) (x , y)))))
       lm0 = refV _
-      lm05 : apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+      lm05 : apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
                ≐
              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
-              piV-ext00 {(ap1 (mk-Par A B) (aps (↓ A) (x , y)))} 
+              piV-ext00 {(ap1 (mk-Par A B) (aps (↓ A) (x , y)))}
                         {(ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y))}  (mk-Par-sub A B (↓ A) (x , y))
               (pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y)))) y
       lm05 = refV _
 
 
-      lm08 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+      lm08 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))) (pj1 (apel (asm A) (x , y)))))
                ≐
-              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
-      lm08 =  Π-ext-eq1b {Γ} A B c p x y 
+      lm08 =  Π-ext-eq1b {Γ} A B c p x y
 
 
 
-      lm1 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (Π-eta-aux-lm {Γ} A B c p) (x , y))) (pj1 (apel (asm A) (x , y)))))  ≐ 
+      lm1 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (Π-eta-aux-lm {Γ} A B c p) (x , y))) (pj1 (apel (asm A) (x , y)))))  ≐
              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
-              piV-ext00 {(ap1 (mk-Par A B) (aps (↓ A) (x , y)))} 
+              piV-ext00 {(ap1 (mk-Par A B) (aps (↓ A) (x , y)))}
                         {(ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y))}  (mk-Par-sub A B (↓ A) (x , y))
               (pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y)))) y
       lm1 = traV lm0  (traV lm08 lm05) -- refV _  works too, but also unifies very slowly
@@ -380,27 +380,27 @@ open import V-model-pt4
       lm2 = refV _
       lm3 :  apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
                piV-ext00 (mk-Par-sub A B (↓ A) (x , y)) (pj1 (pj1 (apel p x))) y  ≐
-            (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣  
-                      (pj1 
+            (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣
+                      (pj1
                          (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y))) (pj1 (apel p x)))
                          y)
       lm3 = refV _
-      
-      
-  in traV lm (traV (traV lm1 lm2) lm3) 
+
+
+  in traV lm (traV (traV lm1 lm2) lm3)
 
 --  refV _ -- works too, but also unifies very slowly
 
 
-Π-ext-eq :  {Γ : ctx} 
+Π-ext-eq :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
-    -> (y : || κ (apt A x) ||) 
+    -> (x : || κ Γ ||)
+    -> (y : || κ (apt A x) ||)
     -> apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A)) (x , y) ≐
              ((apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y))
-             
+
 Π-ext-eq {Γ} A B c p x y =  traV (Π-ext-eq1 {Γ} A B c p x y) (Π-ext-eq2 {Γ} A B c p x y)
 
  --  Π-ext-eq2 {Γ} A B c p x y -- works as well, but unifies very slowly too
@@ -408,27 +408,27 @@ open import V-model-pt4
 
 
 
-Π-ext : {Γ : ctx} 
+Π-ext : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c d : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
     -> (q : Γ ==> d :: Π-f A B)
     ->  (Γ ▷ A ==> app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A) ==
-                   app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (d [ ↓ A ]) (Π-eta-aux-lm A B d q) (vv A) (asm A) 
+                   app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (d [ ↓ A ]) (Π-eta-aux-lm A B d q) (vv A) (asm A)
               :: (B [[ ↑ A (↓ A) ]])  [[ els (asm A) ]])
     -> (Γ ==> c == d :: Π-f A B)
-Π-ext {Γ} A B c d p q r = 
+Π-ext {Γ} A B c d p q r =
  let lm : (x : || κ Γ ||) -> (y : || κ (apt A x) ||) ->
             < κ (apt B (x , y)) > pj1 (pj1 (apel p x)) y ~
                                   pj1 (pj1 (apel q x)) y
-     
+
      lm = λ x y →
         let  lm2 : apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A)) (x , y) ≐
                    apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (d [ ↓ A ]) (Π-eta-aux-lm A B d q) (vv A) (asm A)) (x , y)
              lm2 = (prj1 r) (x , y)
              main : < κ (apt B (x , y)) > pj1 (pj1 (apel p x)) y ~  pj1 (pj1 (apel q x)) y
              main = <> (traV (symV (Π-ext-eq A B c p x y)) (traV lm2 (Π-ext-eq A B d q x y)))
-        in main        
+        in main
  in Π-ext2 A B c d p q lm
 
 

--- a/MLTT-and-setoids/V-model-pt5.agda
+++ b/MLTT-and-setoids/V-model-pt5.agda
@@ -24,16 +24,16 @@ open import V-model-pt4
 
 -- towards verifying extensional Pi-axioms
 
-Π-extensionality-prop :  {Γ : ctx} 
+Π-extensionality-prop :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (u y :  # (apt A  x))
     -> (q : < κ (apt A x) > u ~ y)
-    ->  < κ (apt B (x , y)) >  
-           ap (κ-Fam ±±  (extensionality1 (ty.type B) (x , u) (x , y) (<> (pairV-ext (refV _) (>< q))))) 
-              (pj1 (pj1 (apel p x)) u) 
+    ->  < κ (apt B (x , y)) >
+           ap (κ-Fam ±±  (extensionality1 (ty.type B) (x , u) (x , y) (<> (pairV-ext (refV _) (>< q)))))
+              (pj1 (pj1 (apel p x)) u)
               ~
               pj1 (pj1 (apel p x)) y
 Π-extensionality-prop {Γ} A B c p x u y q =  pj2 (pj1 (apel p x)) u y q
@@ -42,7 +42,7 @@ open import V-model-pt4
 
 
 
-Π-eta-aux-lm :  {Γ : ctx} 
+Π-eta-aux-lm :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
@@ -53,7 +53,7 @@ open import V-model-pt4
 
 
 
-Π-eta-aux-lm2 :  {Γ : ctx} 
+Π-eta-aux-lm2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
@@ -65,17 +65,17 @@ open import V-model-pt4
 
 
 
-Π-ext3 : {Γ : ctx} 
+Π-ext3 : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
     -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
-    ->  || κ (apt B (x , y)) ||   
+    ->  || κ (apt B (x , y)) ||
 Π-ext3 {Γ} A B c p x y = pj1 (pj1 (apel p x)) y
 
 
-Π-ext2b : {Γ : ctx} 
+Π-ext2b : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c d : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
@@ -83,19 +83,19 @@ open import V-model-pt4
     -> ((x : || κ Γ ||) -> (y : || κ (apt A x) ||) -> < κ (apt B (x , y)) > pj1 (pj1 (apel p x)) y ~ pj1 (pj1 (apel q x)) y)
     -> (x : || κ Γ ||)
     -> apr c x ≐ apr d x
-Π-ext2b {Γ} A B c d p q r x = 
+Π-ext2b {Γ} A B c d p q r x =
     let lm1 : apr c x ≐ apt (Π-f A B) x ‣ pj1 (apel p x)
         lm1 = pj2 (apel p x)
         lm2 : apr d x ≐ apt (Π-f A B) x ‣ pj1 (apel q x)
         lm2 = pj2 (apel q x)
         lm3 : apt (Π-f A B) x ‣ pj1 (apel p x) ≐ apt (Π-f A B) x ‣ pj1 (apel q x)
-        lm3 = Π-f-exp6 A B x (pj1 (apel p x)) (pj1 (apel q x)) (\ y -> (>< (r x y))) 
+        lm3 = Π-f-exp6 A B x (pj1 (apel p x)) (pj1 (apel q x)) (\ y -> (>< (r x y)))
     in traV lm1 (traV lm3 (symV lm2))
 
 
 
 
-Π-ext2 : {Γ : ctx} 
+Π-ext2 : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c d : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
@@ -106,251 +106,251 @@ open import V-model-pt4
 
 
 
-Π-ext-eq3-lm :  {Γ : ctx} 
+Π-ext-eq3-lm :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
-   ->  (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣ 
-                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+   ->  (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣
+                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y))
        ≐  (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
-Π-ext-eq3-lm {Γ} A B c p x y = 
+Π-ext-eq3-lm {Γ} A B c p x y =
    let eq : < κ (apt A x) > (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y) ~ y
        eq = κ-trp-id (>><< (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y
- 
-       eq3 = Π-f-exp3b A B x (pj1 (apel p x)) y (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+
+       eq3 = Π-f-exp3b A B x (pj1 (apel p x)) y (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y) (symV (>< eq))
-      
+
    in symV eq3
 
 
 
-Π-ext-eq4 :  {Γ : ctx} 
+Π-ext-eq4 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
     ->  (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y)) ‣
-                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) 
-                                        ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y))
+                                        ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)))
-                                
+
                ≐
-             (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣ 
-                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+             (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣
+                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y))
 
-Π-ext-eq4 {Γ} A B c p x y = symV (e+prop (>><< (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+Π-ext-eq4 {Γ} A B c p x y = symV (e+prop (>><< (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y)) ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)) )
 
 
 
 
-Π-ext-eq3 :  {Γ : ctx} 
+Π-ext-eq3 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
     -> (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣
-                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) 
-                                        ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y))
+                                        ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)))
-                                
+
                ≐  (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
-Π-ext-eq3 {Γ} A B c p x y = 
-  let lm1  :  (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣ 
-                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+Π-ext-eq3 {Γ} A B c p x y =
+  let lm1  :  (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣
+                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y))
              ≐  (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
       lm1 = Π-ext-eq3-lm {Γ} A B c p x y
 
       lm2 : (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y)) ‣
-                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) 
-                                        ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y))
+                                        ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)))
-                                
+
                ≐
-             (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣ 
-                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+             (apt B (x , (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps (↓ A) (x , y))))))) y))) ‣
+                ((pj1 (pj1 (apel p x))) (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y))
       lm2 = Π-ext-eq4 {Γ} A B c p x y
 
       main : (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y)) ‣
-                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
+                                      (ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
                                                              (ap1 (mk-Par (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y))
-                                                             (mk-Par-sub A B (↓ A) (x , y)) 
-                                                            y)) 
-                                        ((pj1 (pj1 (apel p x))) 
-                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) 
+                                                             (mk-Par-sub A B (↓ A) (x , y))
+                                                            y))
+                                        ((pj1 (pj1 (apel p x)))
+                                         (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y))))))
                                              y)))
-                                
+
                ≐  (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
       main = traV lm2 lm1
   in main
 
 
 
-Π-ext-eq2 :  {Γ : ctx} 
+Π-ext-eq2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
-    ->  (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣  
-                      (pj1 
+    ->  (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣
+                      (pj1
                          (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y))) (pj1 (apel p x)))
                          y)
         ≐ (apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y)
-Π-ext-eq2 {Γ} A B c p x y = Π-ext-eq3 {Γ} A B c p x y 
+Π-ext-eq2 {Γ} A B c p x y = Π-ext-eq3 {Γ} A B c p x y
 
 -- Here is a detour we take to try solve some performance issues of Agda regarding unification
 
-Π-ext-eq1b :  {Γ : ctx} 
+Π-ext-eq1b :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
-    ->         (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+    ->         (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))) (pj1 (apel (asm A) (x , y)))))
                ≐
-              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
-Π-ext-eq1b {Γ} A B c p x y  = 
-   let lm = pj2 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+Π-ext-eq1b {Γ} A B c p x y  =
+   let lm = pj2 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))
-       lm1 :  (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+       lm1 :  (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))) (pj1 (apel (asm A) (x , y)))))
                ≐
-              (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
+              (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
               (pj1 (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y)))
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
        lm1 = refV _
 
        tst : apt (Π-f A B [[ ↓ A ]]) (x , y) ≐ apt (Π-f (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) (x , y)
         --  tst = (>><< (ape (Π-f-sub A B (↓ A)) (x , y)))
-       {-- tst =     >><<    (extensionality11 piVV 
-                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))) 
-                              (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)) 
+       {-- tst =     >><<    (extensionality11 piVV
+                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))
+                              (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))
                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y))) --}
-   {--    tst =     >><<    (piV-ext 
-                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))) 
-                              (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)) 
+   {--    tst =     >><<    (piV-ext
+                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))
+                              (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))
                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y)))
    --}
-       tst =     (extensional-eqV (piV-op (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))) 
-                                  (piV-op (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))) 
-                                  (piV-half-ext (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))) 
-                                             (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)) 
-                                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y)))  
-                                  (piV-half-ext (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)) 
-                                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))) 
+       tst =     (extensional-eqV (piV-op (ap1 (mk-Par A B) (aps ( ↓ A) (x , y))))
+                                  (piV-op (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y)))
+                                  (piV-half-ext (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))
+                                             (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))
+                                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y)))
+                                  (piV-half-ext (ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))
+                                              (ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))
                                               (sym' {Par VV κ-Fam}
                                                    {(ap1 (mk-Par A B) (aps ( ↓ A) (x , y)))}
-                                                   {(ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))} 
+                                                   {(ap1 (mk-Par (A [[  ↓ A ]]) (B [[ ↑ A ( ↓ A) ]])) (x , y))}
                                               (mk-Par-sub {Γ ▷ A} {Γ} A B ( ↓ A) (x , y)))))
 
 
-       lm2 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
+       lm2 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
               (pj1 (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y)))
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
               ≐
-             (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (e+ tst 
+             (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (e+ tst
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
        lm2 = refV _
- 
-       lm3 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
+
+       lm3 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
               (pj1 (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y)))
                  (pj1 (apel (elt-subst (↓ A) p) (x , y)))) (pj1 (apel (asm A) (x , y)))))
               ≐
-              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
-       lm3 = refV _  
+       lm3 = refV _
 
    in (traV lm1 lm3)
 
-Π-ext-eq1 :  {Γ : ctx} 
+Π-ext-eq1 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
+    -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
     -> apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A)) (x , y) ≐
-       (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣  
-                      (pj1 
+       (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣
+                      (pj1
                          (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y))) (pj1 (apel p x)))
                          y)
 Π-ext-eq1 {Γ} A B c p x y  =
   let lm : apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A)) (x , y) ≐
-           (apt  (B [[ ↑ A (↓ A) ]]) ((x , y) , 
-            (pj1 (apel (asm A) (x , y)))) ‣ 
+           (apt  (B [[ ↑ A (↓ A) ]]) ((x , y) ,
+            (pj1 (apel (asm A) (x , y)))) ‣
               (pj1 (pj1 (apel (Π-eta-aux-lm A B c p) (x , y))) (pj1 (apel (asm A) (x , y)))))
       lm = refV _
-      lm0 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
+      lm0 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
               (pj1 (pj1 (apel (Π-eta-aux-lm {Γ} A B c p) (x , y))) (pj1 (apel (asm A) (x , y)))))  ≐
-            (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+            (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))) (pj1 (apel (asm A) (x , y)))))
       lm0 = refV _
-      lm05 : apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+      lm05 : apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
                ≐
              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
-              piV-ext00 {(ap1 (mk-Par A B) (aps (↓ A) (x , y)))} 
+              piV-ext00 {(ap1 (mk-Par A B) (aps (↓ A) (x , y)))}
                         {(ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y))}  (mk-Par-sub A B (↓ A) (x , y))
               (pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y)))) y
       lm05 = refV _
 
 
-      lm08 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))                      
+      lm08 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (elttyeq (elt-subst (↓ A) p) (Π-f-sub A B (↓ A)))
                              (x , y))) (pj1 (apel (asm A) (x , y)))))
                ≐
-              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣ 
-                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y))) 
-                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y)) 
+              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
+                ap (κ-Fam ±± (Fxx-lm' (ap1 (mk-Par A B) (aps (↓ A) (x , y)))
+                      (ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y)) (mk-Par-sub A B (↓ A) (x , y)) y))
                     ((pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y))))
                       (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B (↓ A) (x , y)))))) y))
-      lm08 =  Π-ext-eq1b {Γ} A B c p x y 
+      lm08 =  Π-ext-eq1b {Γ} A B c p x y
 
 
 
-      lm1 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣ 
-              (pj1 (pj1 (apel (Π-eta-aux-lm {Γ} A B c p) (x , y))) (pj1 (apel (asm A) (x , y)))))  ≐ 
+      lm1 : (apt  (B [[ ↑ A (↓ A) ]]) ((x , y),  y) ‣
+              (pj1 (pj1 (apel (Π-eta-aux-lm {Γ} A B c p) (x , y))) (pj1 (apel (asm A) (x , y)))))  ≐
              apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
-              piV-ext00 {(ap1 (mk-Par A B) (aps (↓ A) (x , y)))} 
+              piV-ext00 {(ap1 (mk-Par A B) (aps (↓ A) (x , y)))}
                         {(ap1 (mk-Par (A [[ (↓ A) ]]) (B [[ ↑ A (↓ A) ]]) ) (x , y))}  (mk-Par-sub A B (↓ A) (x , y))
               (pj1 (pj1 (apel (elt-subst (↓ A) p) (x , y)))) y
       lm1 = traV lm0  (traV lm08 lm05) -- refV _  works too, but also unifies very slowly
@@ -365,27 +365,27 @@ open import V-model-pt4
       lm2 = refV _
       lm3 :  apt (B [[ ↑ A (↓ A) ]]) ((x , y) , y) ‣
                piV-ext00 (mk-Par-sub A B (↓ A) (x , y)) (pj1 (pj1 (apel p x))) y  ≐
-            (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣  
-                      (pj1 
+            (apt (B [[ ↑ A (↓ A) ]]) ((x , y) , pj1 (apel (asm A) (x , y)))) ‣
+                      (pj1
                          (e+ (>><< (ape (Π-f-sub A B (↓ A)) (x , y))) (pj1 (apel p x)))
                          y)
       lm3 = refV _
-      
-      
-  in traV lm (traV (traV lm1 lm2) lm3) 
+
+
+  in traV lm (traV (traV lm1 lm2) lm3)
 
 --  refV _ -- works too, but also unifies very slowly
 
 
-Π-ext-eq :  {Γ : ctx} 
+Π-ext-eq :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
-    -> (x : || κ Γ ||) 
-    -> (y : || κ (apt A x) ||) 
+    -> (x : || κ Γ ||)
+    -> (y : || κ (apt A x) ||)
     -> apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A)) (x , y) ≐
              ((apt B (x , y)) ‣ (pj1 (pj1 (apel p x)) y))
-             
+
 Π-ext-eq {Γ} A B c p x y =  traV (Π-ext-eq1 {Γ} A B c p x y) (Π-ext-eq2 {Γ} A B c p x y)
 
  --  Π-ext-eq2 {Γ} A B c p x y -- works as well, but is slower
@@ -393,27 +393,26 @@ open import V-model-pt4
 
 
 
-Π-ext : {Γ : ctx} 
+Π-ext : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c d : raw Γ)
     -> (p : Γ ==> c :: Π-f A B)
     -> (q : Γ ==> d :: Π-f A B)
     ->  (Γ ▷ A ==> app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A) ==
-                   app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (d [ ↓ A ]) (Π-eta-aux-lm A B d q) (vv A) (asm A) 
+                   app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (d [ ↓ A ]) (Π-eta-aux-lm A B d q) (vv A) (asm A)
               :: (B [[ ↑ A (↓ A) ]])  [[ els (asm A) ]])
     -> (Γ ==> c == d :: Π-f A B)
-Π-ext {Γ} A B c d p q r = 
+Π-ext {Γ} A B c d p q r =
  let lm : (x : || κ Γ ||) -> (y : || κ (apt A x) ||) ->
             < κ (apt B (x , y)) > pj1 (pj1 (apel p x)) y ~
                                   pj1 (pj1 (apel q x)) y
-     
+
      lm = λ x y →
         let  lm2 : apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) (Π-eta-aux-lm A B c p) (vv A) (asm A)) (x , y) ≐
                    apr (app (A [[ ↓ A ]])  (B [[ ↑ A (↓ A) ]]) (d [ ↓ A ]) (Π-eta-aux-lm A B d q) (vv A) (asm A)) (x , y)
              lm2 = (prj1 r) (x , y)
              main : < κ (apt B (x , y)) > pj1 (pj1 (apel p x)) y ~  pj1 (pj1 (apel q x)) y
              main = <> (traV (symV (Π-ext-eq A B c p x y)) (traV lm2 (Π-ext-eq A B d q x y)))
-        in main        
+        in main
  in Π-ext2 A B c d p q lm
-
 

--- a/MLTT-and-setoids/V-model-pt6.agda
+++ b/MLTT-and-setoids/V-model-pt6.agda
@@ -25,7 +25,7 @@ open import V-model-pt5         -- 225 lines
 
 -- towards the eta equality rule for Pi
 
-Π-e-sub-raw-lm :  
+Π-e-sub-raw-lm :
     {Δ Γ : ctx}  -> (h : subst Δ Γ)
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
@@ -39,18 +39,18 @@ open import V-model-pt5         -- 225 lines
                         ~
                        ((Fxx (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) x) •
                         pj1 (apel q (aps h x)))))
-    -> 
-            (apt B ((aps h x) , pj1 (apel q (aps h x)))) 
+    ->
+            (apt B ((aps h x) , pj1 (apel q (aps h x))))
                   ‣ (pj1 (pj1 (apel p (aps h x))) (pj1 (apel q (aps h x))))
-             ≐ 
+             ≐
             (apt (B [[ ↑ A h ]]) (x , pj1 (apel q (aps h x)))) ‣
-               (ap (κ-Fam ±± q1)  ((pj1 (pj1 (apel (elt-subst h p) x))) 
+               (ap (κ-Fam ±± q1)  ((pj1 (pj1 (apel (elt-subst h p) x)))
                      (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B h x))))) (pj1 (apel q (aps h x))))))
-   
-Π-e-sub-raw-lm {Δ} {Γ} h A B c p a q x q1 = 
-    let eq : << VV >> apt A (aps h x) ~ apt (A [[ h ]]) x 
+
+Π-e-sub-raw-lm {Δ} {Γ} h A B c p a q x q1 =
+    let eq : << VV >> apt A (aps h x) ~ apt (A [[ h ]]) x
         eq = <<>> (refV (apt A (aps h x))) -- (pj1 (mk-Par-sub A B h x))
-        eq2 :  apt A (aps h x) ‣  (pj1 (apel q (aps h x))) ≐ 
+        eq2 :  apt A (aps h x) ‣  (pj1 (apel q (aps h x))) ≐
                apt A (aps h x) ‣  (ap (κ-Fam ±±  (<<>> (symV (refV (apt A (aps h x)))))) (pj1 (apel q (aps h x))))
         eq2 = e+prop ((symV (refV (apt A (aps h x))))) ((pj1 (apel q (aps h x))))
         eq3 : apt B (aps h x , pj1 (apel q (aps h x))) ‣
@@ -71,23 +71,23 @@ open import V-model-pt5         -- 225 lines
                ‣
                pj1 (pj1 (apel p (aps h x)))
                (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps h x)))))) (pj1 (apel q (aps h x))))
-                 ≐ 
+                 ≐
             (apt (B [[ ↑ A h ]]) (x , pj1 (apel q (aps h x)))) ‣
-               (ap (κ-Fam ±± q1)  
-               ((pj1 (pj1 (apel p (aps h x)))) 
+               (ap (κ-Fam ±± q1)
+               ((pj1 (pj1 (apel p (aps h x))))
                      (ap (κ-Fam ±±  (<<>> (symV (refV (apt A (aps h x)))))) (pj1 (apel q (aps h x))))))
 
         lm2 = e+prop (>><< q1) ( pj1 (pj1 (apel p (aps h x)))
                (ap (κ-Fam ±± (<<>> (symV (refV (apt A (aps h x)))))) (pj1 (apel q (aps h x)))))
-        lm : (apt B ((aps h x) , pj1 (apel q (aps h x)))) 
+        lm : (apt B ((aps h x) , pj1 (apel q (aps h x))))
                   ‣ (pj1 (pj1 (apel p (aps h x))) (pj1 (apel q (aps h x))))
-             ≐ 
+             ≐
             (apt (B [[ ↑ A h ]]) (x , pj1 (apel q (aps h x)))) ‣
                (ap (κ-Fam ±± q1)  ((pj1 (pj1 (apel p (aps h x))))  -- elt-subst f p = mk-elt (λ x → apel p (aps f x))
                      (ap (κ-Fam ±±  (<<>> (symV (refV (apt A (aps h x)))) -- (pj1 (mk-Par-sub A B h x))
                               )) (pj1 (apel q (aps h x))))))
         lm = traV eq3 lm2
-     in lm 
+     in lm
 
 
 
@@ -99,10 +99,10 @@ open import V-model-pt5         -- 225 lines
     -> (p : Γ ==> c :: Π-f {Γ} A B)
     -> (a : raw Γ)
     -> (q : Γ ==> a :: A)
-    -> << Raw Δ >> (app {Γ} A B c p a q) [ h ]  
+    -> << Raw Δ >> (app {Γ} A B c p a q) [ h ]
          ~ (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q))
-Π-e-sub-raw {Δ} {Γ} h A B c p a q 
-  = <<>> (<<>> (λ x → 
+Π-e-sub-raw {Δ} {Γ} h A B c p a q
+  = <<>> (<<>> (λ x →
 
   let  ph : Δ ==> c [ h ] :: Π-f (A [[ h ]]) (B [[ ↑ A h ]])
        ph = (elttyeq (elt-subst h p) (Π-f-sub A B h))
@@ -115,27 +115,27 @@ open import V-model-pt5         -- 225 lines
                         ~
                        (Fxx (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) x) •
                         pj1 (apel q (aps h x)))
-       q1 = (Fxx-lm' (ap1 (mk-Par A B) (aps h x))   
-                      (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) x) 
+       q1 = (Fxx-lm' (ap1 (mk-Par A B) (aps h x))
+                      (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) x)
                            (mk-Par-sub A B h x) (pj1 (apel q (aps h x))))
-       lm2 : (apt B ((aps h x) , pj1 (apel q (aps h x)))) 
+       lm2 : (apt B ((aps h x) , pj1 (apel q (aps h x))))
                   ‣ (pj1 (pj1 (apel p (aps h x))) (pj1 (apel q (aps h x))))
-             ≐ 
+             ≐
             (apt (B [[ ↑ A h ]]) (x , pj1 (apel q (aps h x)))) ‣
-               (ap (κ-Fam ±± q1)  ((pj1 (pj1 (apel (elt-subst h p) x)))  
+               (ap (κ-Fam ±± q1)  ((pj1 (pj1 (apel (elt-subst h p) x)))
                    (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B h x))))) (pj1 (apel q (aps h x))))))
        lm2 = Π-e-sub-raw-lm {Δ} {Γ} h A B c p a q x q1
 
-       lm : (apt B ((aps h x) , pj1 (apel q (aps h x)))) 
+       lm : (apt B ((aps h x) , pj1 (apel q (aps h x))))
                   ‣ (pj1 (pj1 (apel p (aps h x))) (pj1 (apel q (aps h x))))
-             ≐ 
-            (apt (B [[ ↑ A (h) ]]) (x , pj1 (apel qh x))) 
+             ≐
+            (apt (B [[ ↑ A (h) ]]) (x , pj1 (apel qh x)))
                  ‣ (pj1 (pj1 (apel ph x)) (pj1 (apel qh x)))
        lm = lm2 -- works, but very slow
 
-       main : app-op {Γ} A B c p a q (aps h x) ≐ 
+       main : app-op {Γ} A B c p a q (aps h x) ≐
               app-op {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q) x
-       main = lm 
+       main = lm
   in (<<>> main)))
 
 -- alternate formulation of the above
@@ -147,7 +147,7 @@ open import V-model-pt5         -- 225 lines
     -> (a : raw Γ)
     -> (q : Γ ==> a :: A)
     -> (x : || κ Δ ||)
-    ->  app-op {Γ} A B c p a q (aps h x) ≐ 
+    ->  app-op {Γ} A B c p a q (aps h x) ≐
               app-op {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q) x
 Π-e-sub-raw-mod {Δ} {Γ} h A B c p a q x
   =
@@ -163,27 +163,27 @@ open import V-model-pt5         -- 225 lines
                         ~
                        (Fxx (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) x) •
                         pj1 (apel q (aps h x)))
-       q1 = (Fxx-lm' (ap1 (mk-Par A B) (aps h x))   
-                      (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) x) 
+       q1 = (Fxx-lm' (ap1 (mk-Par A B) (aps h x))
+                      (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) x)
                            (mk-Par-sub A B h x) (pj1 (apel q (aps h x))))
-       lm2 : (apt B ((aps h x) , pj1 (apel q (aps h x)))) 
+       lm2 : (apt B ((aps h x) , pj1 (apel q (aps h x))))
                   ‣ (pj1 (pj1 (apel p (aps h x))) (pj1 (apel q (aps h x))))
-             ≐ 
+             ≐
             (apt (B [[ ↑ A h ]]) (x , pj1 (apel q (aps h x)))) ‣
-               (ap (κ-Fam ±± q1)  ((pj1 (pj1 (apel (elt-subst h p) x)))  
+               (ap (κ-Fam ±± q1)  ((pj1 (pj1 (apel (elt-subst h p) x)))
                    (ap (κ-Fam ±± (sym' (pj1 (>><< (mk-Par-sub A B h x))))) (pj1 (apel q (aps h x))))))
        lm2 = Π-e-sub-raw-lm {Δ} {Γ} h A B c p a q x q1
 
-       lm : (apt B ((aps h x) , pj1 (apel q (aps h x)))) 
+       lm : (apt B ((aps h x) , pj1 (apel q (aps h x))))
                   ‣ (pj1 (pj1 (apel p (aps h x))) (pj1 (apel q (aps h x))))
-             ≐ 
-            (apt (B [[ ↑ A (h) ]]) (x , pj1 (apel qh x))) 
+             ≐
+            (apt (B [[ ↑ A (h) ]]) (x , pj1 (apel qh x)))
                  ‣ (pj1 (pj1 (apel ph x)) (pj1 (apel qh x)))
        lm = lm2 -- works, but very slow
 
-       main : app-op {Γ} A B c p a q (aps h x) ≐ 
+       main : app-op {Γ} A B c p a q (aps h x) ≐
               app-op {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q) x
-       main = lm 
+       main = lm
   in main
 
 
@@ -200,17 +200,17 @@ open import V-model-pt5         -- 225 lines
     -> (q : Γ ==> a :: A)
 
 --  -----------------------------------------
-    ->  Δ ==> (app {Γ} A B c p a q) [ h ]  
-          ==  (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q)) 
+    ->  Δ ==> (app {Γ} A B c p a q) [ h ]
+          ==  (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q))
           :: B [[ els q ]] [[ h ]]
-Π-e-sub {Δ} {Γ} h A B c p a q  = 
-   let main : << Raw Δ >> (app {Γ} A B c p a q) [ h ] 
-               ~ (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q)) 
+Π-e-sub {Δ} {Γ} h A B c p a q  =
+   let main : << Raw Δ >> (app {Γ} A B c p a q) [ h ]
+               ~ (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q))
        main =  Raw-lm2 (Π-e-sub-raw-mod {Δ} {Γ} h A B c p a q) -- Π-e-sub-raw {Δ} {Γ} h A B c p a q     -- **** stuck here 2.6.0.1
        lm1 : Δ ==> (app {Γ} A B c p a q) [ h ]  :: B [[ els q ]] [[ h ]]
        lm1 = (elt-subst {Δ} {Γ} {(app {Γ} A B c p a q)} {B [[ els q ]]} h (Π-e  {Γ} A B c p a q))
-   in  pair (Π-e-sub-raw-mod {Δ} {Γ} h A B c p a q) -- (Raw-lm main) -- (λ x → >><< ((>><< (>><< main)) x))  
-            (pair lm1 (subj-red {Δ} {B [[ els q ]] [[ h ]]} ((app {Γ} A B c p a q) [ h ]) (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q)) lm1 main)) 
+   in  pair (Π-e-sub-raw-mod {Δ} {Γ} h A B c p a q) -- (Raw-lm main) -- (λ x → >><< ((>><< (>><< main)) x))
+            (pair lm1 (subj-red {Δ} {B [[ els q ]] [[ h ]]} ((app {Γ} A B c p a q) [ h ]) (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q)) lm1 main))
 
 -- ** TO DO: general version of the above: Π-e-sub-gen
 
@@ -224,17 +224,17 @@ open import V-model-pt5         -- 225 lines
     -> (q : Γ ==> a :: A)
     -> (r1 : Δ ==> (c [ h ]) ::  Π-f {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) )
     -> (r2 : Δ ==> (a [ h ]) :: A [[ h ]])
-    -> << Raw Δ >> (app A B c p a q) [ h ]  
+    -> << Raw Δ >> (app A B c p a q) [ h ]
          ~ (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) r1 (a [ h ]) r2)
-Π-e-sub-gen-raw {Δ} {Γ} h A B c p a q r1 r2 =   
-    let eq1 : << Raw Δ >> (app A B c p a q) [ h ]  
+Π-e-sub-gen-raw {Δ} {Γ} h A B c p a q r1 r2 =
+    let eq1 : << Raw Δ >> (app A B c p a q) [ h ]
          ~ (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q))
         eq1 = Π-e-sub-raw {Δ} {Γ} h A B c p a q -- **** stuck here 2.6.0.1
-        eq2 : << Raw Δ >> (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) 
+        eq2 : << Raw Δ >> (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ])
                       (elttyeq (elt-subst h p) (Π-f-sub A B h)) (a [ h ]) (elt-subst h q))
              ~ (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) r1 (a [ h ]) r2)
-        eq2 = app-cong-raw {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) 
-                      (c [ h ]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) r1 (tmrefl r1) 
+        eq2 = app-cong-raw {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]])
+                      (c [ h ]) (c [ h ]) (elttyeq (elt-subst h p) (Π-f-sub A B h)) r1 (tmrefl r1)
                       (a [ h ]) (a [ h ]) (elt-subst h q) r2 (tmrefl r2)
 
     in tra' eq1 eq2 -- tra eq1 eq2
@@ -254,15 +254,15 @@ open import V-model-pt5         -- 225 lines
     -> (r2 : Δ ==> (a [ h ]) :: A [[ h ]])
 
 --  -----------------------------------------
-    ->  Δ ==> (app A B c p a q) [ h ]  
-          ==  (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) r1 (a [ h ]) r2) 
+    ->  Δ ==> (app A B c p a q) [ h ]
+          ==  (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) r1 (a [ h ]) r2)
           :: B [[ els q ]] [[ h ]]
-Π-e-sub-gen {Δ} {Γ} h A B c p a q r1 r2  = 
-   let main : << Raw Δ >> (app A B c p a q) [ h ] 
-               ~ (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) r1 (a [ h ]) r2) 
+Π-e-sub-gen {Δ} {Γ} h A B c p a q r1 r2  =
+   let main : << Raw Δ >> (app A B c p a q) [ h ]
+               ~ (app {Δ} (A [[ h ]]) (B [[ ↑ A (h) ]]) (c [ h ]) r1 (a [ h ]) r2)
        main = Π-e-sub-gen-raw {Δ} {Γ} h A B c p a q r1 r2
        lm1 = (elt-subst {Δ} {Γ} {(app A B c p a q)} {B [[ els q ]]} h (Π-e  {Γ} A B c p a q))
-   in   pair (λ x → >><< ((>><< (>><< main)) x)) -- main 
+   in   pair (λ x → >><< ((>><< (>><< main)) x)) -- main
              (pair lm1
                    (subj-red _ _ lm1 main))
 
@@ -275,11 +275,11 @@ open import V-model-pt5         -- 225 lines
        -> {b : raw (Γ ▷ A)}
        -> (Γ ▷ A ==> b :: B)
        -> << Raw Δ >>  (lambda A B b) [ h ] ~ (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ]))
-Π-i-sub-raw  {Δ} {Γ} h A {B} {b} p 
-  = <<>> (<<>> (λ x → 
+Π-i-sub-raw  {Δ} {Γ} h A {B} {b} p
+  = <<>> (<<>> (λ x →
 
-  let lm1 : (z : # (apr ((lambda A B b) [ h ]) x)) 
-               -> Σ (# (apr (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) x)) 
+  let lm1 : (z : # (apr ((lambda A B b) [ h ]) x))
+               -> Σ (# (apr (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) x))
                    (\y ->  (apr ((lambda A B b) [ h ]) x) ‣ z ≐ (apr (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) x) ‣ y)
       lm1 = \z -> (z , pairV-ext (refV _)
                                 (>><< (extensionality1 (raw.rawterm b)
@@ -289,9 +289,9 @@ open import V-model-pt5         -- 225 lines
                                          (A [[ h ⌢ ↓ (A [[ h ]]) ]])
                                         (Sub-comp-prop-sym A h (↓ (A [[ h ]]))))
                                 (x , z))) z )))
-                                   
+
                                  )))
-      lm2 : (y : # (apr (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) x)) 
+      lm2 : (y : # (apr (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) x))
                -> Σ (# (apr ((lambda A B b) [ h ]) x)) (\z ->  (apr ((lambda A B b) [ h ]) x) ‣ z ≐ (apr (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) x) ‣ y)
       lm2 = \y -> (y , pairV-ext (refV _) (>><< (extensionality1 (raw.rawterm b)
                                               _ _
@@ -300,10 +300,10 @@ open import V-model-pt5         -- 225 lines
                                             (A [[ h ⌢ ↓ (A [[ h ]]) ]])
                                          (Sub-comp-prop-sym A h (↓ (A [[ h ]]))))
                                          (x , y))) y )))
-                                            
+
                                       )))
       lm : apr ((lambda A B b) [ h ]) x ≐ apr (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) x
-      lm = eqV-unexpand (apr ((lambda A B b) [ h ]) x) 
+      lm = eqV-unexpand (apr ((lambda A B b) [ h ]) x)
                  (apr (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) x) lm1 lm2
   in <<>> lm
 
@@ -319,16 +319,16 @@ open import V-model-pt5         -- 225 lines
        -> Γ ▷ A ==> b :: B
 --  -----------------------------------------
         -> Δ ==> (lambda A B b) [ h ] == (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ])) :: (Π-f A B) [[ h ]]
-Π-i-sub  {Δ} {Γ} h A {B} {b} p = 
+Π-i-sub  {Δ} {Γ} h A {B} {b} p =
    let main : << Raw Δ >>  (lambda A B b) [ h ] ~ (lambda (A [[ h ]]) (B [[ ↑ A (h) ]]) (b [ ↑ A (h) ]))
        main = Π-i-sub-raw  {Δ} {Γ} h A {B} {b} p
        lm1 =  (elt-subst {Δ} {Γ} {lambda A B b} { Π-f A B} h (Π-i {Γ} A {B} {b} p))
-   in   pair (λ x → >><< (>><< (>><< main) x)) -- main 
+   in   pair (λ x → >><< (>><< (>><< main) x)) -- main
              (pair lm1
                    (subj-red _ _ lm1 main))
 
 
-Π-eta-left1 :  {Γ : ctx}  
+Π-eta-left1 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -337,29 +337,29 @@ open import V-model-pt5         -- 225 lines
 
 
 
-Π-eta-left2 :  {Γ : ctx}  
+Π-eta-left2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
     -> (Γ ▷ A) ==> vv A ::  A [[ ↓ A ]]
 Π-eta-left2 {Γ} A B c p  = asm A
 
-Π-eta-left3 :  {Γ : ctx}  
+Π-eta-left3 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
     -> (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]))    -- ((Π-f {Γ} A B) [[ ↓ A ]])
 Π-eta-left3 {Γ} A B c p = elttyeq (Π-eta-left1 {Γ} A B c p) (Π-f-sub A B (↓ A))
 
-Π-eta-left4 :  {Γ : ctx}  
+Π-eta-left4 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
-    -> (Γ ▷ A) ==> app (A [[ ↓ A ]]) 
+    -> (Γ ▷ A) ==> app (A [[ ↓ A ]])
                        (B [[ ↑ A (↓ A) ]])
                        (c [ ↓ A ])
-                       (Π-eta-left3 {Γ} A B c p)  
-                       (vv A) 
+                       (Π-eta-left3 {Γ} A B c p)
+                       (vv A)
                        (Π-eta-left2 {Γ} A B c p)
                :: (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 {Γ} A B c p) ]]
 Π-eta-left4 {Γ} A B c p =
@@ -368,7 +368,7 @@ open import V-model-pt5         -- 225 lines
  -- **** stuck here 2.6.0.1
 
 
-Π-eta-left5-lm2 :  {Γ : ctx}  
+Π-eta-left5-lm2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (x : || κ Γ ||)
     -> (y : || κ (apt A x) ||)
@@ -379,20 +379,20 @@ open import V-model-pt5         -- 225 lines
         (tyeq-from-eq ((A [[ ↓ A ]]) [[ ↓ (A [[ ↓ A ]]) ]])
          (A [[ ↓ A ⌢ ↓ (A [[ ↓ A ]]) ]])
          (Sub-comp-prop-sym A (↓ A) (↓ (A [[ ↓ A ]]))))
-        (ap (subst.cmap (els (asm A))) (x , y)))) y)))) ) 
+        (ap (subst.cmap (els (asm A))) (x , y)))) y)))) )
 
 
 
 
 
-Π-eta-left5-lm :  {Γ : ctx}  
+Π-eta-left5-lm :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (u : || κ (Γ ▷ A) ||)
     -> (apt ((B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]]) u)  ≐
        (apt B  u)
-Π-eta-left5-lm {Γ} A B  ( x , y )  = Π-eta-left5-lm2 A B x y 
+Π-eta-left5-lm {Γ} A B  ( x , y )  = Π-eta-left5-lm2 A B x y
 
-Π-eta-left5 :  {Γ : ctx}  
+Π-eta-left5 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -401,68 +401,68 @@ open import V-model-pt5         -- 225 lines
 
 
 
-Π-eta-left6 :  {Γ : ctx}  
+Π-eta-left6 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
-    -> (Γ ▷ A) ==> app (A [[ ↓ A ]]) 
+    -> (Γ ▷ A) ==> app (A [[ ↓ A ]])
                        (B [[ ↑ A (↓ A) ]])
                        (c [ ↓ A ])
-                       (Π-eta-left3 {Γ} A B c p)  
-                       (vv A) 
+                       (Π-eta-left3 {Γ} A B c p)
+                       (vv A)
                        (Π-eta-left2 {Γ} A B c p)
                :: B
 Π-eta-left6 {Γ} A B c p =  elttyeq (Π-eta-left4 {Γ} A B c p) (Π-eta-left5 {Γ} A B c p)
-      
-Π-eta-left7 :  {Γ : ctx}  
+
+Π-eta-left7 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
-    -> Γ ==> lambda A B (app (A [[ ↓ A ]]) 
+    -> Γ ==> lambda A B (app (A [[ ↓ A ]])
                        (B [[ ↑ A (↓ A) ]])
                        (c [ ↓ A ])
-                       (Π-eta-left3 {Γ} A B c p)  
-                       (vv A) 
+                       (Π-eta-left3 {Γ} A B c p)
+                       (vv A)
                        (Π-eta-left2 {Γ} A B c p))  ::  Π-f {Γ} A B
 Π-eta-left7 {Γ} A B c p =  Π-i A (Π-eta-left6 {Γ} A B c p)
 
 -- **** stuck here 2.6.0.1
 
-Π-eta-left8 :  {Γ : ctx}  
+Π-eta-left8 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
-    -> (Γ ▷ A) ==> app (A [[ ↓ A ]]) 
+    -> (Γ ▷ A) ==> app (A [[ ↓ A ]])
                        (B [[ ↑ A (↓ A) ]])
                        (c [ ↓ A ])
-                       (Π-eta-aux-lm A B c p)  
-                       (vv A) 
+                       (Π-eta-aux-lm A B c p)
+                       (vv A)
                        (asm A)
                ::  (B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]]
 Π-eta-left8 {Γ} A B c p = Π-e {Γ ▷ A}
-                               (A [[ ↓ A ]]) 
+                               (A [[ ↓ A ]])
                                (B [[ ↑ A (↓ A) ]])
                                (c [ ↓ A ])
-                               (Π-eta-aux-lm A B c p)  
-                               (vv A) 
-                               (asm A) 
+                               (Π-eta-aux-lm A B c p)
+                               (vv A)
+                               (asm A)
 
 -- **** stuck here 2.6.0.1
 
 {-- moved to pt0
 
-subst-cong : {Θ Δ Γ : ctx} -> (f f' : subst Δ Γ) -> (g  g' : subst Θ Δ) 
-      -> < Subst Δ Γ > f ~ f' 
-      -> < Subst Θ Δ > g ~ g' 
-      -> < Subst Θ Γ > (f ⌢ g) ~ (f' ⌢ g') 
+subst-cong : {Θ Δ Γ : ctx} -> (f f' : subst Δ Γ) -> (g  g' : subst Θ Δ)
+      -> < Subst Δ Γ > f ~ f'
+      -> < Subst Θ Δ > g ~ g'
+      -> < Subst Θ Γ > (f ⌢ g) ~ (f' ⌢ g')
 subst-cong {Θ} {Δ} {Γ} f f' g g' p q =
-    <> (<> (λ x →  
+    <> (<> (λ x →
    let eq1 : < κ Γ > setoidmap.op (subst.cmap f ° subst.cmap g) x ~
-                     setoidmap.op (subst.cmap f ° subst.cmap g' ) x 
-       eq1 = extensionality (subst.cmap f) _ _ ((>< (>< q) x)) 
+                     setoidmap.op (subst.cmap f ° subst.cmap g' ) x
+       eq1 = extensionality (subst.cmap f) _ _ ((>< (>< q) x))
        eq2 : < κ Γ > setoidmap.op (subst.cmap f ° subst.cmap g' ) x ~
                     setoidmap.op (subst.cmap (f') ° subst.cmap (g')) x
-       eq2 = >< (>< p) ( aps g' x) 
+       eq2 = >< (>< p) ( aps g' x)
        eq : < κ Γ > setoidmap.op (subst.cmap f ° subst.cmap g) x ~
                     setoidmap.op (subst.cmap (f') ° subst.cmap (g')) x
        eq = tra eq1 eq2
@@ -473,25 +473,25 @@ subst-cong {Θ} {Δ} {Γ} f f' g g' p q =
 
 -- to be moved: pt4
 
-qq-ext-el-lm-gen :  {Γ : ctx} 
+qq-ext-el-lm-gen :  {Γ : ctx}
     -> (A : ty Γ)
     -> (p : Γ ▷ A ==> vv A :: A [[ ↓ A ]])
     -> < Subst (Γ ▷ A) (Γ ▷ A) >  ((↑ A (↓ A))  ⌢  (els p))
                                          ~ (ids {Γ ▷ A})
-qq-ext-el-lm-gen {Γ} A p = 
+qq-ext-el-lm-gen {Γ} A p =
     let lm : < Subst (Γ ▷ A) (Γ ▷ A ▷ (A [[ ↓ A ]])) >  (els p) ~ (els (asm A))
         lm = els-irr p (asm A)
         lm2 : < Subst (Γ ▷ A) (Γ ▷ A) >  ((↑ A (↓ A))  ⌢  (els p)) ~ ((↑ A (↓ A))  ⌢  (els (asm A)))
         lm2 = subst-cong (↑ A (↓ A)) (↑ A (↓ A)) (els p)  (els (asm A)) (refl (Subst (Γ ▷ A ▷ (A [[ ↓ A ]])) (Γ ▷ A)) (↑ A (↓ A))) lm
-    in (tra {Subst (Γ ▷ A) (Γ ▷ A)} 
-            {((↑ A (↓ A))  ⌢  (els p))} {((↑ A (↓ A))  ⌢  (els (asm A)))} {(ids {Γ ▷ A})} 
-            lm2 (qq-ext-el-lm {Γ} A) ) 
+    in (tra {Subst (Γ ▷ A) (Γ ▷ A)}
+            {((↑ A (↓ A))  ⌢  (els p))} {((↑ A (↓ A))  ⌢  (els (asm A)))} {(ids {Γ ▷ A})}
+            lm2 (qq-ext-el-lm {Γ} A) )
 
 -- **** stuck here 2.6.0.1
 
 
 
-Π-eta-beta-spec2-lm : {Γ : ctx}  
+Π-eta-beta-spec2-lm : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -501,12 +501,12 @@ qq-ext-el-lm-gen {Γ} A p =
        (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)
        [ ↑ A (↓ A) ])
       :: Π-f (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])
-Π-eta-beta-spec2-lm {Γ} A B c p = 
-  let  lm1 : (Γ ▷ A) ==> app (A [[ ↓ A ]]) 
+Π-eta-beta-spec2-lm {Γ} A B c p =
+  let  lm1 : (Γ ▷ A) ==> app (A [[ ↓ A ]])
                        (B [[ ↑ A (↓ A) ]])
                        (c [ ↓ A ])
-                       (Π-eta-left3 {Γ} A B c p)  
-                       (vv A) 
+                       (Π-eta-left3 {Γ} A B c p)
+                       (vv A)
                        (Π-eta-left2 {Γ} A B c p)
                :: (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 {Γ} A B c p) ]]
        lm1 = Π-eta-left4 {Γ} A B c p  -- **** stuck here 2.6.0.1
@@ -514,36 +514,36 @@ qq-ext-el-lm-gen {Γ} A p =
        lm3a : < Subst (Γ ▷ A) (Γ ▷ A) >  ((↑ A (↓ A))  ⌢  (els (Π-eta-left2 A B c p)))  ~ (ids {Γ ▷ A})
        lm3a = qq-ext-el-lm-gen A (Π-eta-left2 A B c p)
        lm3b :  Γ ▷ A ==> (B [[ ((↑ A (↓ A))  ⌢  (els (Π-eta-left2 A B c p))) ]])
-                      == (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]]  
+                      == (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]]
        lm3b = tysubst-com B (↑ A (↓ A)) (els (Π-eta-left2 A B c p))
        lm3c :   Γ ▷ A ==> (B [[ ((↑ A (↓ A))  ⌢  (els (Π-eta-left2 A B c p))) ]]) == B [[ ids {Γ ▷ A} ]]
        lm3c = tyeq-subst2 B _ _ lm3a
        lm3d :  Γ ▷ A ==>  B [[ ids {Γ ▷ A} ]] == B
        lm3d = tysubst-id B
-       lm3 : Γ ▷ A ==> (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]] ==  B 
+       lm3 : Γ ▷ A ==> (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]] ==  B
        lm3 = tytra (tysym lm3b) (tytra lm3c lm3d)
-       lm4 :  Γ ▷ A ▷ (A [[ ↓ A ]]) ==> 
+       lm4 :  Γ ▷ A ▷ (A [[ ↓ A ]]) ==>
                ((B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]]) [[ ↑ A (↓ A) ]]
                ==  B [[ ↑ A (↓ A) ]]
        lm4 = tyeq-subst (↑ A (↓ A)) lm3
 
        lm5 : Γ ▷ A ▷ (A [[ ↓ A ]]) ==>
-           app (A [[ ↓ A ]]) 
-               (B [[ ↑ A (↓ A) ]]) 
+           app (A [[ ↓ A ]])
+               (B [[ ↑ A (↓ A) ]])
                (c [ ↓ A ])
-               (Π-eta-left3 A B c p) 
-               (vv A) 
+               (Π-eta-left3 A B c p)
+               (vv A)
                (Π-eta-left2 A B c p)
             [ ↑ A (↓ A) ]
            :: B [[ ↑ A (↓ A) ]]
        lm5 = elttyeq lm2 lm4
-       lm6 =  Π-i {Γ ▷ A} 
-                  (A [[ ↓ A ]]) 
-                  {B [[ ↑ A (↓ A) ]]} 
+       lm6 =  Π-i {Γ ▷ A}
+                  (A [[ ↓ A ]])
+                  {B [[ ↑ A (↓ A) ]]}
                   {(app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                     (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)
-                   [ ↑ A (↓ A) ])} 
-                  lm5 
+                   [ ↑ A (↓ A) ])}
+                  lm5
   in lm6
 
 
@@ -551,21 +551,21 @@ qq-ext-el-lm-gen {Γ} A p =
 -- move to earlier part :
 
 
-sub-ext : {Δ Γ : ctx} -> {a a' : raw Γ} -> {f f' : subst Δ Γ} 
+sub-ext : {Δ Γ : ctx} -> {a a' : raw Γ} -> {f f' : subst Δ Γ}
       -> << Raw Γ >> a ~ a' -> < Subst Δ Γ > f ~ f'
       -> << Raw Δ >> (a [ f ]) ~ (a' [ f' ])
-sub-ext {Δ} {Γ} {a} {a'} {f} {f'} p q 
-  = <<>> (<<>> (λ x → 
+sub-ext {Δ} {Γ} {a} {a'} {f} {f'} p q
+  = <<>> (<<>> (λ x →
      (let  eq2 = >< (>< q) x
            eq1 : < κ Γ > aps f x ~  aps f' x
-           eq1 = <> (>< eq2) 
+           eq1 = <> (>< eq2)
            eq : apr a (aps f x) ≐  apr a' (aps f' x)
-           eq =  traV (>><< (>><< (>><< p) (aps f x))) (>><< (extensionality1 (raw.rawterm a') _ _ eq1))  
+           eq =  traV (>><< (>><< (>><< p) (aps f x))) (>><< (extensionality1 (raw.rawterm a') _ _ eq1))
      in <<>> eq)))
 
 
 
-term-els-lm5 : {Γ : ctx}  
+term-els-lm5 : {Γ : ctx}
             -> (A : ty Γ)
             -> < Subst (Γ ▷ A) (Γ ▷ A) > ((↑ A (↓ A)) ⌢ (els (asm A))) ~ (ids {Γ ▷ A})
 term-els-lm5 {Γ} A  =
@@ -578,25 +578,25 @@ term-els-lm5 {Γ} A  =
 
 
 
-term-els-lm4 : {Γ : ctx}  
+term-els-lm4 : {Γ : ctx}
             -> (A : ty Γ)
             -> (c : raw (Γ ▷ A))
-            -> << Raw (Γ ▷ A) >> (c [ (( ↑ A (↓ A)) ⌢ (els (asm A))) ]) ~  (c [ ids {Γ ▷ A}]) 
-term-els-lm4 {Γ} A c =  sub-ext {Γ ▷ A} {Γ ▷ A} {c} {c} {(( ↑ A (↓ A)) ⌢ (els (asm A)))} {ids {Γ ▷ A}} (refl' (Raw (Γ ▷ A)) c) (term-els-lm5 A) 
+            -> << Raw (Γ ▷ A) >> (c [ (( ↑ A (↓ A)) ⌢ (els (asm A))) ]) ~  (c [ ids {Γ ▷ A}])
+term-els-lm4 {Γ} A c =  sub-ext {Γ ▷ A} {Γ ▷ A} {c} {c} {(( ↑ A (↓ A)) ⌢ (els (asm A)))} {ids {Γ ▷ A}} (refl' (Raw (Γ ▷ A)) c) (term-els-lm5 A)
 
 -- **** stuck here 2.6.0.1
 
 
-term-els-lm3 : {Γ : ctx}  
+term-els-lm3 : {Γ : ctx}
             -> (A : ty Γ)
             -> (c : raw (Γ ▷ A))
             ->  << Raw (Γ ▷ A) >> (c [ ids {Γ ▷ A} ]) ~ c
-term-els-lm3 {Γ} A c = sub-id-prop {Γ ▷ A} c 
+term-els-lm3 {Γ} A c = sub-id-prop {Γ ▷ A} c
 
 
 
 
-term-els-lm2 : {Γ : ctx}  
+term-els-lm2 : {Γ : ctx}
             -> (A : ty Γ)
             -> (c : raw (Γ ▷ A))
             ->  << Raw (Γ ▷ A) >> (c [ (↑ A (↓ A)) ⌢ (els (asm A)) ]) ~ c
@@ -605,15 +605,15 @@ term-els-lm2 {Γ} A c  =
 
 
 
-term-els-lm : {Γ : ctx}  
+term-els-lm : {Γ : ctx}
             -> (A : ty Γ)
             -> (c : raw (Γ ▷ A))
             ->  << Raw (Γ ▷ A) >> (c [ ↑ A (↓ A) ]) [ els (asm A) ] ~ c
 term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (term-els-lm2 {Γ} A c)
-     
+
 -- **** stuck here 2.6.0.1
 
-Π-eta-beta-spec3 : {Γ : ctx}  
+Π-eta-beta-spec3 : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -626,7 +626,7 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
           app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
              (Π-eta-aux-lm A B c p) (vv A) (asm A)
            :: (B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]]
-Π-eta-beta-spec3 {Γ} A B c p = 
+Π-eta-beta-spec3 {Γ} A B c p =
     let lm1 :  << Raw (Γ ▷ A) >> ((app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)
                [ ↑ A (↓ A) ])
@@ -647,95 +647,95 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
 
     in pair (λ x → >><< (>><< (>><< main) x)) -- main
             (pair (subj-red {Γ ▷ A} {(B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]]} _ _  (Π-eta-left8 {Γ} A B c p) smain )
-                  (Π-eta-left8 {Γ} A B c p))           
+                  (Π-eta-left8 {Γ} A B c p))
 
 
-Π-eta-beta-spec2 : {Γ : ctx}  
+Π-eta-beta-spec2 : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
     -> Γ ▷ A ==>
-              app (A [[ ↓ A ]]) 
+              app (A [[ ↓ A ]])
                   (B [[ ↑ A (↓ A) ]])
                   (lambda {Γ ▷ A}
-                          (A [[ ↓ A ]])  
+                          (A [[ ↓ A ]])
                           (B [[ ↑ A (↓ A) ]])
                           ((app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                              (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p))
                             [ ↑ A (↓ A) ]))
-                  (Π-eta-beta-spec2-lm {Γ} A B c p) 
-                  (vv A) 
+                  (Π-eta-beta-spec2-lm {Γ} A B c p)
+                  (vv A)
                   (asm A)
                   ==
-              app (A [[ ↓ A ]]) 
-                  (B [[ ↑ A (↓ A) ]]) 
+              app (A [[ ↓ A ]])
+                  (B [[ ↑ A (↓ A) ]])
                   (c [ ↓ A ])
-                  (Π-eta-aux-lm A B c p) 
-                  (vv A) 
+                  (Π-eta-aux-lm A B c p)
+                  (vv A)
                   (asm A)
                :: (B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]]
-Π-eta-beta-spec2 {Γ} A B c p = 
+Π-eta-beta-spec2 {Γ} A B c p =
   let  {-- lm1 - lm5 make separate lemma --}
        lm1 = Π-eta-left4 {Γ} A B c p   -- **** stuck here 2.6.0.1
        lm2 = elt-subst (↑ A (↓ A)) lm1
        lm3a : < Subst (Γ ▷ A) (Γ ▷ A) >  ((↑ A (↓ A))  ⌢  (els (Π-eta-left2 A B c p)))  ~ (ids {Γ ▷ A})
        lm3a = qq-ext-el-lm-gen A (Π-eta-left2 A B c p)
        lm3b :  Γ ▷ A ==> (B [[ ((↑ A (↓ A))  ⌢  (els (Π-eta-left2 A B c p))) ]])
-                      == (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]]  
+                      == (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]]
        lm3b = tysubst-com B (↑ A (↓ A)) (els (Π-eta-left2 A B c p))
        lm3c :   Γ ▷ A ==> (B [[ ((↑ A (↓ A))  ⌢  (els (Π-eta-left2 A B c p))) ]]) == B [[ ids {Γ ▷ A} ]]
        lm3c = tyeq-subst2 B _ _ lm3a
        lm3d :  Γ ▷ A ==>  B [[ ids {Γ ▷ A} ]] == B
        lm3d = tysubst-id B
-       lm3 : Γ ▷ A ==> (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]] ==  B 
+       lm3 : Γ ▷ A ==> (B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]] ==  B
        lm3 = tytra (tysym lm3b) (tytra lm3c lm3d)
-       lm4 :  Γ ▷ A ▷ (A [[ ↓ A ]]) ==> 
+       lm4 :  Γ ▷ A ▷ (A [[ ↓ A ]]) ==>
                ((B [[ ↑ A (↓ A) ]]) [[ els (Π-eta-left2 A B c p) ]]) [[ ↑ A (↓ A) ]]
                ==  B [[ ↑ A (↓ A) ]]
        lm4 = tyeq-subst (↑ A (↓ A)) lm3
 
        lm5 : Γ ▷ A ▷ (A [[ ↓ A ]]) ==>
-           app (A [[ ↓ A ]]) 
-               (B [[ ↑ A (↓ A) ]]) 
+           app (A [[ ↓ A ]])
+               (B [[ ↑ A (↓ A) ]])
                (c [ ↓ A ])
-               (Π-eta-left3 A B c p) 
-               (vv A) 
+               (Π-eta-left3 A B c p)
+               (vv A)
                (Π-eta-left2 A B c p)
             [ ↑ A (↓ A) ]
            :: B [[ ↑ A (↓ A) ]]
        lm5 = elttyeq lm2 lm4
        lm = Π-beta-gen {Γ ▷ A}
-                       (A [[ ↓ A ]]) 
+                       (A [[ ↓ A ]])
                        (B [[ ↑ A (↓ A) ]])
                        ((app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                              (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p))
                             [ ↑ A (↓ A) ])
                        lm5
-                       (Π-eta-beta-spec2-lm {Γ} A B c p) 
-                       (vv A) -- (vv A) 
+                       (Π-eta-beta-spec2-lm {Γ} A B c p)
+                       (vv A) -- (vv A)
                        (asm A) -- (asm A)
-          
+
   in (tmtra { Γ ▷ A }
             ((B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]])
-            (app (A [[ ↓ A ]]) 
+            (app (A [[ ↓ A ]])
                   (B [[ ↑ A (↓ A) ]])
                   (lambda {Γ ▷ A}
-                          (A [[ ↓ A ]])  
+                          (A [[ ↓ A ]])
                           (B [[ ↑ A (↓ A) ]])
                           ((app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                              (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p))
                             [ ↑ A (↓ A) ]))
-                  (Π-eta-beta-spec2-lm {Γ} A B c p) 
-                  (vv A) 
+                  (Π-eta-beta-spec2-lm {Γ} A B c p)
+                  (vv A)
                   (asm A))
              ((app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)
                 [ ↑ A (↓ A) ]) [ els (asm A) ])
-             (app (A [[ ↓ A ]]) 
-                  (B [[ ↑ A (↓ A) ]]) 
+             (app (A [[ ↓ A ]])
+                  (B [[ ↑ A (↓ A) ]])
                   (c [ ↓ A ])
-                  (Π-eta-aux-lm A B c p) 
-                  (vv A) 
+                  (Π-eta-aux-lm A B c p)
+                  (vv A)
                   (asm A))
              lm
              (Π-eta-beta-spec3 {Γ} A B c p)
@@ -744,7 +744,7 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
 
 
 
-Π-eta-beta-spec-cong2 : {Γ : ctx}  
+Π-eta-beta-spec-cong2 : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
@@ -759,7 +759,7 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
        (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)
        [ ↑ A (↓ A) ])
       :: Π-f (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])
-Π-eta-beta-spec-cong2 {Γ} A B c p = 
+Π-eta-beta-spec-cong2 {Γ} A B c p =
    let  lm = Π-i-sub {Γ ▷ A} {Γ} (↓ A) A {B}    -- **** stuck here 2.6.0.1
          {(app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
           (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p))} (Π-eta-left6 {Γ} A B c p)
@@ -767,7 +767,7 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
 
         lm2 :  Γ ▷ A ==> Π-f A B [[ ↓ A ]] == Π-f (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])
         lm2 = Π-f-sub A B ( ↓ A )
-   in (elteqtyeq {Γ ▷ A} 
+   in (elteqtyeq {Γ ▷ A}
                  (lambda A B
                       (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                        (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p))
@@ -776,25 +776,25 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
                                       (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                        (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)
                        [ ↑ A (↓ A) ]))
-                 (Π-f A B [[ ↓ A ]])  
-                 (Π-f (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])) 
-                 lm 
-                 lm2) 
- 
+                 (Π-f A B [[ ↓ A ]])
+                 (Π-f (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]))
+                 lm
+                 lm2)
 
-Π-eta-beta-spec-cong : {Γ : ctx}  
+
+Π-eta-beta-spec-cong : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
     -> Γ ▷ A ==>
-              app (A [[ ↓ A ]]) 
+              app (A [[ ↓ A ]])
                   (B [[ ↑ A (↓ A) ]])
                   ((lambda A B
-                        (app (A [[ ↓ A ]]) 
-                             (B [[ ↑ A (↓ A) ]]) 
+                        (app (A [[ ↓ A ]])
+                             (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             (Π-eta-left3 A B c p) 
-                             (vv A) 
+                             (Π-eta-left3 A B c p)
+                             (vv A)
                              (Π-eta-left2 A B c p)))
                     [ ↓ A ])
                   (Π-eta-aux-lm A B
@@ -802,86 +802,86 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
                         (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                        (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)))
                         (Π-eta-left7 A B c p))
-                  (vv A) 
+                  (vv A)
                   (asm A)
                   ==
-              app (A [[ ↓ A ]]) 
+              app (A [[ ↓ A ]])
                   (B [[ ↑ A (↓ A) ]])
                   (lambda {Γ ▷ A}
-                          (A [[ ↓ A ]])  
+                          (A [[ ↓ A ]])
                           (B [[ ↑ A (↓ A) ]])
                           ((app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                              (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p))
                             [ ↑ A (↓ A) ]))
-                  (Π-eta-beta-spec2-lm {Γ} A B c p) 
-                  (vv A) 
-                  (asm A)             
+                  (Π-eta-beta-spec2-lm {Γ} A B c p)
+                  (vv A)
+                  (asm A)
                :: (B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]]
-Π-eta-beta-spec-cong {Γ} A B c p = 
+Π-eta-beta-spec-cong {Γ} A B c p =
 --  << Raw Γ >>  app A B c p a q ~ app A B c' p' a' q'
     pair (Raw-lm (app-cong-raw {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])   -- **** stuck here 2.6.0.1
                   ((lambda A B
-                        (app (A [[ ↓ A ]]) 
-                             (B [[ ↑ A (↓ A) ]]) 
+                        (app (A [[ ↓ A ]])
+                             (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             (Π-eta-left3 A B c p) 
-                             (vv A) 
+                             (Π-eta-left3 A B c p)
+                             (vv A)
                              (Π-eta-left2 A B c p)))
-                    [ ↓ A ]) 
+                    [ ↓ A ])
                   (lambda {Γ ▷ A}
-                          (A [[ ↓ A ]])  
+                          (A [[ ↓ A ]])
                           (B [[ ↑ A (↓ A) ]])
                           ((app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                              (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p))
-                            [ ↑ A (↓ A) ])) 
+                            [ ↑ A (↓ A) ]))
                     (Π-eta-aux-lm A B
                       (lambda A B
                         (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                        (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)))
                         (Π-eta-left7 A B c p))
-                     (Π-eta-beta-spec2-lm {Γ} A B c p) 
+                     (Π-eta-beta-spec2-lm {Γ} A B c p)
                       (Π-eta-beta-spec-cong2 {Γ} A B c p) (vv A) (vv A) (asm A) (asm A) (tmrefl (asm A))))
-                                        (pair (Π-e {Γ ▷ A} 
+                                        (pair (Π-e {Γ ▷ A}
                                                    (A [[ ↓ A ]])
-                                                   (B [[ ↑ A (↓ A) ]]) 
+                                                   (B [[ ↑ A (↓ A) ]])
                                                    (lambda A B
                                                      (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                                                         (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p))
-                                                      [ ↓ A ]) 
+                                                      [ ↓ A ])
                                                    (Π-eta-aux-lm A B
                                                    (lambda A B
                                                     (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                                                      (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)))
-                                                     (Π-eta-left7 A B c p)) 
-                                                   (vv A) 
-                                                   (asm A)) 
-                                               (Π-e {Γ ▷ A} 
+                                                     (Π-eta-left7 A B c p))
+                                                   (vv A)
+                                                   (asm A))
+                                               (Π-e {Γ ▷ A}
                                                    (A [[ ↓ A ]])
                                                    (B [[ ↑ A (↓ A) ]])
                                                    (lambda (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])
                                                        (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                                                         (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)
-                                                        [ ↑ A (↓ A) ]))   
-                                                   (Π-eta-beta-spec2-lm A B c p) 
-                                                   (vv A) 
+                                                        [ ↑ A (↓ A) ]))
+                                                   (Π-eta-beta-spec2-lm A B c p)
+                                                   (vv A)
                                                    (asm A)))
 
 
 
 
-Π-eta-beta-spec : {Γ : ctx}  
+Π-eta-beta-spec : {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
     -> Γ ▷ A ==>
-              app (A [[ ↓ A ]]) 
+              app (A [[ ↓ A ]])
                   (B [[ ↑ A (↓ A) ]])
                   ((lambda A B
-                        (app (A [[ ↓ A ]]) 
-                             (B [[ ↑ A (↓ A) ]]) 
+                        (app (A [[ ↓ A ]])
+                             (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             (Π-eta-left3 A B c p) 
-                             (vv A) 
+                             (Π-eta-left3 A B c p)
+                             (vv A)
                              (Π-eta-left2 A B c p)))
                     [ ↓ A ])
                   (Π-eta-aux-lm A B
@@ -889,47 +889,47 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
                         (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                        (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)))
                         (Π-eta-left7 A B c p))
-                  (vv A) 
+                  (vv A)
                   (asm A)
                   ==
-              app (A [[ ↓ A ]]) 
-                  (B [[ ↑ A (↓ A) ]]) 
+              app (A [[ ↓ A ]])
+                  (B [[ ↑ A (↓ A) ]])
                   (c [ ↓ A ])
-                  (Π-eta-aux-lm A B c p) 
-                  (vv A) 
+                  (Π-eta-aux-lm A B c p)
+                  (vv A)
                   (asm A)
                :: (B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]]
-Π-eta-beta-spec {Γ} A B c p = 
+Π-eta-beta-spec {Γ} A B c p =
          tmtra {Γ ▷ A} ((B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]])
-                   _ _ 
-                   (app (A [[ ↓ A ]]) 
-                     (B [[ ↑ A (↓ A) ]]) 
+                   _ _
+                   (app (A [[ ↓ A ]])
+                     (B [[ ↑ A (↓ A) ]])
                      (c [ ↓ A ])
-                     (Π-eta-aux-lm A B c p) 
-                     (vv A) 
-                     (asm A)) 
-                   (Π-eta-beta-spec-cong {Γ} A B c p) 
-                   (Π-eta-beta-spec2 {Γ} A B c p) 
+                     (Π-eta-aux-lm A B c p)
+                     (vv A)
+                     (asm A))
+                   (Π-eta-beta-spec-cong {Γ} A B c p)
+                   (Π-eta-beta-spec2 {Γ} A B c p)
 
 -- **** stuck here 2.6.0.1
 
 
 -- ... and now the eta equality
 
-Π-eta-eq :  {Γ : ctx}  
+Π-eta-eq :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
-    -> Γ ==> lambda A B (app (A [[ ↓ A ]]) 
+    -> Γ ==> lambda A B (app (A [[ ↓ A ]])
                              (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             (Π-eta-left3 {Γ} A B c p)  
-                             (vv A) 
-                             (Π-eta-left2 {Γ} A B c p))  
+                             (Π-eta-left3 {Γ} A B c p)
+                             (vv A)
+                             (Π-eta-left2 {Γ} A B c p))
              == c ::  Π-f {Γ} A B
-Π-eta-eq {Γ} A B c p = 
+Π-eta-eq {Γ} A B c p =
     let   eq : Γ ▷ A ==>
-              app (A [[ ↓ A ]]) 
+              app (A [[ ↓ A ]])
                   (B [[ ↑ A (↓ A) ]])
                   (lambda A B
                         (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
@@ -940,24 +940,24 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
                         (app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
                        (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)))
                         (Π-eta-left7 A B c p))
-                  (vv A) 
+                  (vv A)
                   (asm A)
                   ==
-               app (A [[ ↓ A ]]) 
-                   (B [[ ↑ A (↓ A) ]]) 
+               app (A [[ ↓ A ]])
+                   (B [[ ↑ A (↓ A) ]])
                    (c [ ↓ A ])
-                   (Π-eta-aux-lm A B c p) 
-                   (vv A) 
+                   (Π-eta-aux-lm A B c p)
+                   (vv A)
                    (asm A)
                :: (B [[ ↑ A (↓ A) ]]) [[ els (asm A) ]]
-          eq = Π-eta-beta-spec {Γ} A B c p  
+          eq = Π-eta-beta-spec {Γ} A B c p
 
-    in Π-ext {Γ} A B 
-           (lambda A B (app (A [[ ↓ A ]]) 
+    in Π-ext {Γ} A B
+           (lambda A B (app (A [[ ↓ A ]])
                        (B [[ ↑ A (↓ A) ]])
                        (c [ ↓ A ])
-                       (Π-eta-left3 {Γ} A B c p)  
-                       (vv A) 
+                       (Π-eta-left3 {Γ} A B c p)
+                       (vv A)
                        (Π-eta-left2 {Γ} A B c p)))
            c
            (Π-eta-left7 {Γ} A B c p)
@@ -965,77 +965,77 @@ term-els-lm {Γ} A c =  tra' (sub-comp-prop c ( ↑ A (↓ A))  (els (asm A))) (
            eq
 
 
-Π-eta-eq-gen-lm2 :  {Γ : ctx}  
+Π-eta-eq-gen-lm2 :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
 
     -> (q1 : (Γ ▷ A) ==> vv A ::  A [[ ↓ A ]])
-    -> (q2 : (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])))  
+    -> (q2 : (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])))
 
     -> << Raw (Γ ▷ A) >>
       app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ]) q2 (vv A) q1 ~
       app (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]]) (c [ ↓ A ])
          (Π-eta-left3 A B c p) (vv A) (Π-eta-left2 A B c p)
-Π-eta-eq-gen-lm2 {Γ} A B c p q1 q2 = 
-    app-irr {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])  (c [ ↓ A ]) q2  (Π-eta-left3 A B c p) (vv A) q1  (Π-eta-left2 A B c p) 
+Π-eta-eq-gen-lm2 {Γ} A B c p q1 q2 =
+    app-irr {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])  (c [ ↓ A ]) q2  (Π-eta-left3 A B c p) (vv A) q1  (Π-eta-left2 A B c p)
 
 -- **** stuck here 2.6.0.1
 
 
-Π-eta-eq-gen-lm :  {Γ : ctx}  
+Π-eta-eq-gen-lm :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
 
     -> (q1 : (Γ ▷ A) ==> vv A ::  A [[ ↓ A ]])
-    -> (q2 : (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])))  
-    -> << Raw Γ >> (lambda A B (app (A [[ ↓ A ]]) 
+    -> (q2 : (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])))
+    -> << Raw Γ >> (lambda A B (app (A [[ ↓ A ]])
                              (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             q2  
-                             (vv A) 
+                             q2
+                             (vv A)
                              q1))
                 ~
-                 lambda A B (app (A [[ ↓ A ]]) 
+                 lambda A B (app (A [[ ↓ A ]])
                              (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             (Π-eta-left3 {Γ} A B c p)  
-                             (vv A) 
-                             (Π-eta-left2 {Γ} A B c p))  
+                             (Π-eta-left3 {Γ} A B c p)
+                             (vv A)
+                             (Π-eta-left2 {Γ} A B c p))
 Π-eta-eq-gen-lm {Γ} A B c p q1 q2 =
          Raw-lm2              -- **** stuck here 2.6.0.1
             ( λ x →
              Π-xi-raw {Γ} A {B}
-                      (app (A [[ ↓ A ]]) 
+                      (app (A [[ ↓ A ]])
                              (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             q2  
-                             (vv A) 
+                             q2
+                             (vv A)
                              q1)
-                      (app (A [[ ↓ A ]]) 
+                      (app (A [[ ↓ A ]])
                              (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             (Π-eta-left3 {Γ} A B c p)  
-                             (vv A) 
+                             (Π-eta-left3 {Γ} A B c p)
+                             (vv A)
                              (Π-eta-left2 {Γ} A B c p)) (Π-eta-eq-gen-lm2 {Γ} A B c p q1 q2) x)
 
 
-Π-eta-eq-gen :  {Γ : ctx}  
+Π-eta-eq-gen :  {Γ : ctx}
     -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
     -> (c : raw Γ)
     -> (p : Γ ==> c :: Π-f {Γ} A B)
 
     -> (q1 : (Γ ▷ A) ==> vv A ::  A [[ ↓ A ]])
-    -> (q2 : (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])))     
-    -> Γ ==> lambda A B (app (A [[ ↓ A ]]) 
+    -> (q2 : (Γ ▷ A) ==> (c [ ↓ A ]) ::   (Π-f {Γ ▷ A} (A [[ ↓ A ]]) (B [[ ↑ A (↓ A) ]])))
+    -> Γ ==> lambda A B (app (A [[ ↓ A ]])
                              (B [[ ↑ A (↓ A) ]])
                              (c [ ↓ A ])
-                             q2  
-                             (vv A) 
-                             q1)  
+                             q2
+                             (vv A)
+                             q1)
              == c ::  Π-f {Γ} A B
-Π-eta-eq-gen {Γ} A B c p q1 q2 = 
+Π-eta-eq-gen {Γ} A B c p q1 q2 =
 -- **** stuck here 2.6.0.1
    let eq = Π-eta-eq-gen-lm {Γ} A B c p q1 q2
        eq2 : << Raw Γ >>  (lambda A B

--- a/MLTT-and-setoids/V-model-pt7.agda
+++ b/MLTT-and-setoids/V-model-pt7.agda
@@ -29,26 +29,26 @@ open import V-model-pt6         -- 853 lines
 
 ext-eq' : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (Γ ==> A == A')
 -- --------------------------
      -> << Ctx >> (Γ ▷ A) ~ (Γ ▷ A')
-ext-eq' {Γ} A A' p = <<>> (ext-eq {Γ} A A' p) --  <<>> (ext-eq' {Γ} A A' p) 
+ext-eq' {Γ} A A' p = <<>> (ext-eq {Γ} A A' p) --  <<>> (ext-eq' {Γ} A A' p)
 
 
 
 
 ext-eq-lm' : {Γ : ctx}
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (p : Γ ==> A == A')
       -> (x : || κ Γ ||)
       -> (y : || κ (apt A x)||)
       -> < κ (Γ ▷ A') > aps (subst-trp (ext-eq' A A' p)) (x , y) ~ (x , (ap (κ-Fam ±± ape p x) y))
-ext-eq-lm' {Γ} A A' p x y = refl _ _ 
+ext-eq-lm' {Γ} A A' p x y = refl _ _
 
 
-mk-Par-cong :  {Γ : ctx} 
-            -> (A  A' : ty Γ) 
+mk-Par-cong :  {Γ : ctx}
+            -> (A  A' : ty Γ)
             -> (p : Γ ==> A == A')
             -> (B : ty (Γ ▷ A))
             -> (B' : ty (Γ ▷ A'))
@@ -57,11 +57,11 @@ mk-Par-cong :  {Γ : ctx}
             ->  << Par VV κ-Fam >>  ap1 (mk-Par A B) x ~ ap1 (mk-Par  A' B') x
 mk-Par-cong {Γ} A A' p B B' q x = <<>>
   (
-          (ape p x) , 
-          (λ y → 
+          (ape p x) ,
+          (λ y →
                  let
                      q1 = ape q (x , y)
-                     eq2 = (ext-eq' A A' p)  
+                     eq2 = (ext-eq' A A' p)
                      eq :  < κ (Γ ▷ A') >
                               aps (subst-trp eq2) (x , y) ~  (x , ap (κ-Fam ±± ape p x) y)
                      eq =  ext-eq-lm {Γ} A A' p x y --  <> (ext-eq-lm {Γ} A A' p x y)
@@ -72,8 +72,8 @@ mk-Par-cong {Γ} A A' p B B' q x = <<>>
                      lm = >><< (extensionality1 (ty.type B') _ _ eq)
                      main : << VV >> Fxx (ap1 (mk-Par A B) x) • y ~
                                  (Fxx (ap1 (mk-Par A' B') x) • ap (κ-Fam ±± ape p x) y)
-                     main = <<>> (traV (>><< q1) lm) 
-                 in main) 
+                     main = <<>> (traV (>><< q1) lm)
+                 in main)
    )
 
 
@@ -81,7 +81,7 @@ mk-Par-cong {Γ} A A' p B B' q x = <<>>
 
 Π-f-cong : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (p : Γ ==> A == A')
       -> (B : ty (Γ ▷ A))
       -> (B' : ty (Γ ▷ A'))

--- a/MLTT-and-setoids/V-model-pt8.agda
+++ b/MLTT-and-setoids/V-model-pt8.agda
@@ -49,7 +49,7 @@ ID-lm {Γ} A a b x y q =
                                                        p2 = pj2 p
                                                        lm :  z ∈ ID-op A a b y
                                                        lm = eq2 , traV p2 (>><< (extensionality1 (raw.rawterm a) x y q))
-                                                   in lm 
+                                                   in lm
                                           )
 
 ID-untyped : {Γ : ctx}
@@ -59,7 +59,7 @@ ID-untyped {Γ} A a b = tyy (record { op = ID-op {Γ} A a b
                            ; ext = λ x y q → <<>> (extensional-eqV (ID-op A a b x) (ID-op A a b y)
                                                      (ID-lm {Γ} A a b x y q)
                                                      (ID-lm {Γ} A a b y x (sym {κ Γ} q)))
-                                         
+
                            })
 
 
@@ -68,17 +68,17 @@ ID-untyped {Γ} A a b = tyy (record { op = ID-op {Γ} A a b
 -- formation rule for identity type
 
 ID : {Γ : ctx}
-     -> (A : ty Γ) 
+     -> (A : ty Γ)
      -> (a : raw Γ)
      -> (p : Γ ==> a :: A)
      -> (b : raw Γ)
-     -> (q : Γ ==> b :: A)    
+     -> (q : Γ ==> b :: A)
      -> ty Γ
 ID {Γ} A a p b q = tyy (record { op = ID-op {Γ} A a b
                            ; ext = λ x y q → <<>> (extensional-eqV (ID-op A a b x) (ID-op A a b y)
                                                     (ID-lm {Γ} A a b x y q)
                                                     (ID-lm {Γ} A a b y x (sym {κ Γ} q)))
-                                         
+
                            })
 
 
@@ -143,34 +143,34 @@ ID-uip {Γ} A a b t p r q = pair (λ x → pj2 (apel q x)) (pair q (ID-i {Γ} A 
 ID-sub :  {Δ Γ : ctx}
      -> (h : subst Δ Γ)
      -> (A : ty Γ)
-     -> (a : raw Γ) 
-     -> (pa : Γ ==> a :: A) 
-     -> (b : raw Γ) 
-     -> (pb : Γ ==> b :: A) 
+     -> (a : raw Γ)
+     -> (pa : Γ ==> a :: A)
+     -> (b : raw Γ)
+     -> (pb : Γ ==> b :: A)
      -> << Ty Δ >> (ID A a pa b pb) [[ h ]] ~ (ID (A [[ h ]]) (a [ h ]) (elt-subst h pa) (b [ h ]) (elt-subst h pb))
-ID-sub {Δ} {Γ} h A a pa b pb = <<>> (<<>> (λ x → <<>>  (refV _))) 
+ID-sub {Δ} {Γ} h A a pa b pb = <<>> (<<>> (λ x → <<>>  (refV _)))
 
 
 
 ID-sub-gen' :  {Δ Γ : ctx}
      -> (h : subst Δ Γ)
      -> (A : ty Γ)
-     -> (a : raw Γ) 
-     -> (pa : Γ ==> a :: A) 
-     -> (b : raw Γ) 
-     -> (pb : Γ ==> b :: A) 
+     -> (a : raw Γ)
+     -> (pa : Γ ==> a :: A)
+     -> (b : raw Γ)
+     -> (pb : Γ ==> b :: A)
      -> (q : Δ ==> a [ h ] :: A [[ h ]])
      -> (r : Δ ==> b [ h ] :: A [[ h ]])
      -> << Ty Δ >> (ID A a pa b pb) [[ h ]] ~ (ID (A [[ h ]]) (a [ h ]) q (b [ h ]) r)
-ID-sub-gen' {Δ} {Γ} h A a pa b pb q r =  <<>> (<<>> (λ x → <<>>  (refV _))) 
+ID-sub-gen' {Δ} {Γ} h A a pa b pb q r =  <<>> (<<>> (λ x → <<>>  (refV _)))
 
 ID-sub-gen :  {Δ Γ : ctx}
      -> (h : subst Δ Γ)
      -> (A : ty Γ)
-     -> (a : raw Γ) 
-     -> (pa : Γ ==> a :: A) 
-     -> (b : raw Γ) 
-     -> (pb : Γ ==> b :: A) 
+     -> (a : raw Γ)
+     -> (pa : Γ ==> a :: A)
+     -> (b : raw Γ)
+     -> (pb : Γ ==> b :: A)
      -> (q : Δ ==> a [ h ] :: A [[ h ]])
      -> (r : Δ ==> b [ h ] :: A [[ h ]])
      -> Δ ==>  (ID A a pa b pb) [[ h ]] == (ID (A [[ h ]]) (a [ h ]) q (b [ h ]) r)
@@ -179,7 +179,7 @@ ID-sub-gen {Δ} {Γ} h A a pa b pb q r = mk-eqty (λ x → <<>> (refV _))
 
 ID-cong' :  {Γ : ctx}
      -> (A A' : ty Γ)
-     -> (a b a' b' : raw Γ) 
+     -> (a b a' b' : raw Γ)
      -> (<< Ty Γ >> A ~ A')
      -> (<< Raw Γ >> a ~ a')
      -> (<< Raw Γ >> b ~ b')
@@ -188,16 +188,16 @@ ID-cong' :  {Γ : ctx}
      -> (pb : Γ ==> b :: A)
      -> (pb' : Γ ==> b' :: A')
      -> << Ty Γ >> ID A a pa b pb ~  ID A' a' pa' b' pb'
-ID-cong' {Γ} A A' a b a' b' p q1 q2 pa pa' pb pb' 
-    = <<>> (<<>> (λ x → <<>> 
-      (pair (λ r → traV (symV (>><< (>><< (>><< q1) x))) (traV r (>><< (>><< (>><< q2) x))) , (>><< (>><< (>><< q1) x))) 
+ID-cong' {Γ} A A' a b a' b' p q1 q2 pa pa' pb pb'
+    = <<>> (<<>> (λ x → <<>>
+      (pair (λ r → traV (symV (>><< (>><< (>><< q1) x))) (traV r (>><< (>><< (>><< q2) x))) , (>><< (>><< (>><< q1) x)))
             (λ r →  traV (>><< (>><< (>><< q1) x)) (traV r (symV (>><< (>><< (>><< q2) x)))) , (>><< (>><< (>><< q1) x))))))
 
 
 
 ID-cong :  {Γ : ctx}
      -> (A A' : ty Γ)
-     -> (a b a' b' : raw Γ) 
+     -> (a b a' b' : raw Γ)
      -> (pa : Γ ==> a :: A)
      -> (pa' : Γ ==> a' :: A')
      -> (pb : Γ ==> b :: A)
@@ -206,34 +206,34 @@ ID-cong :  {Γ : ctx}
      -> (Γ ==> a ==  a' :: A')
      -> (Γ ==> b ==  b' :: A')
      -> Γ ==> ID A a pa b pb == ID A' a' pa' b' pb'
-ID-cong {Γ} A A' a b a' b' pa pa' pb pb' q r1 r2 = 
-        tyeq-from-eq (ID A a pa b pb) (ID A' a' pa' b' pb') 
-                     (ID-cong' {Γ} A A' a b a' b' (<<>> (<<>> (ape q))) 
-                                                 (<<>> (<<>> (λ x → <<>> (prj1 r1 x)))) 
-                                                 (<<>> (<<>> (λ x → <<>> (prj1 r2 x)))) 
-                                                 pa pa' pb pb' ) 
+ID-cong {Γ} A A' a b a' b' pa pa' pb pb' q r1 r2 =
+        tyeq-from-eq (ID A a pa b pb) (ID A' a' pa' b' pb')
+                     (ID-cong' {Γ} A A' a b a' b' (<<>> (<<>> (ape q)))
+                                                 (<<>> (<<>> (λ x → <<>> (prj1 r1 x))))
+                                                 (<<>> (<<>> (λ x → <<>> (prj1 r2 x))))
+                                                 pa pa' pb pb' )
 
 
 rr-sub' :  {Δ Γ : ctx}
      -> (h : subst Δ Γ)
-     -> (a : raw Γ)    
+     -> (a : raw Γ)
      -> << Raw Δ >> (rr a) [ h ] ~ rr (a [ h ])
 rr-sub' {Δ} {Γ} h a = Raw-lm2 (λ x → refV _)
 
 rr-sub :  {Δ Γ : ctx}
      -> (h : subst Δ Γ)
      -> (A : ty Γ)
-     -> (a : raw Γ)    
+     -> (a : raw Γ)
      -> (p : Γ ==> a :: A)
      -> Δ ==> (rr a) [ h ] == rr (a [ h ]) ::  (ID A a p a p) [[ h ]]
-rr-sub {Δ} {Γ} h A a p = pair (λ x → refV _) 
-                               (pair (elt-subst h (ID-i A a p)) 
-                                      (elttyeq (ID-i (A [[ h ]]) (a [ h ]) (elt-subst h p)) 
-                                         (tysym (ID-sub-gen {Δ} {Γ} h A a p a p (elt-subst h p) (elt-subst h p))) )) 
+rr-sub {Δ} {Γ} h A a p = pair (λ x → refV _)
+                               (pair (elt-subst h (ID-i A a p))
+                                      (elttyeq (ID-i (A [[ h ]]) (a [ h ]) (elt-subst h p))
+                                         (tysym (ID-sub-gen {Δ} {Γ} h A a p a p (elt-subst h p) (elt-subst h p))) ))
 
 
 rr-cong' :  {Γ : ctx}
-     ->  (a  b : raw Γ) 
+     ->  (a  b : raw Γ)
      -> (<< Raw Γ >> a ~ b)
      -> << Raw Γ >> rr a ~ rr b
 rr-cong' {Γ} a b p  = p
@@ -241,10 +241,10 @@ rr-cong' {Γ} a b p  = p
 
 rr-cong :  {Γ : ctx}
      -> (A : ty Γ)
-     -> (a  b : raw Γ) 
+     -> (a  b : raw Γ)
      -> (p : Γ ==> a :: A)
      -> (Γ ==> a == b :: A)
-     -> Γ ==> (rr a) == (rr b) ::  (ID A a p a p) 
-rr-cong {Γ} A a b p q  = pair (prj1 q) (pair (ID-i A a p) (elttyeq (ID-i A b (prj2 (prj2 q))) 
+     -> Γ ==> (rr a) == (rr b) ::  (ID A a p a p)
+rr-cong {Γ} A a b p q  = pair (prj1 q) (pair (ID-i A a p) (elttyeq (ID-i A b (prj2 (prj2 q)))
                           (tysym (ID-cong {Γ} A A a a b b p (prj2 (prj2 q)) p (prj2 (prj2 q)) (tyrefl A) q q))))
 

--- a/MLTT-and-setoids/V-model-pt9.agda
+++ b/MLTT-and-setoids/V-model-pt9.agda
@@ -654,7 +654,7 @@ qq-eq :  {Δ Γ : ctx}
        -> < κ (Γ ▷ A) > aps (↑ A h) (x , y) ~ (aps h x , y)
 
 _⌢_ : {Θ Δ Γ : ctx} -> (f : subst Δ Γ) -> (g : subst Θ Δ) -> (subst Θ Γ)
-f ⌢ g = subst.sb (subst.cmap f ° subst.cmap g)
+f ⌢ g = sb (subst.cmap f ° subst.cmap g)
 --}
 
 els-h-sub :  {Δ Γ : ctx}

--- a/MLTT-and-setoids/V-model-pt9.agda
+++ b/MLTT-and-setoids/V-model-pt9.agda
@@ -27,23 +27,23 @@ open import V-model-pt8         -- 134 lines
                      -- this file  441 lines
                      -- total     6859 lines
 
-Σ-f :  {Γ : ctx} 
+Σ-f :  {Γ : ctx}
 --
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
 --     ---------------------------------------
        -> ty Γ
--- 
+--
 Σ-f A B = ty.tyy (comp01 sigmaVV (mk-Par A  B))
 
 
-Σ-f-exp1 :  {Γ : ctx} 
+Σ-f-exp1 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        ->  (apt (Σ-f A B)  u) ≐ sigmaV (apt A u) (mk-Par-op-Fx A B u)
 Σ-f-exp1 A B u = refV _
 
 -- sigmaV : (a : V) -> (g :  setoidmap1 (κ a) VV) -> V
--- sigmaV a g =  sup (Σ (# a) (\y -> # (g • y))) 
+-- sigmaV a g =  sup (Σ (# a) (\y -> # (g • y)))
 --                     (\u -> < a ‣ (pj1 u) , (g • (pj1 u)) ‣ (pj2 u) >)
 
 -- Move to iterative-sets-pt2.agda:
@@ -54,14 +54,14 @@ sigmaV-iV a g = Σ (# a) (\y -> # (g • y))
 sigmaV-bV : (a : V) -> (g :  setoidmap1 (κ a) VV) ->  sigmaV-iV a g -> V
 sigmaV-bV a g u =  < a ‣ (pj1 u) , (g • (pj1 u)) ‣ (pj2 u) >
 
-Σ-f-exp2 :  {Γ : ctx} 
+Σ-f-exp2 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (u : || κ Γ ||)
        ->  (apt (Σ-f A B)  u) ≐ sup (sigmaV-iV (apt A u) (mk-Par-op-Fx A B u))
-                                    (sigmaV-bV (apt A u) (mk-Par-op-Fx A B u))  
+                                    (sigmaV-bV (apt A u) (mk-Par-op-Fx A B u))
 Σ-f-exp2 A B u = refV _
 
-Σ-f-exp3 :  {Γ : ctx} 
+Σ-f-exp3 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (x : || κ Γ ||)
        -> (u : # (apt (Σ-f {Γ} A B)  x))
@@ -72,7 +72,7 @@ sigmaV-bV a g u =  < a ‣ (pj1 u) , (g • (pj1 u)) ‣ (pj2 u) >
 
 Σ-f-cong : {Γ : ctx}
 --
-      -> (A  A' : ty Γ) 
+      -> (A  A' : ty Γ)
       -> (p : Γ ==> A == A')
       -> (B : ty (Γ ▷ A))
       -> (B' : ty (Γ ▷ A'))
@@ -82,30 +82,30 @@ sigmaV-bV a g u =  < a ‣ (pj1 u) , (g • (pj1 u)) ‣ (pj2 u) >
 Σ-f-cong {Γ} A A' p B B' q  = mk-eqty (λ x → let lm = mk-Par-cong  {Γ} A A' p B B' q x
                                               in extensionality11 sigmaVV (ap1 (mk-Par A B) x) (ap1 (mk-Par  A' B') x) lm)
 
-pr-op : {Γ : ctx} 
+pr-op : {Γ : ctx}
 --
-      -> (a  : raw Γ) 
-      -> (b : raw Γ) 
+      -> (a  : raw Γ)
+      -> (b : raw Γ)
       -> (|| κ Γ || -> V)
-pr-op {Γ} a b x =  < apr a x , apr b x > 
+pr-op {Γ} a b x =  < apr a x , apr b x >
 
 
-pr : {Γ : ctx} 
+pr : {Γ : ctx}
 --
-      -> (a  : raw Γ) 
-      -> (b : raw Γ) 
+      -> (a  : raw Γ)
+      -> (b : raw Γ)
       -> raw Γ
-pr {Γ} a b = mkraw (record { op = pr-op {Γ} a b 
-                           ; ext = λ x y p → <<>> (pairV-ext (>><< (extensionality1 (raw.rawterm a) x y p)) 
+pr {Γ} a b = mkraw (record { op = pr-op {Γ} a b
+                           ; ext = λ x y p → <<>> (pairV-ext (>><< (extensionality1 (raw.rawterm a) x y p))
                                                        (>><< (extensionality1 (raw.rawterm b) x y p)))
                            })
 
 
 
-pr-cong' : {Γ : ctx} 
+pr-cong' : {Γ : ctx}
 --
-      -> (a a'  : raw Γ) 
-      -> (b b' : raw Γ) 
+      -> (a a'  : raw Γ)
+      -> (b b' : raw Γ)
       -> << Raw Γ >> a ~ a'
       -> << Raw Γ >> b ~ b'
       -> << Raw Γ >> pr a b ~ pr a' b'
@@ -113,9 +113,9 @@ pr-cong' a a' b b' p q  = Raw-lm2 (\x -> pairV-ext (Raw-lm p x) (Raw-lm q x))
 
 
 Σ-i : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))
@@ -123,39 +123,39 @@ pr-cong' a a' b b' p q  = Raw-lm2 (\x -> pairV-ext (Raw-lm p x) (Raw-lm q x))
 Σ-i {Γ} A B a p b q = mk-elt (λ x → ((pj1 (apel p x)) , (pj1 (apel q x))) , pairV-ext (pj2 (apel p x)) (pj2 (apel q x)))
 
 
-pr-cong : {Γ : ctx} 
+pr-cong : {Γ : ctx}
 --
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a a'  : raw Γ) 
-      -> (b b' : raw Γ) 
+      -> (a a'  : raw Γ)
+      -> (b b' : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (Γ ==> a == a' :: A)
       -> (Γ ==> b == b' :: (B [[ els p ]]))
       -> Γ ==> pr a b == pr a' b' :: Σ-f A B
 
-pr-cong {Γ} A B a a' b b' p q1 q2  = 
+pr-cong {Γ} A B a a' b b' p q1 q2  =
    let --  r' = Σ-e-1 A B c' p'
         -- lm = Σ-e-2 {Γ} A B c' p' r'
         lm2 : < Subst Γ (Γ ▷ A) >  els p ~ els (prj2 (prj2 q1))
         lm2 = els-cong p (prj2 (prj2 q1)) q1 -- els-cong (Σ-e-1 A B c' p') r (pr1-cong A B c' c p' p (tmsym (Σ-f A B) _ _ q ))
         lm3 :  Γ ==>  B [[ els p ]] == B [[ els (prj2 (prj2 q1)) ]]
-        lm3 = tyeq-subst2 B _ _ lm2 
+        lm3 = tyeq-subst2 B _ _ lm2
         lm4 : Γ ==> b' :: B [[ els (prj2 (prj2 q1)) ]]
         lm4 = elttyeq (prj2 (prj2 q2)) lm3
 
-   in  elteq-from-eq (Σ-f A B) (pr a b) (pr a' b') 
-                (Σ-i {Γ} A B a p b (prj1 (prj2 q2))) 
-                (Σ-i {Γ} A B a' (prj2 (prj2 q1)) b' lm4) 
+   in  elteq-from-eq (Σ-f A B) (pr a b) (pr a' b')
+                (Σ-i {Γ} A B a p b (prj1 (prj2 q2)))
+                (Σ-i {Γ} A B a' (prj2 (prj2 q1)) b' lm4)
                 (pr-cong' a a' b b' (eq-from-elteq A a a' q1) (eq-from-elteq (B [[ els p ]]) b b' q2) )
 
 {--
 
 
- 
+
 
 eq-from-elteq : {Γ : ctx} -> (A : ty Γ) ->  (a b : raw Γ)
-      -> Γ ==> a == b :: A 
+      -> Γ ==> a == b :: A
 --   -------------------------
      ->  << Raw Γ >> a ~ b
 
@@ -164,10 +164,10 @@ elteq-from-eq : {Γ : ctx} -> (A : ty Γ) ->  (a b : raw Γ)
 --   -------------------------
      -> Γ ==> a == b :: A
 elteq-from-eq A a b p q r =  pair (λ x → >><< (>><< (>><< r) x))
-                                  (pair p q) 
+                                  (pair p q)
 
 pr1-cong' : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c c'  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -180,13 +180,13 @@ pr1-cong' : {Γ : ctx}
 -- see iterative-sets-pt2.agd
 
 pr1-op : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (Γ ==> c :: Σ-f A B)
       -> (|| κ Γ || -> V)
 pr1-op {Γ} A B c p x =  apt A x  ‣ pj1 (pj1 (apel p x))
-  
+
 -- pj1-sigmaV-op : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
 --             ||  κ (sigmaV a g) || -> V
 -- pj1-sigmaV-op a g u = a ‣ (pj1 u)
@@ -195,7 +195,7 @@ pr1-op {Γ} A B c p x =  apt A x  ‣ pj1 (pj1 (apel p x))
 --             setoidmap1 (κ (sigmaV a g)) VV
 
 pr1-ext  : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -211,7 +211,7 @@ pr1-ext {Γ} A B c p x y q =  -- extensionality1 ((raw.rawterm c)) x y q
            eq2 = traV (symV lm2) (traV eq lm4)
            eq3 : < (apt A x) ‣ (pj1 (pj1 (apel p x))) , (apt B  (x , (pj1  (pj1 (apel p x))))) ‣ (pj2 (pj1 (apel p x))) >
                ≐ < (apt A y) ‣ (pj1 (pj1 (apel p y))) , (apt B  (y , (pj1  (pj1 (apel p y))))) ‣ (pj2 (pj1 (apel p y))) >
-           eq3 = traV (symV (Σ-f-exp3 A B x (pj1 (apel p x)))) (traV eq2 (Σ-f-exp3 A B y (pj1 (apel p y)))) 
+           eq3 = traV (symV (Σ-f-exp3 A B x (pj1 (apel p x)))) (traV eq2 (Σ-f-exp3 A B y (pj1 (apel p y))))
 
 
            main : apt A x  ‣ pj1 (pj1 (apel p x)) ≐  apt A y  ‣ pj1 (pj1 (apel p y))
@@ -220,16 +220,16 @@ pr1-ext {Γ} A B c p x y q =  -- extensionality1 ((raw.rawterm c)) x y q
 
 
 pr1 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (Γ ==> c :: Σ-f A B)
       -> raw Γ
-pr1 {Γ} A B c p = mkraw (record { op = pr1-op {Γ} A B c p 
+pr1 {Γ} A B c p = mkraw (record { op = pr1-op {Γ} A B c p
                                 ; ext = pr1-ext {Γ} A B c p })
 
 pr1-cong' : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c c'  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -252,7 +252,7 @@ pr1-cong' {Γ} A B c c' p p' q = Raw-lm2 {Γ}
              ≐ < apt A x ‣ pj1 (pj1 (apel p' x)) ,  apt B (x , pj1 (pj1 (apel p' x))) ‣ pj2 (pj1 (apel p' x)) >
        lm6 = traV (symV lm1) (traV (traV (symV  lm2) (traV lm5 lm4)) lm3)
        main :   (apr (pr1 A B c p)  x) ≐ (apr (pr1 A B c' p')  x)
-             
+
        main =  prj1 (pairV-inv-1 lm6)
    in main)
 
@@ -260,49 +260,49 @@ pr1-cong' {Γ} A B c c' p p' q = Raw-lm2 {Γ}
 
 
 Σ-e-1 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
       -> Γ ==> pr1 A B c p :: A
- 
+
 Σ-e-1 {Γ} A B c p = mk-elt (λ x → (pj1 (pj1 (apel p x))) , (refV _))
 
 
 
 
 pr1-cong : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c c'  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
       -> (p' : Γ ==> c' :: Σ-f A B)
       -> (Γ ==> c == c' :: Σ-f A B)
       -> Γ ==> pr1 {Γ} A B c p ==  pr1 {Γ} A B c' p' :: A
-pr1-cong {Γ} A B c c' p p' q = 
-   elteq-from-eq A (pr1 {Γ} A B c p) (pr1 {Γ} A B c' p') (Σ-e-1 {Γ} A B c p) (Σ-e-1 {Γ} A B c' p') 
+pr1-cong {Γ} A B c c' p p' q =
+   elteq-from-eq A (pr1 {Γ} A B c p) (pr1 {Γ} A B c' p') (Σ-e-1 {Γ} A B c p) (Σ-e-1 {Γ} A B c' p')
              (pr1-cong' A B c c' p p' (<<>> (<<>> (λ x → <<>> (prj1 q x)))))
 
 
 pr2-op : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (Γ ==> c :: Σ-f A B)
       -> (|| κ Γ || -> V)
-pr2-op {Γ} A B c p x = (apt B (x , pj1 (pj1 (apel p x)))) ‣ pj2 (pj1 (apel p x)) 
+pr2-op {Γ} A B c p x = (apt B (x , pj1 (pj1 (apel p x)))) ‣ pj2 (pj1 (apel p x))
 
 
 
 pr2-ext  : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
       -> (x y : || κ Γ ||)
       -> (q : < κ Γ > x ~ y)
       -> << VV >> pr2-op A B c p x ~ pr2-op A B c p y
-pr2-ext {Γ} A B c p x y q = 
+pr2-ext {Γ} A B c p x y q =
    let     lm2 = pj2 (apel p x)
            lm4 = pj2 (apel p y)
            eq : apr c x ≐ apr c y
@@ -311,46 +311,46 @@ pr2-ext {Γ} A B c p x y q =
            eq2 = traV (symV lm2) (traV eq lm4)
            eq3 : < (apt A x) ‣ (pj1 (pj1 (apel p x))) , (apt B  (x , (pj1  (pj1 (apel p x))))) ‣ (pj2 (pj1 (apel p x))) >
                ≐ < (apt A y) ‣ (pj1 (pj1 (apel p y))) , (apt B  (y , (pj1  (pj1 (apel p y))))) ‣ (pj2 (pj1 (apel p y))) >
-           eq3 = traV (symV (Σ-f-exp3 A B x (pj1 (apel p x)))) (traV eq2 (Σ-f-exp3 A B y (pj1 (apel p y)))) 
+           eq3 = traV (symV (Σ-f-exp3 A B x (pj1 (apel p x)))) (traV eq2 (Σ-f-exp3 A B y (pj1 (apel p y))))
 
 
-           main : (apt B (x , pj1 (pj1 (apel p x)))) ‣ pj2 (pj1 (apel p x)) ≐ (apt B (y , pj1 (pj1 (apel p y)))) ‣ pj2 (pj1 (apel p y)) 
+           main : (apt B (x , pj1 (pj1 (apel p x)))) ‣ pj2 (pj1 (apel p x)) ≐ (apt B (y , pj1 (pj1 (apel p y)))) ‣ pj2 (pj1 (apel p y))
            main = prj2 (pairV-inv-1 eq3)
    in <<>> main
-  
+
 
 
 pr2 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (Γ ==> c :: Σ-f A B)
       -> raw Γ
-pr2 {Γ} A B c p = mkraw (record { op = pr2-op {Γ} A B c p 
+pr2 {Γ} A B c p = mkraw (record { op = pr2-op {Γ} A B c p
                                 ; ext = pr2-ext {Γ} A B c p })
 
 
 
 Σ-e-2-lm : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
       -> (q : Γ ==> pr1 A B c p :: A)
       -> (x : || κ Γ ||)
       -> apr (pr2 A B c p) x ∈ apt (B [[ els q ]]) x
-Σ-e-2-lm {Γ} A B c p q x = 
+Σ-e-2-lm {Γ} A B c p q x =
    let lm : apt (Σ-f A B) x ‣ pj1 (apel p x) ≐
                < apt A x ‣ pj1 (pj1 (apel p x)) ,  apt B (x , pj1 (pj1 (apel p x))) ‣ pj2 (pj1 (apel p x)) >
        lm = Σ-f-exp3 A B x (pj1 (apel p x))
-       lm2 : < apt A x ‣ pj1 (pj1 (apel p x)) ,  apt B (x , pj1 (pj1 (apel p x))) ‣ pj2 (pj1 (apel p x)) > 
+       lm2 : < apt A x ‣ pj1 (pj1 (apel p x)) ,  apt B (x , pj1 (pj1 (apel p x))) ‣ pj2 (pj1 (apel p x)) >
              ∈ sigmaV (apt A x) (mk-Par-op-Fx A B x)
        lm2 = memV-right-ext _ _ _ (pj1 (apel p x) , (symV lm)) (symV (Σ-f-exp1 {Γ} A B x))
        lm3 = sigmaV-lm (apt A x) (mk-Par-op-Fx A B x) _ _ lm2
        q2 = pj1 lm3
        pq1 = pj1 (apel q x)
        pq2 = pj2 (apel q x)
-       
+
        lm4 :  apt B (x , pj1 (pj1 (apel p x))) ‣ pj2 (pj1 (apel p x)) ∈
                       mk-Par-op-Fx A B x • pj1 q2
        lm4 = pj2 lm3
@@ -359,7 +359,7 @@ pr2 {Γ} A B c p = mkraw (record { op = pr2-op {Γ} A B c p
        eq3 :  (ty.type A • x)  ≐  (ty.type A • aps  (ids {Γ}) x)
        eq3 = refV _
        eq2 :  (ty.type A • x) ‣ pj1 (pj1 (apel p x)) ≐  (ty.type A • aps  (ids {Γ}) x) ‣ pj1 (apel q x)
-       eq2 = pq2 
+       eq2 = pq2
 
        eq :  < κ (Γ ▷ A) > x , pj1 (pj1 (apel p x)) ~  ap (subst.cmap (els q)) x
        eq = <> (pairV-ext eq1 eq2)
@@ -368,12 +368,12 @@ pr2 {Γ} A B c p = mkraw (record { op = pr2-op {Γ} A B c p
        main : apr (pr2 A B c p) x ∈ apt (B [[ els q ]]) x
        main = memV-right-ext _ _ _ lm4 lm5
    in main
-      
+
 
 
 
 pr2-cong' : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c c'  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -381,7 +381,7 @@ pr2-cong' : {Γ : ctx}
       -> << Raw Γ >>  c ~ c'
       -> << Raw Γ >> pr2 {Γ} A B c p ~  pr2 {Γ} A B c' p'
 pr2-cong' {Γ} A B c c' p p' q = Raw-lm2 {Γ}
-   (\x -> 
+   (\x ->
    let lm1 : apt (Σ-f A B) x ‣ pj1 (apel p x) ≐
                < apt A x ‣ pj1 (pj1 (apel p x)) ,  apt B (x , pj1 (pj1 (apel p x))) ‣ pj2 (pj1 (apel p x)) >
        lm1 = Σ-f-exp3 A B x (pj1 (apel p x))
@@ -396,13 +396,13 @@ pr2-cong' {Γ} A B c c' p p' q = Raw-lm2 {Γ}
              ≐ < apt A x ‣ pj1 (pj1 (apel p' x)) ,  apt B (x , pj1 (pj1 (apel p' x))) ‣ pj2 (pj1 (apel p' x)) >
        lm6 = traV (symV lm1) (traV (traV (symV  lm2) (traV lm5 lm4)) lm3)
        main :  (apr (pr2 A B c p)  x) ≐ (apr (pr2 A B c' p')  x)
-             
+
        main =  prj2 (pairV-inv-1 lm6)
    in main)
 
 
 Σ-e-2 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -412,7 +412,7 @@ pr2-cong' {Γ} A B c c' p p' q = Raw-lm2 {Γ}
 
 
 pr2-cong : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c c'  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -420,7 +420,7 @@ pr2-cong : {Γ : ctx}
       -> (Γ ==> c == c' :: Σ-f A B)
       -> (r : Γ ==> pr1 {Γ} A B c p :: A)
       -> Γ ==> pr2 {Γ} A B c p ==  pr2{Γ} A B c' p' :: B [[ els r ]]
-pr2-cong {Γ} A B c c' p p' q r = 
+pr2-cong {Γ} A B c c' p p' q r =
     let r' = Σ-e-1 A B c' p'
         lm = Σ-e-2 {Γ} A B c' p' r'
         lm2 : < Subst Γ (Γ ▷ A) > els (Σ-e-1 A B c' p') ~ els r
@@ -428,16 +428,16 @@ pr2-cong {Γ} A B c c' p p' q r =
         lm3 :  Γ ==> B [[ els (Σ-e-1 A B c' p') ]] == B [[ els r ]]
         lm3 = tyeq-subst2 B _ _ lm2
 
-    in      elteq-from-eq (B [[ els r ]]) (pr2 {Γ} A B c p) (pr2 {Γ} A B c' p') 
-               (Σ-e-2 {Γ} A B c p r) (elttyeq lm lm3)  (pr2-cong' A B c c' p p' (<<>> (<<>> (λ x → <<>> (prj1 q x))))) 
+    in      elteq-from-eq (B [[ els r ]]) (pr2 {Γ} A B c p) (pr2 {Γ} A B c' p')
+               (Σ-e-2 {Γ} A B c p r) (elttyeq lm lm3)  (pr2-cong' A B c c' p p' (<<>> (<<>> (λ x → <<>> (prj1 q x)))))
 
---   elteq-from-eq A (pr1 {Γ} A B c p) (pr1 {Γ} A B c' p') (Σ-e-1 {Γ} A B c p) (Σ-e-1 {Γ} A B c' p') 
+--   elteq-from-eq A (pr1 {Γ} A B c p) (pr1 {Γ} A B c' p') (Σ-e-1 {Γ} A B c p) (Σ-e-1 {Γ} A B c' p')
 --             (pr1-cong' A B c c' p p' (<<>> (<<>> (λ x → <<>> (prj1 q x)))))
 
-{-- 
+{--
 
 pr1-cong : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c c'  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -445,14 +445,14 @@ pr1-cong : {Γ : ctx}
       -> (Γ ==> c == c' :: Σ-f A B)
       -> Γ ==> pr1 {Γ} A B c p ==  pr1 {Γ} A B c' p' :: A
 
-tyeq-subst2 :  {Δ Γ : ctx} -> (A : ty Γ) -> (f g : subst Δ Γ) 
+tyeq-subst2 :  {Δ Γ : ctx} -> (A : ty Γ) -> (f g : subst Δ Γ)
 --
                   -> < Subst Δ Γ > f ~ g
---      -------------------------------------------------- 
+--      --------------------------------------------------
          -> Δ ==> A [[ f ]] ==  A [[ g ]]
 
-els-cong :   {Γ : ctx} 
-    -> {A : ty Γ}   
+els-cong :   {Γ : ctx}
+    -> {A : ty Γ}
     -> {a a' : raw Γ}
     -> (p : Γ ==> a :: A)
     -> (q : Γ ==> a' :: A)
@@ -464,16 +464,16 @@ els-cong :   {Γ : ctx}
 --}
 
 Σ-c-1-raw : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))
       -> (q : Γ ==> pr a b :: Σ-f A B)
       -> (x : || κ Γ ||)
       -> apr (pr1 A B (pr a b) q) x ≐ apr a x
-Σ-c-1-raw {Γ} A B a p b r q x = 
+Σ-c-1-raw {Γ} A B a p b r q x =
     let   lm : apt (Σ-f A B) x ‣ pj1 (apel q x) ≐
                  < apt A x ‣ pj1 (pj1 (apel q x)) ,  apt B (x , pj1 (pj1 (apel q x))) ‣ pj2 (pj1 (apel q x)) >
           lm = Σ-f-exp3 A B x (pj1 (apel q x))
@@ -489,9 +489,9 @@ els-cong :   {Γ : ctx}
 
 
 Σ-c-1 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))
@@ -499,19 +499,19 @@ els-cong :   {Γ : ctx}
       -> Γ ==> pr1 A B (pr a b) q == a :: A
 Σ-c-1 {Γ} A B a p b r q =  pair (Σ-c-1-raw {Γ} A B a p b r q) (pair (Σ-e-1 {Γ} A B (pr a b) q) p)
 
- 
+
 
 Σ-c-2-raw : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))
       -> (q : Γ ==> pr a b :: Σ-f A B)
       -> (x : || κ Γ ||)
       -> apr (pr2 A B (pr a b) q) x ≐ apr b x
-Σ-c-2-raw {Γ} A B a p b r q x  =   
+Σ-c-2-raw {Γ} A B a p b r q x  =
   let     lm : apt (Σ-f A B) x ‣ pj1 (apel q x) ≐
                  < apt A x ‣ pj1 (pj1 (apel q x)) ,  apt B (x , pj1 (pj1 (apel q x))) ‣ pj2 (pj1 (apel q x)) >
           lm = Σ-f-exp3 A B x (pj1 (apel q x))
@@ -523,20 +523,20 @@ els-cong :   {Γ : ctx}
           main :  apr (pr2 A B (pr a b) q) x ≐ apr b x
           main = symV (prj2 lm4)
     in main
-    
 
-  
+
+
 
 Σ-c-2 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))
       -> (q : Γ ==> pr a b :: Σ-f A B)
       ->  Γ ==> pr2 A B (pr a b) q == b  :: (B [[ els p ]])
-Σ-c-2 {Γ} A B a p b r q = pair (Σ-c-2-raw {Γ} A B a p b r q) 
+Σ-c-2 {Γ} A B a p b r q = pair (Σ-c-2-raw {Γ} A B a p b r q)
                                (pair (subj-red {Γ} {B [[ els p ]]}
                                                b (pr2 A B (pr a b) q) r
                                                (sym' (Raw-lm2 (Σ-c-2-raw {Γ} A B a p b r q)))) r)
@@ -546,13 +546,13 @@ els-cong :   {Γ : ctx}
 
 
 Σ-c-eta-raw : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
       -> (x : || κ Γ ||)
       -> apr c x ≐ apr (pr (pr1 A B c p) (pr2 A B c p)) x
-Σ-c-eta-raw {Γ} A B c p x = 
+Σ-c-eta-raw {Γ} A B c p x =
    let lm : apt (Σ-f A B) x ‣ pj1 (apel p x) ≐
                < apt A x ‣ pj1 (pj1 (apel p x)) ,  apt B (x , pj1 (pj1 (apel p x))) ‣ pj2 (pj1 (apel p x)) >
        lm = Σ-f-exp3 A B x (pj1 (apel p x))
@@ -565,30 +565,30 @@ els-cong :   {Γ : ctx}
 
 
 Σ-c-eta : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
       ->  Γ ==> c == pr (pr1 A B c p) (pr2 A B c p) :: Σ-f A B
-Σ-c-eta {Γ} A B c p = pair (Σ-c-eta-raw {Γ} A B c p) 
-                           (pair p 
-                                (Σ-i {Γ} A B (pr1 A B c p) (Σ-e-1 {Γ} A B c p) 
+Σ-c-eta {Γ} A B c p = pair (Σ-c-eta-raw {Γ} A B c p)
+                           (pair p
+                                (Σ-i {Γ} A B (pr1 A B c p) (Σ-e-1 {Γ} A B c p)
                                              (pr2 A B c p) (Σ-e-2 {Γ} A B c p (Σ-e-1 {Γ} A B c p))))
 
 
 -- substituting into a Pi-type
 
-Σ-f-sub :  {Δ Γ : ctx} 
+Σ-f-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ) 
+       -> (A : ty Γ)   -> (B : ty (Γ ▷ A))  -> (h : subst Δ Γ)
 --     ---------------------------------------
-       -> Δ ==>  (Σ-f A B) [[ h ]] ==  Σ-f (A [[ h ]]) (B [[ ↑ A h ]]) 
+       -> Δ ==>  (Σ-f A B) [[ h ]] ==  Σ-f (A [[ h ]]) (B [[ ↑ A h ]])
 Σ-f-sub {Δ} {Γ} A B h = mk-eqty (\u ->
-    let lm :  << VV >> ap11 sigmaVV (ap1 (mk-Par A B) (aps h u)) ~ 
-                      ap11 sigmaVV (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]]) ) u) 
-        lm = extensionality11 sigmaVV 
-                              (ap1 (mk-Par A B) (aps h u)) 
-                              (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) u) 
+    let lm :  << VV >> ap11 sigmaVV (ap1 (mk-Par A B) (aps h u)) ~
+                      ap11 sigmaVV (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]]) ) u)
+        lm = extensionality11 sigmaVV
+                              (ap1 (mk-Par A B) (aps h u))
+                              (ap1 (mk-Par (A [[ h ]]) (B [[ ↑ A h ]])) u)
                               (mk-Par-sub {Δ} {Γ} A B h u)
     in lm)
 
@@ -596,33 +596,33 @@ els-cong :   {Γ : ctx}
 
 -- move to pt1
 
-els-lm : {Γ : ctx} 
+els-lm : {Γ : ctx}
 --
-       -> (A : ty Γ)    
+       -> (A : ty Γ)
        -> (a   : raw Γ)
        -> (p : Γ ==> a :: A)
        -> (x : || κ Γ ||)
        -> < κ (Γ ▷ A) > aps (els p) x  ~ (x , pj1 (apel p x))
-els-lm {Γ} A a p x = refl (κ (Γ ▷ A)) (aps (els p) x) 
+els-lm {Γ} A a p x = refl (κ (Γ ▷ A)) (aps (els p) x)
 
-{-- 
-qq-eq :  {Δ Γ : ctx} 
-       -> (A : ty Γ)    -> (h : subst Δ Γ) 
+{--
+qq-eq :  {Δ Γ : ctx}
+       -> (A : ty Γ)    -> (h : subst Δ Γ)
        -> (x : # Δ)
        -> (y : # (apt (A [[ h ]]) x))
-       -> < κ (Γ ▷ A) > aps (↑ A h) (x , y) ~ (aps h x , y) 
+       -> < κ (Γ ▷ A) > aps (↑ A h) (x , y) ~ (aps h x , y)
 --}
 
-els-h-sub-lm :  {Δ Γ : ctx} 
+els-h-sub-lm :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)    
+       -> (A : ty Γ)
        -> (a   : raw Γ)
        -> (p : Γ ==> a :: A)
-       -> (h : subst Δ Γ) 
+       -> (h : subst Δ Γ)
        -> (x : || κ Δ ||)
-       -> < κ (Γ ▷ A) >  ap (subst.cmap (els p ⌢ h)) x  ~ 
+       -> < κ (Γ ▷ A) >  ap (subst.cmap (els p ⌢ h)) x  ~
                          ap (subst.cmap (↑ A h ⌢ els (elt-subst h p))) x
-els-h-sub-lm {Δ} {Γ} A a p h x =  
+els-h-sub-lm {Δ} {Γ} A a p h x =
       let  lm1 : < κ (Γ ▷ A) >  ap (subst.cmap (els p ⌢ h)) x  ~ aps (els p) (aps h x)
            lm1 = refl (κ (Γ ▷ A)) (aps (els p) (aps h x))
            lm2 : < κ (Γ ▷ A) >  ap (subst.cmap (↑ A h ⌢ els (elt-subst h p))) x  ~ aps (↑ A h) (aps (els (elt-subst h p)) x)
@@ -633,12 +633,12 @@ els-h-sub-lm {Δ} {Γ} A a p h x =
            lm4 = els-lm {Δ} (A [[ h ]]) (a [ h ] ) (elt-subst h p) x
            lm4b : < κ (Γ ▷ A) > aps (↑ A h) (x , pj1 (apel (elt-subst h p) x)) ~  aps (↑ A h) (aps (els (elt-subst h p)) x)
            lm4b = aps-ext (↑ A h) _ _ lm4
-           lm5 :  < κ (Γ ▷ A) > aps (↑ A h) (x ,  pj1 (apel (elt-subst h p) x)) ~ (aps h x , pj1 (apel (elt-subst h p) x)) 
+           lm5 :  < κ (Γ ▷ A) > aps (↑ A h) (x ,  pj1 (apel (elt-subst h p) x)) ~ (aps h x , pj1 (apel (elt-subst h p) x))
            lm5 = qq-eq A h x (pj1 (apel (elt-subst h p) x))
            lm6 :  < κ (Γ ▷ A) >  ((aps h x) , pj1 (apel p (aps h x))) ~ (aps h x , pj1 (apel (elt-subst h p) x))
            lm6 = <> (pairV-ext (refV _) (refV _))
            lm7 :  < κ (Γ ▷ A) > aps (els p) (aps h x) ~ aps (↑ A h) (aps (els (elt-subst h p)) x)
-           lm7 = tra lm3 (tra lm6 (tra (sym lm5) lm4b)) 
+           lm7 = tra lm3 (tra lm6 (tra (sym lm5) lm4b))
 
       in tra lm1 (tra lm7 (sym lm2))
 
@@ -647,37 +647,37 @@ els-h-sub-lm {Δ} {Γ} A a p h x =
 
 {--
 
-qq-eq :  {Δ Γ : ctx} 
-       -> (A : ty Γ)    -> (h : subst Δ Γ) 
+qq-eq :  {Δ Γ : ctx}
+       -> (A : ty Γ)    -> (h : subst Δ Γ)
        -> (x : # Δ)
        -> (y : # (apt (A [[ h ]]) x))
-       -> < κ (Γ ▷ A) > aps (↑ A h) (x , y) ~ (aps h x , y) 
+       -> < κ (Γ ▷ A) > aps (↑ A h) (x , y) ~ (aps h x , y)
 
 _⌢_ : {Θ Δ Γ : ctx} -> (f : subst Δ Γ) -> (g : subst Θ Δ) -> (subst Θ Γ)
 f ⌢ g = subst.sb (subst.cmap f ° subst.cmap g)
 --}
 
-els-h-sub :  {Δ Γ : ctx} 
+els-h-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)    
+       -> (A : ty Γ)
        -> (a   : raw Γ)
        -> (p : Γ ==> a :: A)
-       -> (h : subst Δ Γ) 
+       -> (h : subst Δ Γ)
 -- ---------------------------------------------------------------
        -> < Subst Δ (Γ ▷ A) > ((els p) ⌢ h)  ~  (( ↑ A h) ⌢ (els (elt-subst h p)))
-els-h-sub {Δ} {Γ} A a p h = <> (<> (λ x → (els-h-sub-lm {Δ} {Γ} A a p h x))) 
+els-h-sub {Δ} {Γ} A a p h = <> (<> (λ x → (els-h-sub-lm {Δ} {Γ} A a p h x)))
 
-B-els-h-sub :  {Δ Γ : ctx} 
+B-els-h-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   
-       -> (B : ty (Γ ▷ A))  
+       -> (A : ty Γ)
+       -> (B : ty (Γ ▷ A))
        -> (a   : raw Γ)
        -> (p : Γ ==> a :: A)
-       -> (h : subst Δ Γ) 
+       -> (h : subst Δ Γ)
 -- ---------------------------------------------------------------
        ->  Δ ==> (B [[ els p ]] [[ h ]]) == (B [[ ↑ A h ]] [[ els (elt-subst h p) ]])
 --
-B-els-h-sub {Δ} {Γ} A B a p h = 
+B-els-h-sub {Δ} {Γ} A B a p h =
      let lm1 : Δ ==> (B [[ els p ]] [[ h ]]) == (B [[ (els p) ⌢ h ]])
          lm1 = tysym (tysubst-com  B (els p) h)
          lm2 : Δ ==>  (B [[ ↑ A h ]] [[ els (elt-subst h p) ]]) ==  (B [[ ( ↑ A h) ⌢ (els (elt-subst h p)) ]])
@@ -693,34 +693,34 @@ e+prop : {u v : V} -> (p : u ≐ v)
 --}
 
 
-pr-sub :  {Δ Γ : ctx} 
+pr-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   
-       -> (B : ty (Γ ▷ A))  
-       -> (h : subst Δ Γ) 
+       -> (A : ty Γ)
+       -> (B : ty (Γ ▷ A))
+       -> (h : subst Δ Γ)
        -> (a b  : raw Γ)
        -> (p : Γ ==> a :: A)
        -> (Γ ==> b :: (B [[ els p ]]))
- 
+
 --     ---------------------------------------
        -> Δ ==>  (pr a b) [ h ] ==  pr (a [ h ]) (b [ h ])  :: (Σ-f A B) [[ h ]]
-pr-sub {Δ} {Γ} A B h a b p q = 
- let  
-      lm : Δ ==>  (Σ-f A B) [[ h ]] ==  Σ-f (A [[ h ]]) (B [[ ↑ A h ]]) 
+pr-sub {Δ} {Γ} A B h a b p q =
+ let
+      lm : Δ ==>  (Σ-f A B) [[ h ]] ==  Σ-f (A [[ h ]]) (B [[ ↑ A h ]])
       lm = Σ-f-sub {Δ} {Γ} A B h
       ph : Δ ==> a [ h ] :: A  [[ h ]]
       ph = elt-subst h p
       q' : Δ ==> b [ h ] :: (B [[ els p ]] [[ h ]])
       q' = elt-subst h q
       lm1 :  Δ ==> (B [[ els p ]] [[ h ]]) == (B [[ ↑ A h ]] [[ els ph ]])
-      lm1 = B-els-h-sub {Δ} {Γ} A B a p h  
+      lm1 = B-els-h-sub {Δ} {Γ} A B a p h
       qh : Δ ==> b [ h ] :: (B [[ ↑ A h ]] [[ els ph ]])
       qh =  elttyeq q' lm1
 
 
-      lm2 : Δ ==>  pr (a [ h ]) (b [ h ])  ::  Σ-f (A [[ h ]]) (B [[ ↑ A h ]]) 
+      lm2 : Δ ==>  pr (a [ h ]) (b [ h ])  ::  Σ-f (A [[ h ]]) (B [[ ↑ A h ]])
       lm2 = Σ-i (A [[ h ]]) (B [[ ↑ A h ]]) (a [ h ]) ph (b [ h ]) qh
- 
+
 
       lm3 : Δ ==> pr (a [ h ]) (b [ h ]) :: Σ-f A B [[ h ]]
       lm3 = elttyeq lm2 (tysym lm)
@@ -729,7 +729,7 @@ pr-sub {Δ} {Γ} A B h a b p q =
 {--
 
 pr1-op : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (Γ ==> c :: Σ-f A B)
@@ -737,15 +737,15 @@ pr1-op : {Γ : ctx}
 pr1-op {Γ} A B c p x =  apt A x  ‣ pj1 (pj1 (apel p x))
 
 pr1 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (Γ ==> c :: Σ-f A B)
       -> raw Γ
-pr1 {Γ} A B c p = mkraw (record { op = pr1-op {Γ} A B c p 
+pr1 {Γ} A B c p = mkraw (record { op = pr1-op {Γ} A B c p
                                 ; ext = pr1-ext {Γ} A B c p })
 
-sub-apply : {Δ Γ : ctx}  
+sub-apply : {Δ Γ : ctx}
      -> (a : raw Γ) ->  (f : subst Δ Γ) -> (x : || κ Δ ||)
      -> apr (a [ f ]) x ≐ apr a (aps f x)
 sub-apply a f x = refV _
@@ -754,9 +754,9 @@ sub-apply a f x = refV _
            eq2 = traV (symV lm2) (traV eq lm4)
            eq3 : < (apt A x) ‣ (pj1 (pj1 (apel p x))) , (apt B  (x , (pj1  (pj1 (apel p x))))) ‣ (pj2 (pj1 (apel p x))) >
                ≐ < (apt A y) ‣ (pj1 (pj1 (apel p y))) , (apt B  (y , (pj1  (pj1 (apel p y))))) ‣ (pj2 (pj1 (apel p y))) >
-           eq3 = traV (symV (Σ-f-exp3 A B x (pj1 (apel p x)))) (traV eq2 (Σ-f-exp3 A B y (pj1 (apel p y)))) 
+           eq3 = traV (symV (Σ-f-exp3 A B x (pj1 (apel p x)))) (traV eq2 (Σ-f-exp3 A B y (pj1 (apel p y))))
 
-Σ-f-exp3 :  {Γ : ctx} 
+Σ-f-exp3 :  {Γ : ctx}
        -> (A : ty Γ)   -> (B : ty (Γ ▷ A))
        -> (x : || κ Γ ||)
        -> (u : # (apt (Σ-f {Γ} A B)  x))
@@ -765,41 +765,41 @@ sub-apply a f x = refV _
 
 --}
 
-pr1-sub-raw :  {Δ Γ : ctx} 
+pr1-sub-raw :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   
-       -> (B : ty (Γ ▷ A))  
-       -> (h : subst Δ Γ) 
+       -> (A : ty Γ)
+       -> (B : ty (Γ ▷ A))
+       -> (h : subst Δ Γ)
        -> (c  : raw Γ)
        -> (p : Γ ==> c :: Σ-f A B)
        -> (q : Δ ==> c [ h ] ::  Σ-f (A [[ h ]]) (B [[ ↑ A h ]]))
        -> (x :  || κ Δ ||)
        ->  apr (pr1 A B c p [ h ]) x ≐ apr (pr1 (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q) x
-pr1-sub-raw {Δ} {Γ} A B h c p q x = 
-   let 
+pr1-sub-raw {Δ} {Γ} A B h c p q x =
+   let
        eq1 : apr c (aps h x) ≐
                  apt (Σ-f A B) (aps h x) ‣ pj1 (apel p (aps h x))
        eq1 = pj2 (apel p (aps h x))
        eq2 : apr (c [ h ]) x ≐
                  apt (Σ-f (A [[ h ]]) (B [[ ↑ A h ]])) x ‣ pj1 (apel q x)
        eq2 = pj2 (apel q x)
-       eq3 : apt (Σ-f A B) (aps h x) ‣ pj1 (apel p (aps h x)) 
+       eq3 : apt (Σ-f A B) (aps h x) ‣ pj1 (apel p (aps h x))
                   ≐
              apt (Σ-f (A [[ h ]]) (B [[ ↑ A h ]])) x ‣ pj1 (apel q x)
        eq3 = traV (symV eq1) eq2
-       eq4 : apt (Σ-f A B) (aps h x) ‣ (pj1 (apel p (aps h x)))  ≐  
-                  < (apt A (aps h x)) ‣ (pj1 (pj1 (apel p (aps h x)))) , 
+       eq4 : apt (Σ-f A B) (aps h x) ‣ (pj1 (apel p (aps h x)))  ≐
+                  < (apt A (aps h x)) ‣ (pj1 (pj1 (apel p (aps h x)))) ,
                      (apt B  ((aps h x) , (pj1  (pj1 (apel p (aps h x)))))) ‣ (pj2 (pj1 (apel p (aps h x)))) >
        eq4 = Σ-f-exp3  A B (aps h x) (pj1 (apel p (aps h x)))
-       eq5 : apt (Σ-f (A [[ h ]]) (B [[ ↑ A h ]])) x ‣ (pj1 (apel q x))  ≐ 
-               < (apt (A [[ h ]]) x) ‣ (pj1 (pj1 (apel q x))) , 
+       eq5 : apt (Σ-f (A [[ h ]]) (B [[ ↑ A h ]])) x ‣ (pj1 (apel q x))  ≐
+               < (apt (A [[ h ]]) x) ‣ (pj1 (pj1 (apel q x))) ,
                    (apt (B [[ ↑ A h ]])  (x , (pj1  (pj1 (apel q x))))) ‣ (pj2 (pj1 (apel q x))) >
        eq5 =  Σ-f-exp3 (A [[ h ]]) (B [[ ↑ A h ]]) x (pj1 (apel q x))
-       eq6 : (apt A (aps h x)) ‣ (pj1 (pj1 (apel p (aps h x))))  
+       eq6 : (apt A (aps h x)) ‣ (pj1 (pj1 (apel p (aps h x))))
               ≐ (apt (A [[ h ]]) x) ‣ (pj1 (pj1 (apel q x)))
        eq6 =  prj1 (pairV-inv-1 (traV (symV eq4) (traV eq3 eq5)))
 -- pairV-inv-1 : {x y z u : V} -> < x , y > ≐ < z , u > ->  and (x ≐ z) (y ≐ u)
-       lm1 :  apr (pr1 A B c p [ h ]) x  ≐  apr (pr1 A B c p) (aps h x) 
+       lm1 :  apr (pr1 A B c p [ h ]) x  ≐  apr (pr1 A B c p) (aps h x)
        lm1 = sub-apply (pr1 A B c p) h x
        lm2 : apr (pr1 A B c p) (aps h x) ≐ apt A (aps h x)  ‣  pj1 (pj1 (apel p (aps h x)))
        lm2 = refV _
@@ -809,55 +809,55 @@ pr1-sub-raw {Δ} {Γ} A B h c p q x =
        lm4 = eq6
    in traV lm1 (traV lm2 (traV lm4 (symV lm3)))
 
-pr1-sub :  {Δ Γ : ctx} 
+pr1-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   
-       -> (B : ty (Γ ▷ A))  
-       -> (h : subst Δ Γ) 
+       -> (A : ty Γ)
+       -> (B : ty (Γ ▷ A))
+       -> (h : subst Δ Γ)
        -> (c  : raw Γ)
        -> (p : Γ ==> c :: Σ-f A B)
        -> (q : Δ ==> c [ h ] ::  Σ-f (A [[ h ]]) (B [[ ↑ A h ]]))
 --     ---------------------------------------
-       -> Δ ==>  (pr1 A B c p) [ h ] ==  pr1 (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q  :: A [[ h ]] 
+       -> Δ ==>  (pr1 A B c p) [ h ] ==  pr1 (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q  :: A [[ h ]]
 
 pr1-sub {Δ} {Γ} A B h c p q = pair (pr1-sub-raw {Δ} {Γ} A B h c p q)
-                                   (pair (elt-subst h (Σ-e-1  {Γ} A B c p )) 
+                                   (pair (elt-subst h (Σ-e-1  {Γ} A B c p ))
                                          (Σ-e-1 {Δ} (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q))
 
-pr2-sub-raw :  {Δ Γ : ctx} 
+pr2-sub-raw :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   
-       -> (B : ty (Γ ▷ A))  
-       -> (h : subst Δ Γ) 
+       -> (A : ty Γ)
+       -> (B : ty (Γ ▷ A))
+       -> (h : subst Δ Γ)
        -> (c  : raw Γ)
        -> (p : Γ ==> c :: Σ-f A B)
        -> (q : Δ ==> c [ h ] ::  Σ-f (A [[ h ]]) (B [[ ↑ A h ]]))
        -> (r : Δ ==> (pr1 A B c p) [ h ] :: A [[ h ]])
        -> (x : || κ Δ ||)
        -> apr (pr2 A B c p [ h ]) x ≐  apr (pr2 (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q) x
-pr2-sub-raw {Δ} {Γ} A B h c p q r x = 
-  let 
+pr2-sub-raw {Δ} {Γ} A B h c p q r x =
+  let
        eq1 : apr c (aps h x) ≐
                  apt (Σ-f A B) (aps h x) ‣ pj1 (apel p (aps h x))
        eq1 = pj2 (apel p (aps h x))
        eq2 : apr (c [ h ]) x ≐
                  apt (Σ-f (A [[ h ]]) (B [[ ↑ A h ]])) x ‣ pj1 (apel q x)
        eq2 = pj2 (apel q x)
-       eq3 : apt (Σ-f A B) (aps h x) ‣ pj1 (apel p (aps h x)) 
+       eq3 : apt (Σ-f A B) (aps h x) ‣ pj1 (apel p (aps h x))
                   ≐
              apt (Σ-f (A [[ h ]]) (B [[ ↑ A h ]])) x ‣ pj1 (apel q x)
        eq3 = traV (symV eq1) eq2
-       eq4 : apt (Σ-f A B) (aps h x) ‣ (pj1 (apel p (aps h x)))  ≐  
-                  < (apt A (aps h x)) ‣ (pj1 (pj1 (apel p (aps h x)))) , 
+       eq4 : apt (Σ-f A B) (aps h x) ‣ (pj1 (apel p (aps h x)))  ≐
+                  < (apt A (aps h x)) ‣ (pj1 (pj1 (apel p (aps h x)))) ,
                      (apt B  ((aps h x) , (pj1  (pj1 (apel p (aps h x)))))) ‣ (pj2 (pj1 (apel p (aps h x)))) >
        eq4 = Σ-f-exp3  A B (aps h x) (pj1 (apel p (aps h x)))
-       eq5 : apt (Σ-f (A [[ h ]]) (B [[ ↑ A h ]])) x ‣ (pj1 (apel q x))  ≐ 
-               < (apt (A [[ h ]]) x) ‣ (pj1 (pj1 (apel q x))) , 
+       eq5 : apt (Σ-f (A [[ h ]]) (B [[ ↑ A h ]])) x ‣ (pj1 (apel q x))  ≐
+               < (apt (A [[ h ]]) x) ‣ (pj1 (pj1 (apel q x))) ,
                    (apt (B [[ ↑ A h ]])  (x , (pj1  (pj1 (apel q x))))) ‣ (pj2 (pj1 (apel q x))) >
        eq5 =  Σ-f-exp3 (A [[ h ]]) (B [[ ↑ A h ]]) x (pj1 (apel q x))
-       eq6 : (apt B  ((aps h x) , (pj1  (pj1 (apel p (aps h x)))))) ‣ (pj2 (pj1 (apel p (aps h x)))) 
+       eq6 : (apt B  ((aps h x) , (pj1  (pj1 (apel p (aps h x)))))) ‣ (pj2 (pj1 (apel p (aps h x))))
                 ≐
-             (apt (B [[ ↑ A h ]])  (x , (pj1  (pj1 (apel q x))))) ‣ (pj2 (pj1 (apel q x))) 
+             (apt (B [[ ↑ A h ]])  (x , (pj1  (pj1 (apel q x))))) ‣ (pj2 (pj1 (apel q x)))
        eq6 =  prj2 (pairV-inv-1 (traV (symV eq4) (traV eq3 eq5)))
 -- pairV-inv-1 : {x y z u : V} -> < x , y > ≐ < z , u > ->  and (x ≐ z) (y ≐ u)
 
@@ -865,35 +865,35 @@ pr2-sub-raw {Δ} {Γ} A B h c p q r x =
 
 -- TO DO : good formulation?
 
-pr2-sub :  {Δ Γ : ctx} 
+pr2-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   
-       -> (B : ty (Γ ▷ A))  
-       -> (h : subst Δ Γ) 
+       -> (A : ty Γ)
+       -> (B : ty (Γ ▷ A))
+       -> (h : subst Δ Γ)
        -> (c  : raw Γ)
        -> (p : Γ ==> c :: Σ-f A B)
        -> (q : Δ ==> c [ h ] ::  Σ-f (A [[ h ]]) (B [[ ↑ A h ]]))
        -> (r : Δ ==> (pr1 A B c p) [ h ] :: A [[ h ]])
 --     ---------------------------------------
-       -> Δ ==>  (pr2 A B c p) [ h ] ==  pr2 (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q  
+       -> Δ ==>  (pr2 A B c p) [ h ] ==  pr2 (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q
                       ::  (B [[ ↑ A h ]] [[ els r ]])
 
-pr2-sub {Δ} {Γ} A B h c p q r = 
+pr2-sub {Δ} {Γ} A B h c p q r =
   let lm0 : << Raw Δ >> (pr2 A B c p) [ h ] ~ pr2 (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q
       lm0 = <<>> (<<>> (λ x → <<>> ((pr2-sub-raw {Δ} {Γ} A B h c p q r) x)))
       lm1 :  Γ ==> pr1 A B c p :: A
-      lm1 = Σ-e-1 {Γ} A B c p 
+      lm1 = Σ-e-1 {Γ} A B c p
       lm2 :  Γ ==> pr2 A B c p ::  B [[ els lm1 ]]
       lm2 = Σ-e-2 {Γ} A B c p lm1
       lm3 :  Δ ==> pr2 A B c p [ h ] ::  B [[ els lm1 ]] [ h ]
       lm3 = elt-subst h lm2
       lm3b : < Subst Δ (Δ ▷ (A [[ h ]])) >  (els (elt-subst h (Σ-e-1 A B c p))) ~ (els r)
       lm3b = els-irr (elt-subst h (Σ-e-1 A B c p)) r
-      lm4 :  Δ ==>  B [[ els lm1 ]] [ h ] == (B [[ ↑ A h ]]) [[ els r ]] 
+      lm4 :  Δ ==>  B [[ els lm1 ]] [ h ] == (B [[ ↑ A h ]]) [[ els r ]]
       lm4 = tytra (B-els-h-sub A B _ lm1 h) (tyeq-subst2 (B [[ ↑ A h ]]) _ _ lm3b)
       lm5 :  Δ ==> pr2 A B c p [ h ] :: (B [[ ↑ A h ]]) [[ els r ]]
       lm5 = elttyeq lm3 lm4
- 
+
       lm9 : Δ ==> pr2 (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) q ::  (B [[ ↑ A h ]]) [[ els r ]]
       lm9 =  subj-red _ _ lm5 lm0
      --
@@ -902,27 +902,27 @@ pr2-sub {Δ} {Γ} A B h c p q r =
 
 {--
 
-els-irr :   {Γ : ctx} 
-    -> {A : ty Γ}   
+els-irr :   {Γ : ctx}
+    -> {A : ty Γ}
     -> {a : raw Γ}
     -> (p : Γ ==> a :: A)
     -> (q : Γ ==> a :: A)
     -> < Subst Γ (Γ ▷ A) > els p ~ els q
 
-tyeq-subst2 :  {Δ Γ : ctx} -> (A : ty Γ) -> (f g : subst Δ Γ) 
+tyeq-subst2 :  {Δ Γ : ctx} -> (A : ty Γ) -> (f g : subst Δ Γ)
 --
                   -> < Subst Δ Γ > f ~ g
---      -------------------------------------------------- 
+--      --------------------------------------------------
          -> Δ ==> A [[ f ]] ==  A [[ g ]]
 
 
-B-els-h-sub :  {Δ Γ : ctx} 
+B-els-h-sub :  {Δ Γ : ctx}
 --
-       -> (A : ty Γ)   
-       -> (B : ty (Γ ▷ A))  
+       -> (A : ty Γ)
+       -> (B : ty (Γ ▷ A))
        -> (a   : raw Γ)
        -> (p : Γ ==> a :: A)
-       -> (h : subst Δ Γ) 
+       -> (h : subst Δ Γ)
 -- ---------------------------------------------------------------
        ->  Δ ==> (B [[ els p ]] [[ h ]]) == (B [[ ↑ A h ]] [[ els (elt-subst h p) ]])
 --
@@ -931,7 +931,7 @@ B-els-h-sub :  {Δ Γ : ctx}
        -> (r : Δ ==> (pr1 A B c p) [ h ] :: A [[ h ]])
 
 Σ-e-1 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -940,7 +940,7 @@ B-els-h-sub :  {Δ Γ : ctx}
 Σ-e-2 {Δ} (A [[ h ]]) (B [[ ↑ A h ]]) (c [ h ]) r
 
 Σ-e-2 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
@@ -949,22 +949,22 @@ B-els-h-sub :  {Δ Γ : ctx}
 Σ-e-2 {Γ} A B c p q = mk-elt (Σ-e-2-lm {Γ} A B c p q)
 
 Σ-e-1 : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
       -> (c  : raw Γ)
       -> (p : Γ ==> c :: Σ-f A B)
       -> Γ ==> pr1 A B c p :: A
 
-elt-subst :  {Δ Γ : ctx} -> {a : raw Γ} -> {A : ty Γ} -> (f : subst Δ Γ) 
+elt-subst :  {Δ Γ : ctx} -> {a : raw Γ} -> {A : ty Γ} -> (f : subst Δ Γ)
 --
-         -> Γ ==> a :: A 
---   -------------------------------------------------------- 
-         -> Δ ==> a [ f ] ::  A [[ f ]] 
+         -> Γ ==> a :: A
+--   --------------------------------------------------------
+         -> Δ ==> a [ f ] ::  A [[ f ]]
 
 Σ-i : {Γ : ctx}
-      -> (A  : ty Γ) 
+      -> (A  : ty Γ)
       -> (B : ty (Γ ▷ A))
-      -> (a  : raw Γ) 
+      -> (a  : raw Γ)
       -> (p : Γ ==> a :: A)
       -> (b : raw Γ)
       -> (Γ ==> b :: (B [[ els p ]]))

--- a/MLTT-and-setoids/basic-relation.agda
+++ b/MLTT-and-setoids/basic-relation.agda
@@ -18,8 +18,8 @@ data tc  (A : Set) (R : A -> A -> Set) :  (A -> A -> Set) where
 
 
 
-tc-is-transitive : (A : Set) -> (R : A -> A -> Set) -> 
-         (x y z : A) -> tc A R x y -> tc A R y z  -> tc A R x z 
+tc-is-transitive : (A : Set) -> (R : A -> A -> Set) ->
+         (x y z : A) -> tc A R x y -> tc A R y z  -> tc A R x z
 tc-is-transitive A R x y z p (base a b q) = extend x y z p q
 tc-is-transitive A R x y z p (extend a b c q r) = extend _ _ _ (tc-is-transitive A R _ _ _ p q) r
 
@@ -27,22 +27,22 @@ tc-transitive : (A : Set) -> (R : A -> A -> Set) -> transitive A (tc A R)
 tc-transitive A R = tc-is-transitive A R
 
 
-tc-smallest : (A : Set) -> (R : A -> A -> Set) 
-             -> (S : A -> A -> Set) 
+tc-smallest : (A : Set) -> (R : A -> A -> Set)
+             -> (S : A -> A -> Set)
              -> ((x y : A) -> R x y -> S x y)
              -> transitive A S
              -> ((x y : A) -> tc A R x y -> S x y)
 tc-smallest A R S p q x y (base a b r) = p x y r
-tc-smallest A R S p q x y (extend a b c t r) = 
+tc-smallest A R S p q x y (extend a b c t r) =
     let lm : S x b
-        lm = tc-smallest A R S p q x b t 
+        lm = tc-smallest A R S p q x b t
         main : S x y
         main = q x b y lm (p b y r)
     in main
 
 tc-symmetry-lm : (A : Set) -> (R : A -> A -> Set) -> (symmetric A R) -> (symmetric A (tc A R))
 tc-symmetry-lm A R p x y (base a b q) = base y x (p x y q)
-tc-symmetry-lm A R p x y (extend a b c q r) = 
+tc-symmetry-lm A R p x y (extend a b c q r) =
     let ih : tc A R b x
         ih = tc-symmetry-lm A R p x b q
         lm : tc A R y b
@@ -62,9 +62,9 @@ symmetrize-lm2 : (A : Set) -> (R : A -> A -> Set) ->
             ((x y : A) -> R x y -> symmetrize A R x y)
 symmetrize-lm2 A R x y p = inl p
 
-symmetrize-lm3 : (A : Set) 
-            -> (R : A -> A -> Set) 
-            -> (S : A -> A -> Set) 
+symmetrize-lm3 : (A : Set)
+            -> (R : A -> A -> Set)
+            -> (S : A -> A -> Set)
             -> (symmetric A S)
             -> ((x y : A) -> R x y -> S x y)
             -> ((x y : A) -> symmetrize A R x y -> S x y)
@@ -84,50 +84,50 @@ per-is-per A R = pair (tc-symmetry-lm A (symmetrize A R) (symmetrize-lm1 A R)) (
 
 -- per A R  is the smallest partial equivalence relation extending R
 
-per-is-smallest :  (A : Set) 
-             -> (R : A -> A -> Set) 
-             -> (S : A -> A -> Set) 
+per-is-smallest :  (A : Set)
+             -> (R : A -> A -> Set)
+             -> (S : A -> A -> Set)
              -> ((x y : A) -> R x y -> S x y)
              -> is-per A S
              -> ((x y : A) -> per A R x y -> S x y)
-per-is-smallest A R S p q x y r = 
+per-is-smallest A R S p q x y r =
    let  -- per A R =  tc A (symmetrize A R)
        lm : (x y : A) -> symmetrize A R x y -> S x y
        lm = symmetrize-lm3 A R S (prj1 q) p
        main : S x y
-       main = tc-smallest A (symmetrize A R) S lm (prj2 q) x y r 
+       main = tc-smallest A (symmetrize A R) S lm (prj2 q) x y r
    in main
-   
+
 -- if R is reflexive, then  per A R  is the smallest equivalence relation extending R
- 
-per-eqrel-lm1 :  (A : Set) 
-             -> (R : A -> A -> Set) 
+
+per-eqrel-lm1 :  (A : Set)
+             -> (R : A -> A -> Set)
              -> ((x : A) -> R x x)
              -> Eqrel A (per A R)
-per-eqrel-lm1  A R p = pair (λ x → base x x (inl (p x))) (per-is-per A R)   
+per-eqrel-lm1  A R p = pair (λ x → base x x (inl (p x))) (per-is-per A R)
 
-per-eqrel-lm2 :  (A : Set) 
-             -> (R : A -> A -> Set) 
+per-eqrel-lm2 :  (A : Set)
+             -> (R : A -> A -> Set)
              -> ((x : A) -> R x x)
-             -> (S : A -> A -> Set) 
+             -> (S : A -> A -> Set)
              -> ((x y : A) -> R x y -> S x y)
              -> Eqrel A S
              -> ((x y : A) -> per A R x y -> S x y)
-per-eqrel-lm2 A R p S q r x y = per-is-smallest A R S q (pair (prj1 (prj2 r)) (prj2 (prj2 r))) x y 
+per-eqrel-lm2 A R p S q r x y = per-is-smallest A R S q (pair (prj1 (prj2 r)) (prj2 (prj2 r))) x y
 
 
--- 
+--
 
 binrel-is-extensional : (A B : setoid) -> (R :  || A ||  -> || B || -> Set) -> Set
-binrel-is-extensional A B R = (x x' :  || A ||) -> (y y' :  || B ||) 
-                          -> < A > x ~ x' -> < B > y ~ y' -> R x y -> R x' y' 
+binrel-is-extensional A B R = (x x' :  || A ||) -> (y y' :  || B ||)
+                          -> < A > x ~ x' -> < B > y ~ y' -> R x y -> R x' y'
 
 
-tc-preserves-extensionality : (A : setoid) -> (R : || A || -> || A || -> Set) 
-         -> (binrel-is-extensional A A R) 
+tc-preserves-extensionality : (A : setoid) -> (R : || A || -> || A || -> Set)
+         -> (binrel-is-extensional A A R)
          -> binrel-is-extensional A  A (tc (|| A ||) R)
 tc-preserves-extensionality A R p x x' y y' q r (base a b t) = base x' y' (p _ _ _ _ q r t)
-tc-preserves-extensionality A R p x x' y y' q r (extend a b c t t') = 
+tc-preserves-extensionality A R p x x' y y' q r (extend a b c t t') =
    let ih : tc || A || R x' b
        ih = tc-preserves-extensionality A R p x x' b b q (refl A b) t
        t'' : R b y'
@@ -136,9 +136,9 @@ tc-preserves-extensionality A R p x x' y y' q r (extend a b c t t') =
        main = extend _ _ _ ih t''
    in main
 
- 
-symmetrize-preserves-extensionality : (A : setoid) -> (R : || A || -> || A || -> Set) 
-         -> (binrel-is-extensional A A R) 
+
+symmetrize-preserves-extensionality : (A : setoid) -> (R : || A || -> || A || -> Set)
+         -> (binrel-is-extensional A A R)
          -> binrel-is-extensional A  A (symmetrize (|| A ||) R)
 symmetrize-preserves-extensionality A R p x x' y y' q1 q2 (inl r) = inl (p _ _ _ _ q1 q2 r)
 symmetrize-preserves-extensionality A R p x x' y y' q1 q2 (inr r) = inr (p _ _ _ _ q2 q1 r)

--- a/MLTT-and-setoids/basic-setoids-test.agda
+++ b/MLTT-and-setoids/basic-setoids-test.agda
@@ -122,7 +122,7 @@ mutual
   T (w a b)   = W (T a) (\x -> T (b x))
   T (id a b c) = Id (T a) b c
 
--- Axiom for forming families over a disjoint union 
+-- Axiom for forming families over a disjoint union
 -- provable for A B in U
 
 
@@ -150,7 +150,7 @@ Jrec A a b C d c =  J {A} {a} {b} {C} d c
 
 
 Isub : {A : Set} -> (P : A -> Set)  ->  {x y : A} -> (Id A x y) -> (P x) -> (P y)
-Isub {A} P {x} {y} p = Jrec A x y (\u -> \v -> \w -> (P u) -> (P v)) ((\v -> v)) p 
+Isub {A} P {x} {y} p = Jrec A x y (\u -> \v -> \w -> (P u) -> (P v)) ((\v -> v)) p
 
 Ifunext : {A  B : Set} -> (f : A -> B)  ->  {x y : A} -> (Id A x y) -> Id B (f x) (f y)
 Ifunext {A} {B} f {x} {y} p  = Jrec A x y (\x -> \y -> \z -> Id B (f x) (f y)) rf p
@@ -181,7 +181,7 @@ impE : {A : Set} -> {B : Set} -> (implies A B) -> A -> B
 impE f a = f a
 
 fun : (A : Set) -> (B : Set)  -> Set
-fun A B = A -> B 
+fun A B = A -> B
 
 all : (A : Set) -> (B : A -> Set) -> Set
 all A B = (x : A) -> B x
@@ -206,7 +206,7 @@ andR {A} {B} c = prj2 c
 exists : (A : Set) -> (B : A -> Set) -> Set
 exists A B =  Σ A B
 
-existsI : {A : Set} -> {B : A -> Set} -> 
+existsI : {A : Set} -> {B : A -> Set} ->
           (a : A) -> (b : B a) -> exists A B
 existsI a b = ( a , b )
 
@@ -223,7 +223,7 @@ orE : {A B : Set} -> {C : (or A B) -> Set}
    -> ((a : A) -> C (orL a)) -> ((b : B) -> C (orR b)) -> (c : or A B) -> C c
 orE = D
 
-orEweak : {A B C : Set} 
+orEweak : {A B C : Set}
    -> (A -> C) -> (B -> C)  -> (c : or A B) -> C
 orEweak f g (inl a) = f a
 orEweak f g (inr b) = g b
@@ -265,32 +265,32 @@ non-trivial-Bool = impI (λ p → Isub Val p tt)
 
 -- sums are disjoint.
 
-is-inl :  (A B : Set) -> (u : A + B) -> Bool 
+is-inl :  (A B : Set) -> (u : A + B) -> Bool
 is-inl A B u = D (\a -> true) (\b -> false) u
 
-is-inr :  (A B : Set) -> (u : A + B) -> Bool 
+is-inr :  (A B : Set) -> (u : A + B) -> Bool
 is-inr A B u = D (\a -> false) (\b -> true) u
 
-disjointness-sum :  (A B : Set) -> (a : A) -> (b : B) 
+disjointness-sum :  (A B : Set) -> (a : A) -> (b : B)
             -> not (Id (A + B) (inl a) (inr b))
 disjointness-sum A B a b = impI (λ p → impE non-trivial-Bool (Ifunext (is-inl A B) p))
 
-disjointness-sum2 :  (A B : Set) -> (a : A) -> (b : B) 
+disjointness-sum2 :  (A B : Set) -> (a : A) -> (b : B)
             -> not (Id (A + B) (inr b) (inl a))
 disjointness-sum2 A B a b = impI (λ p → impE non-trivial-Bool (Ifunext (is-inr A B) p))
 
 -- inl and inr are injective proved using code-encode of
--- p 85-86 in HoTT (but use  LD instead of full universe). 
+-- p 85-86 in HoTT (but use  LD instead of full universe).
 -- Vaguely seen this before. Wilander's paper?
 
-code-inl : (A B : Set) -> (a : A) -> (u : (A + B)) -> Set 
+code-inl : (A B : Set) -> (a : A) -> (u : (A + B)) -> Set
 code-inl A B a = (LD A B (\x -> Id A a x)  (\y -> False))
 
-code-inr : (A B : Set) -> (b : B) -> (u : (A + B)) -> Set 
+code-inr : (A B : Set) -> (b : B) -> (u : (A + B)) -> Set
 code-inr A B b = (LD A B (\x -> False)  (\y -> Id B b y))
 
 encode-inl :  (A B : Set) -> (a : A) -> (u : A + B) -> (Id (A + B) (inl a) u) -> (code-inl A B a u)
-encode-inl A B a u p  = Isub (code-inl A B a) p rf 
+encode-inl A B a u p  = Isub (code-inl A B a) p rf
 
 encode-inr :  (A B : Set) -> (b : B) -> (u : A + B) -> (Id (A + B) (inr b) u) -> (code-inr A B b u)
 encode-inr A B b u p  = Isub (code-inr A B b) p rf
@@ -303,7 +303,7 @@ inr-injective A B b d p = encode-inr A B b (inr d) p
 
 
 Isym : (A : Set) -> (x y : A) -> Id A x y -> Id A y x
-Isym A x y p = Jrec A x y ((\x -> \y ->  \z -> Id A y x)) rf p 
+Isym A x y p = Jrec A x y ((\x -> \y ->  \z -> Id A y x)) rf p
 
 Itra : (A : Set) -> (x y z : A) -> Id A x y -> Id A y z -> Id A x z
 Itra A x y z p q =  impE (Jrec A x y ((\u -> \v ->  \w -> implies (Id A v z) (Id A u z) ))
@@ -365,7 +365,7 @@ record <_>_~_ (X : setoid) (a b : || X ||) : Set where
 refl : (X : setoid) -> (a : || X ||) ->  < X > a ~ a
 refl X a = <> ((Refl (setoid.eqrel X)) a)
 
-sym :  {X : setoid} -> {a : || X ||} -> {b : || X ||} -> < X > a ~ b  ->  < X > b ~ a 
+sym :  {X : setoid} -> {a : || X ||} -> {b : || X ||} -> < X > a ~ b  ->  < X > b ~ a
 sym {X} {a} {b} p = <> (impE (((Sym (setoid.eqrel X)) a) b) (>< p))
 
 tra :  {X : setoid} -> {a : || X ||} -> {b : || X ||} -> {c : || X ||} -> < X > a ~ b  -> < X > b ~ c ->  < X > a ~ c
@@ -422,7 +422,7 @@ record <<_>>_~_ (X : classoid) (a b : ||| X |||) : Set where
 refl' : (X : classoid) -> (a : ||| X |||) ->  << X >> a ~ a
 refl' X a = <<>> (Eqrel'.rf' (classoid.eqrel X) a)
 
-sym' :  {X : classoid} -> {a : ||| X |||} -> {b : ||| X |||} -> << X >> a ~ b  ->  << X >> b ~ a 
+sym' :  {X : classoid} -> {a : ||| X |||} -> {b : ||| X |||} -> << X >> a ~ b  ->  << X >> b ~ a
 sym' {X} {a} {b} p = <<>> (Eqrel'.sy' (classoid.eqrel X) a b (>><< p ))
 
 tra' :  {X : classoid} -> {a : ||| X |||} -> {b : ||| X |||} -> {c : ||| X |||} -> << X >> a ~ b  -> << X >> b ~ c ->  << X >> a ~ c
@@ -443,9 +443,9 @@ Id-to-Eq X {x} {y} p = Jrec || X || x y (λ u v z →  < X > u ~ v) (refl X _) p
 triv-setoid : Set -> setoid
 triv-setoid A = record { object = A
                        ; _∼_  =  (\x ->  (\y -> True))
-                       ; eqrel = andI (allI (λ a → tt)) 
-                         (andI (allI (λ a → allI (λ b → impI (λ p → tt)))) 
-                            (allI (λ a → allI (λ b → allI (λ c → impI (λ p → impI (λ q → tt))))))) } 
+                       ; eqrel = andI (allI (λ a → tt))
+                         (andI (allI (λ a → allI (λ b → impI (λ p → tt))))
+                            (allI (λ a → allI (λ b → allI (λ c → impI (λ p → impI (λ q → tt))))))) }
 
 
 -- free setoid on a type
@@ -453,9 +453,9 @@ triv-setoid A = record { object = A
 free-setoid : Set -> setoid
 free-setoid A = record { object = A
                           ; _∼_  =  (\x ->  (\y -> Id A x y))
-                          ; eqrel = andI (allI (λ a → rf)) 
-                          (andI (allI (λ a → allI (λ b → impI (λ p → Isym A a b p)))) 
-                            (allI (λ a → allI (λ b → allI (λ c → impI (λ p → impI (λ q → Itra A a b c p q))))))) } 
+                          ; eqrel = andI (allI (λ a → rf))
+                          (andI (allI (λ a → allI (λ b → impI (λ p → Isym A a b p))))
+                            (allI (λ a → allI (λ b → allI (λ c → impI (λ p → impI (λ q → Itra A a b c p q))))))) }
 
 
 
@@ -475,11 +475,11 @@ setoidmaps : (A B : setoid) -> setoid
 setoidmaps A B = record {object = setoidmap A B
                           ; _∼_  =  exteq {A} {B}
                           ; eqrel = andI (allI (λ a x → refl B _))
-                                         (andI (allI (λ a → allI (λ b → impI (λ p x →  
-                                                       sym (p x))))) 
-                                              ((allI (λ a → allI (λ b → (allI (λ c → 
-                                                 impI (λ p → impI (λ q x → 
-                                          tra (p x) (q x))) )))))))                         
+                                         (andI (allI (λ a → allI (λ b → impI (λ p x →
+                                                       sym (p x)))))
+                                              ((allI (λ a → allI (λ b → (allI (λ c →
+                                                 impI (λ p → impI (λ q x →
+                                          tra (p x) (q x))) )))))))
                          }
 
 
@@ -491,7 +491,7 @@ A => B = setoidmaps A B
 ap : {A B : setoid} -> (f : || A => B ||) -> (a : || A ||) -> || B ||
 ap f a  = setoidmap.op f a
 
-extensionality : {A B : setoid} -> (f : || A => B ||) -> (x y : || A ||) -> 
+extensionality : {A B : setoid} -> (f : || A => B ||) -> (x y : || A ||) ->
              (< A > x ~ y) ->  (< B > (ap f x) ~ (ap f y))
 extensionality {A} {B} f x y p = impE (setoidmap.ext f x y) p
 
@@ -505,7 +505,7 @@ binsetoidmap-helper : {A B C : setoid} -> (f : || A || -> || B || -> || C ||)
   -> (p : (a a' : || A ||) -> (< A > a ~ a' -> (b : || B ||) -> < C > f a b ~ f a' b))
   -> (q : (a : || A ||) ->  (b b' : || B ||) -> (< B > b ~ b' ->  < C > f a b ~ f a b'))
   -> || A => (B => C) ||
-binsetoidmap-helper {A} {B} {C} f p q 
+binsetoidmap-helper {A} {B} {C} f p q
              = record { op =  (\x -> record { op =   (\y -> f x y)
                                            ; ext = allI (\u ->  allI (\v -> impI (\p ->  (q x u v (<> p)))))
                                            })
@@ -513,23 +513,23 @@ binsetoidmap-helper {A} {B} {C} f p q
                       }
 
 trinsetoidmap-helper : {A B C D : setoid} -> (f : || A || -> || B || -> || C || -> || D ||)
- ->  (p : (a a' : || A ||) -> < A > a ~ a' -> (b : || B ||) -> (c : || C ||) 
+ ->  (p : (a a' : || A ||) -> < A > a ~ a' -> (b : || B ||) -> (c : || C ||)
       -> < D > f a b c ~ f a' b c)
  ->  (q : (a : || A ||) -> (b b' : || B ||) ->   < B > b ~ b' -> (c : || C ||) -> < D > f a b c ~ f a b' c)
  ->  (t : (a : || A ||) -> (b : || B ||) -> (c c' : || C ||) -> < C >  c ~ c' -> < D > f a b c ~ f a b c')
  -> || A => (B => (C => D)) ||
-trinsetoidmap-helper {A} {B} {C} {D} f p q t 
+trinsetoidmap-helper {A} {B} {C} {D} f p q t
                     = record { op = (\x -> record { op = (\y -> record { op = (\z -> f x y z)
-                                                                            ; ext = allI (\u ->  
-                                                                                    allI (\v -> 
+                                                                            ; ext = allI (\u ->
+                                                                                    allI (\v ->
                                                                                       impI (\p' -> t x y u v p')))
                                                                             })
-                                                     ; ext = allI (\u ->  
-                                                              allI (\v -> 
+                                                     ; ext = allI (\u ->
+                                                              allI (\v ->
                                                                 impI (\p' -> λ x' → q x u v p' x')))
                                                      })
-                             ; ext =  allI (\u ->  
-                                        allI (\v -> 
+                             ; ext =  allI (\u ->
+                                        allI (\v ->
                                           impI (\p' -> λ x x' → p u v p' x x')))
                               }
 
@@ -544,19 +544,19 @@ idmap {A} = record { op =  (\x -> x)
 infix 5 _°_
 
 _°_ : {A B C : setoid} -> (f : || B => C ||) -> (g : || A => B ||) -> || A => C ||
-_°_ {A} {B} {C} f g =  record { op =   (\x -> ap f (ap g x)) 
-                              ; ext =  allI (λ u → allI (λ v → 
-                                   impI (λ p →    (setoidmap.ext f (ap g u) (ap g v)) 
-                                                         (setoidmap.ext g u v p)    
+_°_ {A} {B} {C} f g =  record { op =   (\x -> ap f (ap g x))
+                              ; ext =  allI (λ u → allI (λ v →
+                                   impI (λ p →    (setoidmap.ext f (ap g u) (ap g v))
+                                                         (setoidmap.ext g u v p)
                                       )))
                                }
-                                                 
+
 _≅_ : setoid -> setoid -> Set
-A ≅ B = Σ || A => B || (\f ->  
-        Σ || B => A || (\g -> 
+A ≅ B = Σ || A => B || (\f ->
+        Σ || B => A || (\g ->
            (and ((x : || A ||) -> < A > ap g (ap f x) ~ x)
                 ((y : || B ||) -> < B > ap f (ap g y) ~ y))))
-    
+
 fwd : {A B : setoid} -> (A ≅ B) -> || A => B ||
 fwd p = pj1 p
 
@@ -588,15 +588,15 @@ exteq1 {A} {B} f g = (x : || A ||) ->  << B >> (f • x) ~ (g • x)
 setoidmaps1 : (A : setoid) -> (B : classoid) -> classoid
 setoidmaps1 A B = record {object = setoidmap1 A B
                           ; _∼_  =  exteq1 {A} {B}
-                          ; eqrel = record { rf' = λ f x → refl' B (f • x) 
-                                           ; sy' = λ f g p x → sym' {B} (p x) 
+                          ; eqrel = record { rf' = λ f x → refl' B (f • x)
+                                           ; sy' = λ f g p x → sym' {B} (p x)
                                            ; tr' = λ f g h p q x → tra' {B} (p x) (q x) }
                          }
 
 _=>01_ : setoid -> classoid -> classoid
 A =>01 B = setoidmaps1 A B
 
-extensionality1 : {A : setoid} -> {B : classoid} -> (f : ||| A =>01 B |||) -> (x y : || A ||) -> 
+extensionality1 : {A : setoid} -> {B : classoid} -> (f : ||| A =>01 B |||) -> (x y : || A ||) ->
              (< A > x ~ y) ->  (<< B >> (f • x) ~ (f • y))
 extensionality1 {A} {B} f x y p = (setoidmap1.ext f x y) p
 
@@ -607,11 +607,11 @@ is-injective1 {A} {B} f = (x y : || A ||) -> (<< B >> (f • x) ~ (f • y)) -> 
 
 
 comp1 : {A B : setoid} -> {C : classoid} -> (f : setoidmap1 B C) -> (g : || A => B ||) -> setoidmap1 A C
-comp1 {A} {B} {C} f g =  record { op =   (\x -> ap1 f (ap g x)) 
-                                ; ext = λ x y p → setoidmap1.ext f (ap g x) (ap g y) 
+comp1 {A} {B} {C} f g =  record { op =   (\x -> ap1 f (ap g x))
+                                ; ext = λ x y p → setoidmap1.ext f (ap g x) (ap g y)
                                                                     (setoidmap.ext g x y p)
                                }
-        
+
 
 
 record setoidmap11 (A B : classoid) : Set1 where
@@ -623,22 +623,21 @@ ap11 : {A B : classoid} -> (f : setoidmap11 A B) -> (a : ||| A  |||) -> ||| B ||
 ap11 f a = setoidmap11.op f a
 
 
-extensionality11 : {A B : classoid} -> (f : setoidmap11 A B) -> (x y : ||| A |||) -> 
+extensionality11 : {A B : classoid} -> (f : setoidmap11 A B) -> (x y : ||| A |||) ->
              (<< A >> x ~ y) ->  (<< B >> (ap11 f x) ~ (ap11 f  y))
 extensionality11 {A} {B} f x y p = (setoidmap11.ext f x y) p
 
 
 
 comp11 : {A B C : classoid} -> (f : setoidmap11 B C) -> (g : setoidmap11 A B) -> setoidmap11 A C
-comp11 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap11 g x)) 
-                                ; ext = λ x y p → setoidmap11.ext f (ap11 g x) (ap11 g y) 
+comp11 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap11 g x))
+                                ; ext = λ x y p → setoidmap11.ext f (ap11 g x) (ap11 g y)
                                                                     (setoidmap11.ext g x y p)
                                }
 
 comp01 : {A : setoid} -> {B C : classoid} -> (f : setoidmap11 B C) -> (g : setoidmap1 A B) -> setoidmap1 A C
-comp01 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap1 g x)) 
-                                ; ext = λ x y p → setoidmap11.ext f (ap1 g x) (ap1 g y) 
+comp01 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap1 g x))
+                                ; ext = λ x y p → setoidmap11.ext f (ap1 g x) (ap1 g y)
                                                                     (setoidmap1.ext g x y p)
                                }
-
 

--- a/MLTT-and-setoids/basic-setoids.agda
+++ b/MLTT-and-setoids/basic-setoids.agda
@@ -66,7 +66,7 @@ record <_>_~_ (X : setoid) (a b : || X ||) : Set where
 refl : (X : setoid) -> (a : || X ||) ->  < X > a ~ a
 refl X a = <> ((Refl (setoid.eqrel X)) a)
 
-sym :  {X : setoid} -> {a : || X ||} -> {b : || X ||} -> < X > a ~ b  ->  < X > b ~ a 
+sym :  {X : setoid} -> {a : || X ||} -> {b : || X ||} -> < X > a ~ b  ->  < X > b ~ a
 sym {X} {a} {b} p = <> (impE (((Sym (setoid.eqrel X)) a) b) (>< p))
 
 tra :  {X : setoid} -> {a : || X ||} -> {b : || X ||} -> {c : || X ||} -> < X > a ~ b  -> < X > b ~ c ->  < X > a ~ c
@@ -124,7 +124,7 @@ record <<_>>_~_ (X : classoid) (a b : ||| X |||) : Set where
 refl' : (X : classoid) -> (a : ||| X |||) ->  << X >> a ~ a
 refl' X a = <<>> (Eqrel'.rf' (classoid.eqrel X) a)
 
-sym' :  {X : classoid} -> {a : ||| X |||} -> {b : ||| X |||} -> << X >> a ~ b  ->  << X >> b ~ a 
+sym' :  {X : classoid} -> {a : ||| X |||} -> {b : ||| X |||} -> << X >> a ~ b  ->  << X >> b ~ a
 sym' {X} {a} {b} p = <<>> (Eqrel'.sy' (classoid.eqrel X) a b (>><< p ))
 
 tra' :  {X : classoid} -> {a : ||| X |||} -> {b : ||| X |||} -> {c : ||| X |||} -> << X >> a ~ b  -> << X >> b ~ c ->  << X >> a ~ c
@@ -145,9 +145,9 @@ Id-to-Eq X {x} {y} p = Jrec || X || x y (λ u v z →  < X > u ~ v) (refl X _) p
 triv-setoid : Set -> setoid
 triv-setoid A = record { object = A
                        ; _∼_  =  (\x ->  (\y -> True))
-                       ; eqrel = andI (allI (λ a → tt)) 
-                         (andI (allI (λ a → allI (λ b → impI (λ p → tt)))) 
-                            (allI (λ a → allI (λ b → allI (λ c → impI (λ p → impI (λ q → tt))))))) } 
+                       ; eqrel = andI (allI (λ a → tt))
+                         (andI (allI (λ a → allI (λ b → impI (λ p → tt))))
+                            (allI (λ a → allI (λ b → allI (λ c → impI (λ p → impI (λ q → tt))))))) }
 
 
 -- free setoid on a type
@@ -155,9 +155,9 @@ triv-setoid A = record { object = A
 free-setoid : Set -> setoid
 free-setoid A = record { object = A
                           ; _∼_  =  (\x ->  (\y -> Id A x y))
-                          ; eqrel = andI (allI (λ a → rf)) 
-                          (andI (allI (λ a → allI (λ b → impI (λ p → Isym A a b p)))) 
-                            (allI (λ a → allI (λ b → allI (λ c → impI (λ p → impI (λ q → Itra A a b c p q))))))) } 
+                          ; eqrel = andI (allI (λ a → rf))
+                          (andI (allI (λ a → allI (λ b → impI (λ p → Isym A a b p))))
+                            (allI (λ a → allI (λ b → allI (λ c → impI (λ p → impI (λ q → Itra A a b c p q))))))) }
 
 
 
@@ -177,11 +177,11 @@ setoidmaps : (A B : setoid) -> setoid
 setoidmaps A B = record {object = setoidmap A B
                           ; _∼_  =  exteq {A} {B}
                           ; eqrel = andI (allI (λ a x → refl B _))
-                                         (andI (allI (λ a → allI (λ b → impI (λ p x →  
-                                                       sym (p x))))) 
-                                              ((allI (λ a → allI (λ b → (allI (λ c → 
-                                                 impI (λ p → impI (λ q x → 
-                                          tra (p x) (q x))) )))))))                         
+                                         (andI (allI (λ a → allI (λ b → impI (λ p x →
+                                                       sym (p x)))))
+                                              ((allI (λ a → allI (λ b → (allI (λ c →
+                                                 impI (λ p → impI (λ q x →
+                                          tra (p x) (q x))) )))))))
                          }
 
 
@@ -193,7 +193,7 @@ A => B = setoidmaps A B
 ap : {A B : setoid} -> (f : || A => B ||) -> (a : || A ||) -> || B ||
 ap f a  = setoidmap.op f a
 
-extensionality : {A B : setoid} -> (f : || A => B ||) -> (x y : || A ||) -> 
+extensionality : {A B : setoid} -> (f : || A => B ||) -> (x y : || A ||) ->
              (< A > x ~ y) ->  (< B > (ap f x) ~ (ap f y))
 extensionality {A} {B} f x y p = impE (setoidmap.ext f x y) p
 
@@ -212,19 +212,19 @@ idmap {A} = record { op =  (\x -> x)
 infix 5 _°_
 
 _°_ : {A B C : setoid} -> (f : || B => C ||) -> (g : || A => B ||) -> || A => C ||
-_°_ {A} {B} {C} f g =  record { op =   (\x -> ap f (ap g x)) 
-                              ; ext =  allI (λ u → allI (λ v → 
-                                   impI (λ p →    (setoidmap.ext f (ap g u) (ap g v)) 
-                                                         (setoidmap.ext g u v p)    
+_°_ {A} {B} {C} f g =  record { op =   (\x -> ap f (ap g x))
+                              ; ext =  allI (λ u → allI (λ v →
+                                   impI (λ p →    (setoidmap.ext f (ap g u) (ap g v))
+                                                         (setoidmap.ext g u v p)
                                       )))
                                }
-                                                 
+
 _≅_ : setoid -> setoid -> Set
-A ≅ B = Σ || A => B || (\f ->  
-        Σ || B => A || (\g -> 
+A ≅ B = Σ || A => B || (\f ->
+        Σ || B => A || (\g ->
            (and ((x : || A ||) -> < A > ap g (ap f x) ~ x)
                 ((y : || B ||) -> < B > ap f (ap g y) ~ y))))
-    
+
 fwd : {A B : setoid} -> (A ≅ B) -> || A => B ||
 fwd p = pj1 p
 
@@ -256,13 +256,13 @@ exteq1 {A} {B} f g = (x : || A ||) ->  << B >> (f • x) ~ (g • x)
 setoidmaps1 : (A : setoid) -> (B : classoid) -> classoid
 setoidmaps1 A B = record {object = setoidmap1 A B
                           ; _∼_  =  exteq1 {A} {B}
-                          ; eqrel = record { rf' = λ f x → refl' B (f • x) 
-                                           ; sy' = λ f g p x → sym' {B} (p x) 
+                          ; eqrel = record { rf' = λ f x → refl' B (f • x)
+                                           ; sy' = λ f g p x → sym' {B} (p x)
                                            ; tr' = λ f g h p q x → tra' {B} (p x) (q x) }
                          }
 
 
-extensionality1 : {A : setoid} -> {B : classoid} -> (f : setoidmap1 A B) -> (x y : || A ||) -> 
+extensionality1 : {A : setoid} -> {B : classoid} -> (f : setoidmap1 A B) -> (x y : || A ||) ->
              (< A > x ~ y) ->  (<< B >> (f • x) ~ (f • y))
 extensionality1 {A} {B} f x y p = (setoidmap1.ext f x y) p
 
@@ -273,11 +273,11 @@ is-injective1 {A} {B} f = (x y : || A ||) -> (<< B >> (f • x) ~ (f • y)) -> 
 
 
 comp1 : {A B : setoid} -> {C : classoid} -> (f : setoidmap1 B C) -> (g : || A => B ||) -> setoidmap1 A C
-comp1 {A} {B} {C} f g =  record { op =   (\x -> ap1 f (ap g x)) 
-                                ; ext = λ x y p → setoidmap1.ext f (ap g x) (ap g y) 
+comp1 {A} {B} {C} f g =  record { op =   (\x -> ap1 f (ap g x))
+                                ; ext = λ x y p → setoidmap1.ext f (ap g x) (ap g y)
                                                                     (setoidmap.ext g x y p)
                                }
-        
+
 
 
 record setoidmap11 (A B : classoid) : Set1 where
@@ -289,22 +289,21 @@ ap11 : {A B : classoid} -> (f : setoidmap11 A B) -> (a : ||| A  |||) -> ||| B ||
 ap11 f a = setoidmap11.op f a
 
 
-extensionality11 : {A B : classoid} -> (f : setoidmap11 A B) -> (x y : ||| A |||) -> 
+extensionality11 : {A B : classoid} -> (f : setoidmap11 A B) -> (x y : ||| A |||) ->
              (<< A >> x ~ y) ->  (<< B >> (ap11 f x) ~ (ap11 f  y))
 extensionality11 {A} {B} f x y p = (setoidmap11.ext f x y) p
 
 
 
 comp11 : {A B C : classoid} -> (f : setoidmap11 B C) -> (g : setoidmap11 A B) -> setoidmap11 A C
-comp11 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap11 g x)) 
-                                ; ext = λ x y p → setoidmap11.ext f (ap11 g x) (ap11 g y) 
+comp11 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap11 g x))
+                                ; ext = λ x y p → setoidmap11.ext f (ap11 g x) (ap11 g y)
                                                                     (setoidmap11.ext g x y p)
                                }
 
 comp01 : {A : setoid} -> {B C : classoid} -> (f : setoidmap11 B C) -> (g : setoidmap1 A B) -> setoidmap1 A C
-comp01 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap1 g x)) 
-                                ; ext = λ x y p → setoidmap11.ext f (ap1 g x) (ap1 g y) 
+comp01 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap1 g x))
+                                ; ext = λ x y p → setoidmap11.ext f (ap1 g x) (ap1 g y)
                                                                     (setoidmap1.ext g x y p)
                                }
-
 

--- a/MLTT-and-setoids/basic-types.agda
+++ b/MLTT-and-setoids/basic-types.agda
@@ -46,7 +46,7 @@ record prod (A B : Set) : Set where
     prj2 : B
 open prod public
 
-{-- the above record replaces: 
+{-- the above record replaces:
 
 data prod (A : Set) (B : Set) : Set where
    pair : A -> B -> prod A B
@@ -164,7 +164,7 @@ T : U -> Set
 T = To {N₀} {\x -> N₀}
 
 
-{-- nth Universe, internally indexed; see also notes by C McBride 
+{-- nth Universe, internally indexed; see also notes by C McBride
 "Dependently Typed Metaprogramming (in Agda)"  2013 --}
 
 data Setfam : Set1 where
@@ -182,7 +182,7 @@ Emptyfam = setfam N₀ (\x -> N₀)
 NextUT : Setfam -> Setfam
 NextUT F = setfam (Uo (ind F) (fam F)) (To {ind F} {fam F})
 
-nthUT : N -> Setfam 
+nthUT : N -> Setfam
 nthUT O = NextUT Emptyfam
 nthUT (s k) = NextUT (nthUT k)
 
@@ -198,7 +198,7 @@ nthT k = fam (nthUT k)
 
 
 
--- Axiom for forming families over a disjoint union 
+-- Axiom for forming families over a disjoint union
 -- provable for A B in U
 
 
@@ -223,7 +223,7 @@ Jrec A a b C d c =  J {A} {a} {b} {C} d c
 
 
 Isub : {A : Set} -> (P : A -> Set)  ->  {x y : A} -> (Id A x y) -> (P x) -> (P y)
-Isub {A} P {x} {y} p = Jrec A x y (\u -> \v -> \w -> (P u) -> (P v)) ((\v -> v)) p 
+Isub {A} P {x} {y} p = Jrec A x y (\u -> \v -> \w -> (P u) -> (P v)) ((\v -> v)) p
 
 Ifunext : {A  B : Set} -> (f : A -> B)  ->  {x y : A} -> (Id A x y) -> Id B (f x) (f y)
 Ifunext {A} {B} f {x} {y} p  = Jrec A x y (\x -> \y -> \z -> Id B (f x) (f y)) rf p
@@ -254,7 +254,7 @@ impE : {A : Set} -> {B : Set} -> (implies A B) -> A -> B
 impE f a = f a
 
 fun : (A : Set) -> (B : Set)  -> Set
-fun A B = A -> B 
+fun A B = A -> B
 
 all : (A : Set) -> (B : A -> Set) -> Set
 all A B = (x : A) -> B x
@@ -279,7 +279,7 @@ andR {A} {B} c = prj2 c
 exists : (A : Set) -> (B : A -> Set) -> Set
 exists A B =  Σ A B
 
-existsI : {A : Set} -> {B : A -> Set} -> 
+existsI : {A : Set} -> {B : A -> Set} ->
           (a : A) -> (b : B a) -> exists A B
 existsI a b = ( a , b )
 
@@ -296,7 +296,7 @@ orE : {A B : Set} -> {C : (or A B) -> Set}
    -> ((a : A) -> C (orL a)) -> ((b : B) -> C (orR b)) -> (c : or A B) -> C c
 orE = D
 
-orEweak : {A B C : Set} 
+orEweak : {A B C : Set}
    -> (A -> C) -> (B -> C)  -> (c : or A B) -> C
 orEweak f g (inl a) = f a
 orEweak f g (inr b) = g b
@@ -338,32 +338,32 @@ non-trivial-Bool = impI (λ p → Isub Val p tt)
 
 -- sums are disjoint.
 
-is-inl :  (A B : Set) -> (u : A + B) -> Bool 
+is-inl :  (A B : Set) -> (u : A + B) -> Bool
 is-inl A B u = D (\a -> true) (\b -> false) u
 
-is-inr :  (A B : Set) -> (u : A + B) -> Bool 
+is-inr :  (A B : Set) -> (u : A + B) -> Bool
 is-inr A B u = D (\a -> false) (\b -> true) u
 
-disjointness-sum :  (A B : Set) -> (a : A) -> (b : B) 
+disjointness-sum :  (A B : Set) -> (a : A) -> (b : B)
             -> not (Id (A + B) (inl a) (inr b))
 disjointness-sum A B a b = impI (λ p → impE non-trivial-Bool (Ifunext (is-inl A B) p))
 
-disjointness-sum2 :  (A B : Set) -> (a : A) -> (b : B) 
+disjointness-sum2 :  (A B : Set) -> (a : A) -> (b : B)
             -> not (Id (A + B) (inr b) (inl a))
 disjointness-sum2 A B a b = impI (λ p → impE non-trivial-Bool (Ifunext (is-inr A B) p))
 
 -- inl and inr are injective proved using code-encode of
--- p 85-86 in HoTT (but use  LD instead of full universe). 
+-- p 85-86 in HoTT (but use  LD instead of full universe).
 -- Vaguely seen this before. Wilander's paper?
 
-code-inl : (A B : Set) -> (a : A) -> (u : (A + B)) -> Set 
+code-inl : (A B : Set) -> (a : A) -> (u : (A + B)) -> Set
 code-inl A B a = (LD A B (\x -> Id A a x)  (\y -> False))
 
-code-inr : (A B : Set) -> (b : B) -> (u : (A + B)) -> Set 
+code-inr : (A B : Set) -> (b : B) -> (u : (A + B)) -> Set
 code-inr A B b = (LD A B (\x -> False)  (\y -> Id B b y))
 
 encode-inl :  (A B : Set) -> (a : A) -> (u : A + B) -> (Id (A + B) (inl a) u) -> (code-inl A B a u)
-encode-inl A B a u p  = Isub (code-inl A B a) p rf 
+encode-inl A B a u p  = Isub (code-inl A B a) p rf
 
 encode-inr :  (A B : Set) -> (b : B) -> (u : A + B) -> (Id (A + B) (inr b) u) -> (code-inr A B b u)
 encode-inr A B b u p  = Isub (code-inr A B b) p rf
@@ -376,7 +376,7 @@ inr-injective A B b d p = encode-inr A B b (inr d) p
 
 
 Isym : (A : Set) -> (x y : A) -> Id A x y -> Id A y x
-Isym A x y p = Jrec A x y ((\x -> \y ->  \z -> Id A y x)) rf p 
+Isym A x y p = Jrec A x y ((\x -> \y ->  \z -> Id A y x)) rf p
 
 Itra : (A : Set) -> (x y z : A) -> Id A x y -> Id A y z -> Id A x z
 Itra A x y z p q =  impE (Jrec A x y ((\u -> \v ->  \w -> implies (Id A v z) (Id A u z) ))

--- a/MLTT-and-setoids/dependent-setoids-pt2.agda
+++ b/MLTT-and-setoids/dependent-setoids-pt2.agda
@@ -10,21 +10,21 @@ module dependent-setoids-pt2 where
 open import basic-types
 open import basic-setoids
 open import dependent-setoids
- 
 
-lambda-op-op : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
-  -> (f : || Π-std (Σ-std A B) C ||) 
+
+lambda-op-op : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
+  -> (f : || Π-std (Σ-std A B) C ||)
   -> ( x : || A ||) ->  ( y : || B § x ||) -> || (fix1 {A} {B} C x) § y ||
 lambda-op-op  A B C f x y = pj1 f (x , y)
 
 
-lambda-op-ext : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
-  -> (f : || Π-std (Σ-std A B) C ||) 
-  -> ( x : || A ||) 
+lambda-op-ext : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
+  -> (f : || Π-std (Σ-std A B) C ||)
+  -> ( x : || A ||)
   -> (z y : || B § x ||) (p : < B § x > z ~ y) →
       < fix1 {A} {B} C x § y > ap (fix1 {A} {B} C x ± p) (lambda-op-op A B C f x z) ~
       lambda-op-op A B C f x y
-lambda-op-ext A B C f x z y p = 
+lambda-op-ext A B C f x z y p =
     let q : < Σ-std A B > (x , z) ~ (x , y)
         q = <> (refl A x , tra {B § x} (Fam.id-trp B (refl A x) z) p)
         exf = pj2 f (x , z) (x , y) q
@@ -33,12 +33,12 @@ lambda-op-ext A B C f x z y p =
         main = exf
     in main
 
-lambda-op : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
+lambda-op : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
   -> (f : || Π-std (Σ-std A B) C ||) -> ( x : || A ||) -> || (Π-fam B C) § x ||
-lambda-op A B C f x = (lambda-op-op  A B C f x) , 
+lambda-op A B C f x = (lambda-op-op  A B C f x) ,
                       (λ u v p → pj2 f (x , u) (x , v) (<> (refl A x , tra {B § x} (Fam.id-trp B (refl A x) u) p)))
 
-lambda : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
+lambda : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
   -> (f : || Π-std (Σ-std A B) C ||) -> || Π-std A (Π-fam B C) ||
 lambda A B C f = (lambda-op A B C f) ,
     (λ x y p -> <> (\ u → pj2 f ( x , ap (B ± sym {A} p) u) (y , u) (<> ( p , Fam-inv-eq A B x y p u ))))
@@ -48,23 +48,23 @@ lambda A B C f = (lambda-op A B C f) ,
 
 
 
-curry : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
+curry : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
   -> || Π-std (Σ-std A B) C  => Π-std A (Π-fam B C) ||
-curry A B C = record { op = lambda A B C 
-                      ; ext =  λ f g p ->  
-                                 <> (λ x → <> (λ y → 
-                                        <> (>< (>< p  (x , y))))) 
+curry A B C = record { op = lambda A B C
+                      ; ext =  λ f g p ->
+                                 <> (λ x → <> (λ y →
+                                        <> (>< (>< p  (x , y)))))
                        }
 
 
 
-uncurry-op-op : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
+uncurry-op-op : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
   -> || Π-std A (Π-fam B C) ||  ->  (u : || Σ-std A B ||) -> || C § u ||
 uncurry-op-op A B C f ( x , y) =  pj1 (pj1 f x) y
 
 
 
-uncurry-op-ext : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
+uncurry-op-ext : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
   -> (f : || Π-std A (Π-fam B C) ||) ->
  (x y : || Σ-std A B ||) (p : < Σ-std A B > x ~ y) ->
       < C § y > ap (C ± p) (uncurry-op-op A B C f x) ~
@@ -75,7 +75,7 @@ uncurry-op-ext A B C f (u , v) (u' , v') p =
             exf1 = (>< exf) v'
             exf2 : < C § (u' , v') > Π-fam-trp-op-op {A} {B} C (pj1 (>< p)) (pj1 f u) v' ~
                                        pj1 (pj1 f u') v'
-            exf2 = <> (>< exf1) 
+            exf2 = <> (>< exf1)
             eq   : < B § u' > ap (B ± pj1 (>< p)) v ~ v'
             eq = pj2 (>< p)
             eq2 : < B § u > v ~ (ap (B ±  (sym (pj1 (>< p)))) v')
@@ -85,45 +85,45 @@ uncurry-op-ext A B C f (u , v) (u' , v') p =
                              (pj1 (pj1 f u) v)
                      ~ pj1 (pj1 f u) (ap (B ± sym (pj1 (>< p))) v')
             exf3 = pj2 (pj1 f u) v (ap (B ± (sym (pj1 (>< p)))) v') eq2
-            exf4 :  < C § (u' , v') > 
+            exf4 :  < C § (u' , v') >
                       ap (C ± (<> ((pj1 (>< p)) , Fam-inv-eq A B u u' (pj1 (>< p)) v')))
                          (ap (fix1 {A} {B} C u ± Fam-flip A B u u' (pj1 (>< p)) v v' (pj2 (>< p)))
                              (pj1 (pj1 f u) v))
                      ~   ap (C ± (<> ((pj1 (>< p)) , Fam-inv-eq A B u u' (pj1 (>< p)) v')))
                              (pj1 (pj1 f u) (ap (B ± sym (pj1 (>< p))) v'))
             exf4 = extensionality (C ± (<> ((pj1 (>< p)) , Fam-inv-eq A B u u' (pj1 (>< p)) v'))) _ _ exf3
-            lm :  < C § (u' , v') > 
+            lm :  < C § (u' , v') >
                     ap (C ± p) (pj1 (pj1 f u) v) ~
                     ap (C ± (<> ((pj1 (>< p)) , Fam-inv-eq A B u u' (pj1 (>< p)) v'))) (pj1 (pj1 f u) (ap (B ±  (sym                          (pj1 (>< p)))) v'))
-            lm = tra (Fam.fn-trp C _ _ _ _) exf4 
+            lm = tra (Fam.fn-trp C _ _ _ _) exf4
             main :  < C § (u' , v') > ap (C ± p) (pj1 (pj1 f u) v) ~
                                       pj1 (pj1 f u') v'
-            main = tra lm exf2 
-        in  main 
+            main = tra lm exf2
+        in  main
 
 
 
-uncurry-op : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
+uncurry-op : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
   -> || Π-std A (Π-fam B C) ||  ->  || Π-std (Σ-std A B) C ||
 uncurry-op A B C f = (uncurry-op-op A B C f) ,
                       (uncurry-op-ext A B C f)
 
-uncurry-ext : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
-  -> (f g : || Π-std A (Π-fam B C) ||)  
-  -> (< Π-std A (Π-fam B C) > f ~ g) 
+uncurry-ext : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
+  -> (f g : || Π-std A (Π-fam B C) ||)
+  -> (< Π-std A (Π-fam B C) > f ~ g)
   -> (u : || Σ-std A B ||)
   -> < C § u > uncurry-op-op A B C f u ~ uncurry-op-op A B C g u
-uncurry-ext A B C f g p (x , y) = 
+uncurry-ext A B C f g p (x , y) =
    let eq1 = >< (>< p x) y
        main :  < C § (x , y) > pj1 (pj1 f x) y ~ pj1 (pj1 g x) y
-       main = <> (>< eq1) 
-   in main 
+       main = <> (>< eq1)
+   in main
 
 
 
-uncurry : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) 
+uncurry : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B))
   -> || Π-std A (Π-fam B C)  =>  Π-std (Σ-std A B) C ||
-uncurry A B C = record { op = uncurry-op A B C 
+uncurry A B C = record { op = uncurry-op A B C
                        ; ext = λ f g p → <> (uncurry-ext A B C f g p )
                         }
 
@@ -140,14 +140,14 @@ curry-uncurry-lm A B C f (x , y) = refl (C § (x , y)) _
 
 
 curry-uncurry : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) ->
-    <  (Π-std (Σ-std A B) C)  =>  (Π-std (Σ-std A B) C) > 
+    <  (Π-std (Σ-std A B) C)  =>  (Π-std (Σ-std A B) C) >
     (uncurry A B C)  ° (curry A B C)  ~ idmap {Π-std (Σ-std A B) C}
-curry-uncurry A B C = <> (λ f → <> (λ u → curry-uncurry-lm A B C f u)) 
+curry-uncurry A B C = <> (λ f → <> (λ u → curry-uncurry-lm A B C f u))
 
 uncurry-curry : (A : setoid) -> (B : Fam A) -> (C : Fam (Σ-std A B)) ->
-    <  (Π-std A (Π-fam B C))  =>  (Π-std A (Π-fam B C)) > 
+    <  (Π-std A (Π-fam B C))  =>  (Π-std A (Π-fam B C)) >
     (curry A B C)  ° (uncurry A B C)  ~ idmap {Π-std A (Π-fam B C)}
-uncurry-curry A B C = <> (λ f → <> (λ x → <> (λ y →  refl (C § (x , y)) _))) 
+uncurry-curry A B C = <> (λ f → <> (λ x → <> (λ y →  refl (C § (x , y)) _)))
 
 
 -- Ex-reflection
@@ -162,5 +162,5 @@ Ex-intro-op A F a x = refl (F § x) (pj1 a x)
 
 Ex-intro :  (A : setoid) -> (F : Fam A) -> (a : || Π-std A F ||) ->
  || Π-std A (Ex-fam F a a) ||
-Ex-intro A F a =   (Ex-intro-op A F a) ,  (λ x y p → <> 0₁ ) 
+Ex-intro A F a =   (Ex-intro-op A F a) ,  (λ x y p → <> 0₁ )
 

--- a/MLTT-and-setoids/dependent-setoids.agda
+++ b/MLTT-and-setoids/dependent-setoids.agda
@@ -14,21 +14,21 @@ open import basic-setoids
 
 
 record Fam (A : setoid) : Set1 where
-  field 
+  field
      std : || A || -> setoid
      trp : {a b : || A ||} -> (p : < A > a ~ b) -> || std a => std b ||
-     id-trp : {a : || A ||} -> (p : < A > a ~ a) -> 
+     id-trp : {a : || A ||} -> (p : < A > a ~ a) ->
                (x : || std a ||) -> < std a > ap (trp p) x ~ x
-     ir-trp : {a b : || A ||} -> (p  q : < A > a ~ b) ->  
+     ir-trp : {a b : || A ||} -> (p  q : < A > a ~ b) ->
                (x : || std a ||) -> < std b > ap (trp p) x ~ ap (trp q) x
      fn-trp : {a b c : || A ||} -> (q : < A > b ~ c) -> (p : < A > a ~ b) ->  (r : < A > a ~ c) ->
-               (x : || std a ||) -> < std c >  ap (trp r) x ~ ap (trp q) (ap (trp p) x) 
+               (x : || std a ||) -> < std c >  ap (trp r) x ~ ap (trp q) (ap (trp p) x)
 
 -- introduce short for :  Fam.std F a    and    ap (Fam.trp F p)
 
 -- ok ?
 
-infix 5 _§_ 
+infix 5 _§_
 
 _§_ : {A : setoid} -> (F : Fam A) -> (a : || A ||) -> setoid
 _§_ F a = Fam.std F a
@@ -38,13 +38,13 @@ _±_ : {A : setoid} -> (F : Fam A) -> {a b : || A ||} -> (p : < A > a ~ b) -> ||
 _±_ F p = Fam.trp F p
 
 Fam-flip : (A : setoid) -> (F : Fam A) -> (a b : || A ||) -> (p : < A >  a ~ b) ->
-       (x : || F § a ||) ->  (y : || F § b ||) -> 
-       < F § b > ap (F ± p) x ~ y  -> < F § a >  x  ~  ap (F ± (sym p)) y 
-Fam-flip A F a b p x y q = let lm1 : < F § a > ap (F ± (sym p)) (ap (F ± p) x) 
+       (x : || F § a ||) ->  (y : || F § b ||) ->
+       < F § b > ap (F ± p) x ~ y  -> < F § a >  x  ~  ap (F ± (sym p)) y
+Fam-flip A F a b p x y q = let lm1 : < F § a > ap (F ± (sym p)) (ap (F ± p) x)
                                      ~ ap (F ± (sym p)) y
                                lm1 = extensionality (F ± (sym p)) (ap (F ± p) x) y q
                                lm2 : < F § a >  x  ~ ap (F ± (sym p)) (ap (F ± p) x)
-                               lm2 = tra (sym (Fam.id-trp F (refl A a) x)) 
+                               lm2 = tra (sym (Fam.id-trp F (refl A a) x))
                                                        (Fam.fn-trp F _ _ _ x)
                                main : < F § a >  x  ~  ap (F ± (sym p)) y
                                main = tra lm2 lm1
@@ -55,7 +55,7 @@ Fam-inv-eq : (A : setoid) -> (F : Fam A) -> (a b : || A ||) -> (p : < A >  a ~ b
        < F § b > ap (F ± p) (ap (F ± (sym p)) x) ~  x
 Fam-inv-eq A F a b p x = tra (sym (Fam.fn-trp F _ _ _ x)) (Fam.id-trp F (refl A b) x)
 
-Fam-inv-eq+ : (A : setoid) -> (F : Fam A) -> (a b : || A ||) -> (p : < A >  a ~ b) -> 
+Fam-inv-eq+ : (A : setoid) -> (F : Fam A) -> (a b : || A ||) -> (p : < A >  a ~ b) ->
        (q : < A >  b ~ a) ->    (x : || F § b ||) ->
        < F § b > ap (F ± p) (ap (F ± q) x) ~  x
 Fam-inv-eq+ A F a b p q x = tra (sym (Fam.fn-trp F _ _ _ x)) (Fam.id-trp F (refl A b) x)
@@ -64,20 +64,20 @@ Fam-inv-eq2 : (A : setoid) -> (F : Fam A) -> (a b c : || A ||) ->
        (p : < A >  a ~ b) -> (q : < A >  b ~ c) -> (r : < A >  a ~ c) ->
        (x : || F § c ||) ->
        < F § c > ap (F ± r) (ap (F ± sym p) (ap (F ± sym q) x)) ~ x
-Fam-inv-eq2 A F a b c p q r x = sym (tra (sym (Fam-inv-eq A F b c q x)) 
+Fam-inv-eq2 A F a b c p q r x = sym (tra (sym (Fam-inv-eq A F b c q x))
                                             (Fam.fn-trp F r (sym p) q (ap (F ± sym {A} q) x)))
 
 
 Fam-fn2-eq : {A : setoid} -> (F : Fam A) -> {a b c d : || A ||}
-    -> (p1 : < A >  a ~ b)  -> (p2 : < A >  b ~ d) 
+    -> (p1 : < A >  a ~ b)  -> (p2 : < A >  b ~ d)
     -> (q1 : < A >  a ~ c)  -> (q2 : < A >  c ~ d)
     -> (x : || F § a ||) -> < F § d > ap (F ± p2) (ap (F ± p1) x) ~ ap (F ± q2) (ap (F ± q1) x)
-Fam-fn2-eq {A} F {a} {b} {c} {d} p1 p2 q1 q2 x 
-         = tra {F § d} (sym {F § d} (Fam.fn-trp F _ _ _ x)) 
+Fam-fn2-eq {A} F {a} {b} {c} {d} p1 p2 q1 q2 x
+         = tra {F § d} (sym {F § d} (Fam.fn-trp F _ _ _ x))
                        (Fam.fn-trp F q2 q1 (tra {A} q1 q2) x)
 
  -- fn-trp : {a b c : || A ||} -> (q : < A > b ~ c) -> (p : < A > a ~ b) ->  (r : < A > a ~ c) ->
- --              (x : || std a ||) -> < std c >  ap (trp r) x ~ ap (trp q) (ap (trp p) x) 
+ --              (x : || std a ||) -> < std c >  ap (trp r) x ~ ap (trp q) (ap (trp p) x)
 
 
 
@@ -86,9 +86,9 @@ infix 5 _⊙_
 -- compose family with function
 
 _⊙_ : {A B : setoid} -> (F : Fam B) -> (f : || A => B ||) -> Fam A
-_⊙_ {A} {B} F f =  
+_⊙_ {A} {B} F f =
        record{ std = λ x →  F § (ap f x);
-               trp = λ p → record { op =  λ x →  ap (F ± (extensionality f _ _ p)) x ; 
+               trp = λ p → record { op =  λ x →  ap (F ± (extensionality f _ _ p)) x ;
                                     ext = λ x y q → extensionality (F ± (extensionality f _ _ p)) x y q };
                id-trp = λ p x →  Fam.id-trp F (extensionality f _ _ p) x ;
                ir-trp = λ p q x → Fam.ir-trp F (extensionality f _ _ p) (extensionality f _ _ q) x;
@@ -101,11 +101,11 @@ _⊙_ {A} {B} F f =
 Σ-std A F = record {object =  Σ (|| A ||) (\x -> || F § x ||)
                    ; _∼_  =  λ u v →  Σ (< A > pj1 u ~  pj1 v) (\p -> < F § (pj1 v) >  (ap (F ± p) (pj2 u)) ~ pj2 v)
                    ; eqrel = pair (λ x → ((refl A (pj1 x)) , (Fam.id-trp F (refl A (pj1 x)) (pj2 x))))
-                                  (pair (λ x y p → 
-                                          (sym (pj1 p) , 
-                                           sym (Fam-flip A F (pj1 x) (pj1 y) (pj1 p) (pj2 x) (pj2 y) (pj2 p)))) 
-                                        (λ x y z p q → 
-                                          (tra (pj1 p) (pj1 q) , 
+                                  (pair (λ x y p →
+                                          (sym (pj1 p) ,
+                                           sym (Fam-flip A F (pj1 x) (pj1 y) (pj1 p) (pj2 x) (pj2 y) (pj2 p))))
+                                        (λ x y z p q →
+                                          (tra (pj1 p) (pj1 q) ,
                                             let p1 : < A > pj1 x ~ pj1 y
                                                 p1 = pj1 p
                                                 p2 : < F § (pj1 y) > ap (F ± p1) (pj2 x) ~ pj2 y
@@ -114,16 +114,16 @@ _⊙_ {A} {B} F f =
                                                 q1 = pj1 q
                                                 q2 : < F § (pj1 z) > ap (F ± q1) (pj2 y) ~ pj2 z
                                                 q2 = pj2 q
-                                                lm :  < F § (pj1 z) >  ap (F ± (pj1 q)) (ap (F ± (pj1 p)) (pj2 x)) ~ 
+                                                lm :  < F § (pj1 z) >  ap (F ± (pj1 q)) (ap (F ± (pj1 p)) (pj2 x)) ~
                                                                                   ap (F ± (pj1 q)) (pj2 y)
                                                 lm = extensionality (F ± (pj1 q)) _ _ p2
                                                 main : < F § (pj1 z) >
                                                        ap (F ± (tra (pj1 p) (pj1 q))) (pj2 x) ~ pj2 z
-                                                main = tra {F § (pj1 z)} 
-                                                         (tra 
+                                                main = tra {F § (pj1 z)}
+                                                         (tra
                                                                (Fam.fn-trp F _ _ _ (pj2 x))
                                                                lm) q2
-                                            in main)))                         
+                                            in main)))
                    }
 
 Π-std : (A : setoid) -> (F : Fam A) -> setoid
@@ -131,9 +131,9 @@ _⊙_ {A} {B} F f =
                                 (\f -> (x y : || A ||) -> (p : < A > x ~ y) ->
                                    < F § y >  (ap (F ± p) (f x)) ~ (f y))
                    ; _∼_  =  λ u v →  (x : || A ||) ->  < F § x > (pj1 u) x  ~ (pj1 v) x
-                   ; eqrel = pair (λ f x → refl (F § x) (pj1 f x) ) 
-                                  (pair (λ f g p x → sym (p x)) 
-                                        (λ f g h p q x → tra (p x) (q x)))                         
+                   ; eqrel = pair (λ f x → refl (F § x) (pj1 f x) )
+                                  (pair (λ f g p x → sym (p x))
+                                        (λ f g h p q x → tra (p x) (q x)))
                    }
 
 
@@ -144,11 +144,11 @@ _⊙_ {A} {B} F f =
 
 -- name ?
 comp-Π-std : {A B : setoid} -> {F : Fam B} -> || Π-std B F || -> (f : || A => B ||) ->  || Π-std A (F ⊙ f) ||
-comp-Π-std g f = (λ x → pj1 g (ap f x)) , 
+comp-Π-std g f = (λ x → pj1 g (ap f x)) ,
                    (λ x y p → pj2 g (ap f x) (ap f y) (setoidmap.ext f x y p))
 
 π1 :  (A : setoid) -> (F : Fam A) -> || (Σ-std A F) => A ||
-π1 A F = record { op = λ u → pj1 u 
+π1 A F = record { op = λ u → pj1 u
                 ; ext = λ u v p → pj1 (>< p) }
 
 π2 : (A : setoid) -> (F : Fam A) -> || Π-std (Σ-std A F) (F ⊙ (π1 A F))  ||
@@ -156,28 +156,28 @@ comp-Π-std g f = (λ x → pj1 g (ap f x)) ,
 
 
 
-dpair :  (A B : setoid) -> (F : Fam A) 
+dpair :  (A B : setoid) -> (F : Fam A)
    -> (f : || B => A ||) -> (g : || Π-std B (F ⊙ f)||) -> || B => Σ-std A F ||
-dpair A B F f g = record { op = λ x → (ap f x) , (pj1 g x) 
-                         ; ext = λ x y p →   <> ((setoidmap.ext f x y p) , (pj2 g x y p)) 
+dpair A B F f g = record { op = λ x → (ap f x) , (pj1 g x)
+                         ; ext = λ x y p →   <> ((setoidmap.ext f x y p) , (pj2 g x y p))
                          }
 
 
 
-dpair-eq1 : (A B : setoid) -> (F : Fam A) 
+dpair-eq1 : (A B : setoid) -> (F : Fam A)
              -> (f : || B => A ||) -> (g : || Π-std B (F ⊙ f)||)
              ->  <  B => A >  (π1 A F) ° (dpair A B F f g) ~ f
 dpair-eq1 A B F f g = <> (λ x → (refl A _))
 
 
-dpair-eq2 : (A B : setoid) -> (F : Fam A) 
+dpair-eq2 : (A B : setoid) -> (F : Fam A)
              -> (f : || B => A ||) -> (g : || Π-std B (F ⊙ f)||)
              ->  <   Π-std B (F ⊙ f) > comp-Π-std {_} {_} {(F ⊙ (π1 A F))} (π2 A F) (dpair A B F f g) ~ g
 dpair-eq2 A B F f g = <> (λ x → refl ((F ⊙ f) § x) _)
 
 {-- coherence problem  (F ° f) ° h is not definitionally equal to F ° (f ° h)
 
-dpair-eq3 : (A B : setoid) -> (F : Fam A) 
+dpair-eq3 : (A B : setoid) -> (F : Fam A)
              -> (f : || B => A ||) -> (g : || Π-std B (comp-Fam F f)||)
              -> (C : setoid) -> (h : || C => B ||)
              -> < C => Σ-std A F > comp (dpair A B F f g) h ~ (dpair ? ? ? (comp f h) (comp-Π-std _ _  g h))
@@ -194,68 +194,68 @@ record Fam-iso (A : setoid) (F G : Fam A) : Set where
    field
       lociso : (x : || A ||) ->  (F § x) ≅  (G § x)
       cohere : (x y : || A ||) -> (p : < A > x ~ y) ->
-                (< (F § x) => (G § y) > 
+                (< (F § x) => (G § y) >
                      (fwd (lociso y)) ° (F ± p)
-                  ~  ((G ± p) ° (fwd (lociso x)))) 
+                  ~  ((G ± p) ° (fwd (lociso x))))
 
 
 
-comp-Fam-lm-iso : (A B C : setoid) 
+comp-Fam-lm-iso : (A B C : setoid)
      -> (f : || A => B ||) -> (g : || B => C ||) -> (F : Fam C)
      -> Fam-iso A (F ⊙ (g ° f)) ((F ⊙ g) ⊙ f)
-comp-Fam-lm-iso A B C f g F 
-     = record { lociso = λ x → (record { op = λ y → y 
-                                       ; ext = λ x u v → v }) , 
-                              ((record { op =  λ y → y 
+comp-Fam-lm-iso A B C f g F
+     = record { lociso = λ x → (record { op = λ y → y
                                        ; ext = λ x u v → v }) ,
-                              (pair (λ z → refl ((F ⊙ (g ° f)) § x) z) 
-                                    (λ z → refl (((F ⊙ g) ⊙ f) § x) z))) 
+                              ((record { op =  λ y → y
+                                       ; ext = λ x u v → v }) ,
+                              (pair (λ z → refl ((F ⊙ (g ° f)) § x) z)
+                                    (λ z → refl (((F ⊙ g) ⊙ f) § x) z)))
               ; cohere = \ x y p -> <> (\ z -> (refl (((F ⊙ g) ⊙ f) § y) _)) }
 
 comp-Fam-lm2-iso : (A : setoid)  (F : Fam A)
      -> Fam-iso A (F ⊙ (idmap {A})) F
-comp-Fam-lm2-iso A F 
-     = record { lociso = λ x → (record { op = λ y → y 
-                                       ; ext = λ x u v → v }) , 
-                              ((record { op =  λ y → y 
+comp-Fam-lm2-iso A F
+     = record { lociso = λ x → (record { op = λ y → y
                                        ; ext = λ x u v → v }) ,
-                              (pair (λ z → refl ((F ⊙ idmap) § x) _) 
-                                    (λ z → refl (F § x) _))) 
+                              ((record { op =  λ y → y
+                                       ; ext = λ x u v → v }) ,
+                              (pair (λ z → refl ((F ⊙ idmap) § x) _)
+                                    (λ z → refl (F § x) _)))
               ; cohere =  \ x y p -> <> (\ z → refl (F § y) _ )}
 
 
 
 -- more useful examples of compositions .. todo
 
-fix1-trp-op-lm : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) -> (x : || A ||) 
-  -> {a b : || F § x ||} 
+fix1-trp-op-lm : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) -> (x : || A ||)
+  -> {a b : || F § x ||}
   -> (p : < F § x > a ~ b) -> < (Σ-std A F) > (x , a) ~ (x , b)
 fix1-trp-op-lm {A} {F} G x {a} {b} p = <> ((refl A x) , (tra (Fam.id-trp F (refl A x) a) p ))
 
 
 
 
-fix1-trp-op : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) -> (x : || A ||) 
-  ->  {a b : || F § x ||} 
+fix1-trp-op : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) -> (x : || A ||)
+  ->  {a b : || F § x ||}
   -> (p : < F § x > a ~ b) -> || G § (x , a) || -> || G § (x , b) ||
-fix1-trp-op {A} {F} G x {a} {b} p z 
+fix1-trp-op {A} {F} G x {a} {b} p z
      = let q : < (Σ-std A F) >  (x , a) ~ (x , b)
            q = fix1-trp-op-lm {A} {F} G x p
-       in ap (G ± q) z 
+       in ap (G ± q) z
 
--- so this is 
+-- so this is
 -- fix1-trp-op {A} {F} G x {a} {b} p z  = ap (G ± ((refl A x) , (tra {F § x} (Fam.id-trp F (refl A x) a) p))) z
 --
 
 -- fix1-trp-fun G x p  is G_x(p)
 
-fix1-trp-fun : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) -> (x : || A ||) 
-  -> {a b : || F § x ||} 
+fix1-trp-fun : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) -> (x : || A ||)
+  -> {a b : || F § x ||}
   -> (p : < F § x > a ~ b) -> || (G § (x , a)) => (G § (x , b)) ||
-fix1-trp-fun {A} {F} G x {a} {b} p = record { op =  fix1-trp-op {A} {F} G x p 
-                                            ; ext = λ u v q → 
-                                                  extensionality (G ± (fix1-trp-op-lm {A} {F} G x p)) 
-                                                              u v q  
+fix1-trp-fun {A} {F} G x {a} {b} p = record { op =  fix1-trp-op {A} {F} G x p
+                                            ; ext = λ u v q →
+                                                  extensionality (G ± (fix1-trp-op-lm {A} {F} G x p))
+                                                              u v q
                                             }
 
 -- fix1 G x  is G_x
@@ -263,31 +263,31 @@ fix1-trp-fun {A} {F} G x {a} {b} p = record { op =  fix1-trp-op {A} {F} G x p
 
 
 fix1 : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) -> (x : || A ||) -> Fam (F § x)
-fix1 {A} {F} G x = record { std = λ y → G § (x , y) 
+fix1 {A} {F} G x = record { std = λ y → G § (x , y)
                              ; trp = λ {a} {b} p -> fix1-trp-fun {A} {F} G x p
-                             ; id-trp = λ {a} p y →  
+                             ; id-trp = λ {a} p y →
                                       Fam.id-trp G (fix1-trp-op-lm {A} {F} G x p) y
-                             ; ir-trp = λ {a} {b} p q y → 
-                                      Fam.ir-trp G (fix1-trp-op-lm {A} {F} G x p) 
-                                                   (fix1-trp-op-lm {A} {F} G x q) y 
-                             ; fn-trp = λ {a} {b} {c} q p r y → 
-                                      Fam.fn-trp G (fix1-trp-op-lm {A} {F} G x q) 
+                             ; ir-trp = λ {a} {b} p q y →
+                                      Fam.ir-trp G (fix1-trp-op-lm {A} {F} G x p)
+                                                   (fix1-trp-op-lm {A} {F} G x q) y
+                             ; fn-trp = λ {a} {b} {c} q p r y →
+                                      Fam.fn-trp G (fix1-trp-op-lm {A} {F} G x q)
                                                    (fix1-trp-op-lm {A} {F} G x p)
                                                    (fix1-trp-op-lm {A} {F} G x r) y
                              }
 
 
-Π-fam-trp-op-op-eq : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) 
-    -> {a b : || A ||} -> (p : < A > a ~ b) 
+Π-fam-trp-op-op-eq : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F))
+    -> {a b : || A ||} -> (p : < A > a ~ b)
     -> (z : || F § b ||) -> < Σ-std A F >  (a , (ap (F ± (sym {A} p)) z))  ~ (b , z)
 Π-fam-trp-op-op-eq {A} {F} G {a} {b} p z = <> (p , Fam-inv-eq A F a b p z)
 
 
-Π-fam-trp-op-op : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) 
-    -> {a b : || A ||} -> (p : < A > a ~ b) 
-    ->  || Π-std (F § a) (fix1 {A} {F} G a) || 
+Π-fam-trp-op-op : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F))
+    -> {a b : || A ||} -> (p : < A > a ~ b)
+    ->  || Π-std (F § a) (fix1 {A} {F} G a) ||
     ->  (x : || F § b ||) ->  || (fix1 {A} {F} G b) § x ||
-Π-fam-trp-op-op {A} {F} G {a} {b} p f z = 
+Π-fam-trp-op-op {A} {F} G {a} {b} p f z =
     let -p = sym p
         G1 = fix1 {A} {F} G
         lm : || F § a ||
@@ -295,18 +295,18 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
         lm2 : || (G1 a) § (ap (F ± -p) z) ||
         lm2 = pj1 f lm
         main :  || (G1 b) § z ||
-        main = ap (G ± (Π-fam-trp-op-op-eq {A} {F} G p z)) lm2 
+        main = ap (G ± (Π-fam-trp-op-op-eq {A} {F} G p z)) lm2
     in main
 
 
 
 -- main    Π-fam-trp-op-op {A} {F} G {a} {b} p f z =  ap (G ± ( p , Fam-inv-eq A F a b p z)) (pj1 f (ap (F ± -p) z))
 
-Π-fam-trp-op : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F)) 
-    -> (a b : || A ||) -> (p : < A > a ~ b) 
-    ->  || Π-std (F § a) (fix1 {A} {F} G a) || 
+Π-fam-trp-op : {A : setoid} -> {F : Fam A} ->  (G : Fam (Σ-std A F))
+    -> (a b : || A ||) -> (p : < A > a ~ b)
+    ->  || Π-std (F § a) (fix1 {A} {F} G a) ||
     ->  || Π-std (F § b) (fix1 {A} {F} G b) ||
-Π-fam-trp-op {A} {F} G a b p f 
+Π-fam-trp-op {A} {F} G a b p f
   = (Π-fam-trp-op-op {A} {F} G p f) ,
     (λ x y q → let -p = (sym {A} p)
                    G1 = fix1 {A} {F} G
@@ -319,7 +319,7 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
                    lm = pj2 f (ap (F ± -p) x) (ap (F ± -p) y) eq1
                    eq2 : < Σ-std A F >  (a , ap (F ± -p) y) ~ (b , y)
                    eq2 = <> (p , (Fam-inv-eq A F a b p y))
-                   lm2 :  < (G1 b) § y > 
+                   lm2 :  < (G1 b) § y >
                            ap (G ± eq2) (ap ((G1 a) ± (ext (F ± -p) _ _ q))
                              (pj1 f (ap (F ± -p) x)))
                            ~  ap (G ± eq2) (pj1 f (ap (F ± -p) y))
@@ -327,52 +327,52 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
                    eq3 : < Σ-std A F >  (a , ap (F ± -p) x) ~ (b , x)
                    eq3 = <> (p , (Fam-inv-eq A F a b p x))
                    lm3 :  < (G1 b) § y >
-                            ap ((G1 b) ± q) 
-                                (ap (G ± eq3) (pj1 f (ap (F ± -p) x))) ~ 
+                            ap ((G1 b) ± q)
+                                (ap (G ± eq3) (pj1 f (ap (F ± -p) x))) ~
                             ap (G ± eq2) (ap ((G1 a) ± (ext (F ± -p) _ _ q))
                                 (pj1 f (ap (F ± -p) x)))
                    lm3 = Fam-fn2-eq G _ _ _ _ _
                    main : < (G1 b) § y >
-                            ap ((G1 b) ± q) 
-                                (ap (G ± eq3) (pj1 f (ap (F ± -p) x))) ~                    
+                            ap ((G1 b) ± q)
+                                (ap (G ± eq3) (pj1 f (ap (F ± -p) x))) ~
                             ap (G ± eq2) (pj1 f (ap (F ± -p) y))
                    main = tra lm3 lm2
                in main)
 
 
 
-Π-fam-std : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) 
+Π-fam-std : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F))
          -> (x : || A ||) -> setoid
 Π-fam-std {A} F G x =  Π-std (F § x) (fix1 {A} {F} G x)
 
-Π-fam-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  
+Π-fam-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->
   (a b : || A ||) ->  (p : < A > a ~ b) ->
         || Π-std (F § a) (fix1 {A} {F} G a) => Π-std (F § b) (fix1 {A} {F} G b) ||
-Π-fam-trp {A} F G a b p =         record { op = Π-fam-trp-op {A} {F} G a b p 
+Π-fam-trp {A} F G a b p =         record { op = Π-fam-trp-op {A} {F} G a b p
                                          ; ext = λ f g q ->
                                                         <>  (\ x -> let -p = sym {A} p
                                                                         ext = extensionality
                                                                         q'' = >< q
-                 
-                                                                        q' : (t : || F § a ||) -> 
-                                                                           < (fix1 {A} {F} G a) § t > (pj1 f) t  ~ (pj1 g) t 
-                                                                        q' = λ t →  q'' t   
+
+                                                                        q' : (t : || F § a ||) ->
+                                                                           < (fix1 {A} {F} G a) § t > (pj1 f) t  ~ (pj1 g) t
+                                                                        q' = λ t →  q'' t
                                                                         --  λ u v →  (x : || A ||) ->  < F § x > (pj1 u) x  ~ (pj1 v) x
-                                                                        lm : < (fix1 {A} {F} G a) § (ap (F ± -p) x) > 
+                                                                        lm : < (fix1 {A} {F} G a) § (ap (F ± -p) x) >
                                                                              (pj1 f) (ap (F ± -p) x)  ~ (pj1 g) (ap (F ± -p) x)
                                                                         lm = q' (ap (F ± -p) x)
                                                                         main : < fix1 {A} {F} G b § x > Π-fam-trp-op-op {A} {F} G p f x ~
                                                                                                   Π-fam-trp-op-op {A} {F} G p g x
                                                                         main = ext (G ±  <> (p , (Fam-inv-eq A F a b p x))) _ _ lm -- ext ((G ± ( p , Fam-inv-eq A F a b p x))) _ _ lm
                                                                in main)
-                                          } 
+                                          }
 
 
 
 Π-fam : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  Fam A
-Π-fam {A} F G = record { std = λ x → Π-std (F § x) (fix1 {A} {F} G x) 
+Π-fam {A} F G = record { std = λ x → Π-std (F § x) (fix1 {A} {F} G x)
                         ; trp = λ {a} {b} p ->  Π-fam-trp {A} F G a b p
-                        ; id-trp = λ {a} p f -> <> (\ x -> 
+                        ; id-trp = λ {a} p f -> <> (\ x ->
                               let -p = sym {A} p
                                   lm1 : < F § a > ap (F ± -p) x ~ x
                                   lm1 = Fam.id-trp F -p x
@@ -380,11 +380,11 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
                                         ap (fix1 {A} {F} G a ± Fam.id-trp F (sym {A} p) x) (pj1 f (ap (F ± sym {A} p) x)) ~
                                         pj1 f x
                                   lm2 = pj2 f (ap (F ± -p) x) x lm1
-                                  lm3 : < fix1 {A} {F} G a § x > 
-                                                 ap (G ± (<> ( p , Fam-inv-eq A F a a p x)) ) (pj1 f (ap (F ± -p) x)) 
+                                  lm3 : < fix1 {A} {F} G a § x >
+                                                 ap (G ± (<> ( p , Fam-inv-eq A F a a p x)) ) (pj1 f (ap (F ± -p) x))
                                                  ~ ap (fix1 {A} {F} G a ± (Fam.id-trp F (sym {A} p) x)) (pj1 f (ap (F ± (sym {A} p)) x))
                                   lm3 = Fam.ir-trp G _ _ _
-                                  lm4 : < fix1 {A} {F} G a § x > ap (G ± (<> (p , Fam-inv-eq A F a a p x))) (pj1 f (ap (F ± -p) x)) 
+                                  lm4 : < fix1 {A} {F} G a § x > ap (G ± (<> (p , Fam-inv-eq A F a a p x))) (pj1 f (ap (F ± -p) x))
                                                                  ~ pj1 f x
                                   lm4 = tra lm3 lm2
                                   main : < fix1 {A} {F} G a § x > Π-fam-trp-op-op {A} {F} G p f x ~ pj1 f x
@@ -393,33 +393,33 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
                         ; ir-trp = λ {a} {b} p q f -> <> (\ x ->
                                       let -p = sym p
                                           -q = sym q
-                                          lm1 : < Fam.std F a >  ap (F ± -p) x  ~ ap (F ± -q) x 
+                                          lm1 : < Fam.std F a >  ap (F ± -p) x  ~ ap (F ± -q) x
                                           lm1 = Fam.ir-trp F -p -q _
                                           exf : < fix1 {A} {F} G a § ap (F ± -q) x >
                                                  ap (fix1 {A} {F} G a ± Fam.ir-trp F (-p) (-q) x) (pj1 f (ap (F ± -p) x))
                                                   ~ pj1 f (ap (F ± -q) x)
                                           exf = pj2 f (ap (F ± -p) x) (ap (F ± -q) x) lm1
                                           exf2 : <  Fam.std G (b , x) >
-                                                  ap (G ± (<> ( q , Fam-inv-eq A F a b q x))) 
+                                                  ap (G ± (<> ( q , Fam-inv-eq A F a b q x)))
                                                      (ap (fix1 {A} {F} G a ± Fam.ir-trp F (-p) (-q) x) (pj1 f (ap (F ± -p) x)))
                                                   ~  ap (G ± (<> ( q , Fam-inv-eq A F a b q x))) (pj1 f (ap (F ± -q) x))
                                           exf2 = extensionality ((G ± (<> ( q , Fam-inv-eq A F a b q x)))) _ _ exf
-                                           
-                                          lm2 : < Fam.std G (b , x) > ap (G ± (<> ( p , Fam-inv-eq A F a b p x))) (pj1 f (ap (F ± -p) x)) 
+
+                                          lm2 : < Fam.std G (b , x) > ap (G ± (<> ( p , Fam-inv-eq A F a b p x))) (pj1 f (ap (F ± -p) x))
                                                                     ~ ap (G ± (<> ( q , Fam-inv-eq A F a b q x))) (pj1 f (ap (F ± -q) x))
                                           lm2 = tra (Fam.fn-trp G _ _ _ _) exf2
-                                          main : < Fam.std G (b , x) > (Π-fam-trp-op-op {A} {F} G p f x) 
+                                          main : < Fam.std G (b , x) > (Π-fam-trp-op-op {A} {F} G p f x)
                                                                        ~ (Π-fam-trp-op-op {A} {F} G q f x)
                                           main = lm2
                                       in main)
 
- 
+
                         ; fn-trp = λ {a} {b} {c} q p r f -> <> (\ x →
                                       let -p = sym p
                                           -q = sym q
                                           -r = sym r
                                           lm1 :  < F § a > ap (F ± -r) x ~ ap (F ± -p) (ap (F ± -q) x)
-                                          lm1 = Fam.fn-trp F -p -q -r x 
+                                          lm1 = Fam.fn-trp F -p -q -r x
                                           -- lm1' :  < F § a >  ap (F ± -p) (ap (F ± -q) x)  ~ ap (F ± -r) x
                                           -- lm1' = sym { F § a} lm1
 
@@ -431,47 +431,47 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
                                           eq : < Σ-std A F > (a , ap (F ± -p) (ap (F ± -q) x)) ~ (c , x)
                                           eq = <> (r ,  Fam-inv-eq2 A F a b c p q r x)
 
-                                          lm1-5 :  < G § (c , x) > 
-                                               ap (G ± eq) 
+                                          lm1-5 :  < G § (c , x) >
+                                               ap (G ± eq)
                                                  (ap (fix1 {A} {F} G a ± Fam.fn-trp F -p -q -r x)
                                                     (pj1 f (ap (F ± -r) x)))
-                                                 ~ 
+                                                 ~
                                                ap (G ± eq) (pj1 f (ap (F ± -p) (ap (F ± -q) x)))
                                           lm1-5 = extensionality (G ± eq) _ _ exf
-                                          lm1-6 :  < G § (c , x) > 
-                                                ap (G ± (<> ( r , Fam-inv-eq A F a c r x))) 
+                                          lm1-6 :  < G § (c , x) >
+                                                ap (G ± (<> ( r , Fam-inv-eq A F a c r x)))
                                                     (pj1 f (ap (F ± -r) x))
-                                                 ~ 
-                                               ap (G ± eq) 
+                                                 ~
+                                               ap (G ± eq)
                                                  (ap (fix1 {A} {F} G a ± Fam.fn-trp F -p -q -r x)
                                                     (pj1 f (ap (F ± -r) x)))
                                           lm1-6 = Fam.fn-trp G _ _ _ _
-                                   
-                                          lm2 :  < G § (c , x) > 
-                                                 ap (G ± (<> ( r , Fam-inv-eq A F a c r x))) 
+
+                                          lm2 :  < G § (c , x) >
+                                                 ap (G ± (<> ( r , Fam-inv-eq A F a c r x)))
                                                     (pj1 f (ap (F ± -r) x))
                                                     ~
-                                                 ap (Fam.trp G {(b , _ )} {( c , _ )} (<> ( q , (Fam-inv-eq A F b c q x))) ) 
-                                                    (ap (G ± (<> ( p , (Fam-inv-eq A F a b p (ap (F ± -q) x))))) 
+                                                 ap (Fam.trp G {(b , _ )} {( c , _ )} (<> ( q , (Fam-inv-eq A F b c q x))) )
+                                                    (ap (G ± (<> ( p , (Fam-inv-eq A F a b p (ap (F ± -q) x)))))
                                                         (pj1 f (ap (F ± -p) (ap (F ± -q) x))))
-                                           
-                                                
+
+
                                           lm2 = tra lm1-6 (tra lm1-5 ( Fam.fn-trp G _ _ _ _))
- 
-                                          lm3 :  < G § (c , x) > 
+
+                                          lm3 :  < G § (c , x) >
                                                  ap (G ± (<> ( r , Fam-inv-eq A F a c r x))) (pj1 f (ap (F ± -r) x))
                                                     ~
-                                                 ap (G ± (<> ( q , Fam-inv-eq A F b c q x))) 
+                                                 ap (G ± (<> ( q , Fam-inv-eq A F b c q x)))
                                                     (pj1 (ap (Π-fam-trp F G a b p) f) (ap (F ± -q) x))
 
-                                                
+
                                           lm3 = lm2
- 
+
                                           lm4 :  < G § (c , x) > Π-fam-trp-op-op {A} {F} G {a} {c} r f x ~
                                                        Π-fam-trp-op-op {A} {F} G {b} {c} q (ap (Π-fam-trp F G a b p) f) x
                                           lm4 = lm3
-                                          lm5 :  < G § (c , x) > (pj1 (ap (Π-fam-trp F G a c r) f)) x 
-                                                                    ~ (pj1 (ap (Π-fam-trp F G b c q) (ap (Π-fam-trp F G a b p) f))) x 
+                                          lm5 :  < G § (c , x) > (pj1 (ap (Π-fam-trp F G a c r) f)) x
+                                                                    ~ (pj1 (ap (Π-fam-trp F G b c q) (ap (Π-fam-trp F G a b p) f))) x
                                           lm5 = lm4
                                       in lm5)
                         }
@@ -480,11 +480,11 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
 
 
 
-Σ-fam-std : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) 
+Σ-fam-std : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F))
          -> (x : || A ||) -> setoid
 Σ-fam-std {A} F G x =  Σ-std (F § x) (fix1 {A} {F} G x)
 
-Σ-fam-trp-op : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  
+Σ-fam-trp-op : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->
   (a b : || A ||) ->  (p : < A > a ~ b) ->
         || (Σ-fam-std F G a) || -> || (Σ-fam-std F G b) ||
 Σ-fam-trp-op {A} F G a b p ( x , y ) = (ap (F ± p) x) , (ap (G ± (<> ( p , refl (F § b) (ap (F ± p) x)))) y)
@@ -492,15 +492,15 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
 
 
 
-Σ-fam-trp-ext : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  
+Σ-fam-trp-ext : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->
   (a b : || A ||) ->  (p : < A > a ~ b) -> (u v : || Σ-fam-std F G a ||) ->
-  < Σ-fam-std F G a > u ~ v   -> 
+  < Σ-fam-std F G a > u ~ v   ->
   < Σ-fam-std F G b > Σ-fam-trp-op F G a b p u ~ Σ-fam-trp-op F G a b p v
-Σ-fam-trp-ext {A} F G a b p ( x , y ) ( x' , y' ) (<> ( q , r )) 
-        = <> ( extensionality (F ± p) _ _ q , 
+Σ-fam-trp-ext {A} F G a b p ( x , y ) ( x' , y' ) (<> ( q , r ))
+        = <> ( extensionality (F ± p) _ _ q ,
             let eqr : < G § (a , x') > ap (fix1 {A} {F} G a ± q) y ~ y'
                 eqr = r
-                lm : < G § (b , ap (F ± p) x') > 
+                lm : < G § (b , ap (F ± p) x') >
                       ap (G ± (<> (p , refl (F § b) (ap (F ± p) x'))))  (ap (fix1 {A} {F} G a ± q) y)
                       ~ ap (G ± (<> (p , refl (F § b) (ap (F ± p) x')))) y'
                 lm = extensionality (G ± (<> (p , refl (F § b) (ap (F ± p) x')))) _ _ eqr
@@ -508,18 +508,18 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
 
 
 
-Σ-fam-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  
+Σ-fam-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->
   (a b : || A ||) ->  (p : < A > a ~ b) ->
         || (Σ-fam-std F G a) => (Σ-fam-std F G b) ||
-Σ-fam-trp {A} F G a b p = record { op = Σ-fam-trp-op {A} F G a b p 
+Σ-fam-trp {A} F G a b p = record { op = Σ-fam-trp-op {A} F G a b p
                                  ; ext = Σ-fam-trp-ext {A} F G a b p }
 
-Σ-fam-id-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  
+Σ-fam-id-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->
       (a : || A ||) ->  (p : < A > a ~ a) -> (x : || Σ-fam-std F G a ||) ->
       < Σ-fam-std F G a > ap (Σ-fam-trp F G a a p) x ~ x
-Σ-fam-id-trp {A} F G a p ( x , y ) = 
+Σ-fam-id-trp {A} F G a p ( x , y ) =
     <> ((Fam.id-trp F p x) ,  let main : < G § (a , x) >
-                                     ap (G ± <> (((refl A a) , 
+                                     ap (G ± <> (((refl A a) ,
                                             (tra (Fam.id-trp F (refl A a) _) (Fam.id-trp F p x)))))
                                         (ap (G ± <> ((p , refl (F § a) (ap (F ± p) x)))) y)
                                       ~ y
@@ -528,14 +528,14 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
 
 
 
-Σ-fam-ir-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  
+Σ-fam-ir-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->
       (a  b : || A ||) ->  (p q : < A > a ~ b) -> (x : || Σ-fam-std F G a ||) ->
       < Σ-fam-std F G b > ap (Σ-fam-trp F G a b p) x ~ ap (Σ-fam-trp F G a b q) x
-Σ-fam-ir-trp {A} F G a b p q ( x , y ) = 
+Σ-fam-ir-trp {A} F G a b p q ( x , y ) =
       <> ((Fam.ir-trp F p q x) , (sym (Fam.fn-trp G _ _ _ _)))
 
-Σ-fam-fn-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  
-      (a  b  c : || A ||) ->  (q : < A > b ~ c) ->  (p : < A > a ~ b) -> 
+Σ-fam-fn-trp : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->
+      (a  b  c : || A ||) ->  (q : < A > b ~ c) ->  (p : < A > a ~ b) ->
       (r : < A > a ~ c) -> (x : || Σ-fam-std F G a ||) ->
       < Σ-fam-std F G c > ap (Σ-fam-trp F G a c r) x ~ ap (Σ-fam-trp F G b c q) (ap (Σ-fam-trp F G a b p) x)
 Σ-fam-fn-trp {A} F G a b c q p r ( x , y ) =
@@ -544,23 +544,23 @@ fix1 {A} {F} G x = record { std = λ y → G § (x , y)
 
 
 Σ-fam : {A : setoid} -> (F : Fam A) ->  (G : Fam (Σ-std A F)) ->  Fam A
-Σ-fam {A} F G = record { std = λ x → Σ-fam-std F G x 
-                        ; trp =  λ {a} {b}  p → Σ-fam-trp {A} F G a b p 
-                        ; id-trp = λ {a} p x → Σ-fam-id-trp {A} F G a p x 
-                        ; ir-trp = λ {a} {b} p q x →  Σ-fam-ir-trp {A} F G a b p q x 
+Σ-fam {A} F G = record { std = λ x → Σ-fam-std F G x
+                        ; trp =  λ {a} {b}  p → Σ-fam-trp {A} F G a b p
+                        ; id-trp = λ {a} p x → Σ-fam-id-trp {A} F G a p x
+                        ; ir-trp = λ {a} {b} p q x →  Σ-fam-ir-trp {A} F G a b p q x
                         ; fn-trp = λ {a} {b} {c} q p r x →  Σ-fam-fn-trp {A} F G a b c q p r x }
 
 
 Ex : (A : setoid) -> (a b : || A ||) -> setoid
-Ex A a b = triv-setoid (< A > a ~ b) 
-               
+Ex A a b = triv-setoid (< A > a ~ b)
+
 
 Ex-fam-std : {A : setoid} -> (F : Fam A) -> (a b : || Π-std A F ||) -> (x : || A ||) -> setoid
 Ex-fam-std {A} F a b x = Ex (F § x) (pj1 a x) (pj1 b x)
 
 
 
-Ex-fam-trp-op : {A : setoid} -> (F : Fam A) ->  (a b : || Π-std A F ||)  ->  
+Ex-fam-trp-op : {A : setoid} -> (F : Fam A) ->  (a b : || Π-std A F ||)  ->
   (x y : || A ||) ->  (p : < A > x ~ y) ->
         || (Ex-fam-std F a b) x ||  ->  || (Ex-fam-std F a b) y ||
 Ex-fam-trp-op {A} F a b x y p q =
@@ -570,21 +570,21 @@ Ex-fam-trp-op {A} F a b x y p q =
           exb = pj2 b x y p
           main : < F § y > (pj1 a y) ~ (pj1 b y)
           main = tra (sym exa) (tra (extensionality (F ± p) _ _ lm) exb)
-      in main 
+      in main
 
-Ex-fam-trp : {A : setoid} -> (F : Fam A) ->  (a b : || Π-std A F ||)  ->  
+Ex-fam-trp : {A : setoid} -> (F : Fam A) ->  (a b : || Π-std A F ||)  ->
   (x y : || A ||) ->  (p : < A > x ~ y) ->
         || ((Ex-fam-std F a b) x) => ((Ex-fam-std F a b) y) ||
-Ex-fam-trp  {A} F a b x y p = record { op = Ex-fam-trp-op {A} F a b x y p 
+Ex-fam-trp  {A} F a b x y p = record { op = Ex-fam-trp-op {A} F a b x y p
                                      ; ext = λ u v q -> <> (>< q) }
 
 
 
 Ex-fam : {A : setoid} -> (F : Fam A) -> (a b : || Π-std A F ||) -> Fam A
 Ex-fam {A} F a b = record { std = Ex-fam-std {A} F a b
-                          ; trp = λ {x} {y} p → Ex-fam-trp {A} F a b x y p 
-                          ; id-trp = λ {x} p u → <> 0₁ 
-                          ; ir-trp = λ {x} {y} p q u ->  <> 0₁ 
+                          ; trp = λ {x} {y} p → Ex-fam-trp {A} F a b x y p
+                          ; id-trp = λ {x} p u → <> 0₁
+                          ; ir-trp = λ {x} {y} p q u ->  <> 0₁
                           ; fn-trp = λ {x} {y} {z} q p r u ->  <> 0₁
-                          } 
+                          }
 

--- a/MLTT-and-setoids/iterative-sets-pt2.agda
+++ b/MLTT-and-setoids/iterative-sets-pt2.agda
@@ -19,7 +19,7 @@ open import iterative-sets
 -- Sigma-set in V
 
 sigmaV : (a : V) -> (g :  setoidmap1 (κ a) VV) -> V
-sigmaV a g =  sup (Σ (# a) (\y -> # (g • y))) 
+sigmaV a g =  sup (Σ (# a) (\y -> # (g • y)))
                      (\u -> < a ‣ (pj1 u) , (g • (pj1 u)) ‣ (pj2 u) >)
 
 -- First and second projections
@@ -28,8 +28,8 @@ pj1-sigmaV-op : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
             ||  κ (sigmaV a g) || -> V
 pj1-sigmaV-op a g u = a ‣ (pj1 u)
 
-pj1-sigmaV-ext : (a : V) -> (g :  setoidmap1 (κ a) VV) 
-        -> (u v : ||  κ (sigmaV a g) ||)   
+pj1-sigmaV-ext : (a : V) -> (g :  setoidmap1 (κ a) VV)
+        -> (u v : ||  κ (sigmaV a g) ||)
         -> < κ (sigmaV a g) > u ~ v
         -> pj1-sigmaV-op a g u ≐ pj1-sigmaV-op a g v
 pj1-sigmaV-ext a g u v p = prj1 (pairV-inv-1 (>< p))
@@ -38,24 +38,24 @@ pj1-sigmaV-ext a g u v p = prj1 (pairV-inv-1 (>< p))
 
 pj1-sigmaV : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
             setoidmap1 (κ (sigmaV a g)) VV
-pj1-sigmaV a g = record { op = pj1-sigmaV-op a g 
-                        ; ext = λ x y p →  <<>> ( pj1-sigmaV-ext a g x y p) 
+pj1-sigmaV a g = record { op = pj1-sigmaV-op a g
+                        ; ext = λ x y p →  <<>> ( pj1-sigmaV-ext a g x y p)
                         }
 
 
 
 
-pj1-sigmaV-prop : (a : V) -> (g :  setoidmap1 (κ a) VV)  
+pj1-sigmaV-prop : (a : V) -> (g :  setoidmap1 (κ a) VV)
             -> (u :  || κ (sigmaV a g) ||)
-            -> pj1-sigmaV a g • u ∈ a 
+            -> pj1-sigmaV a g • u ∈ a
 pj1-sigmaV-prop a g u = (pj1 u) , (refV _)
 
 pj2-sigmaV-op : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
             ||  κ (sigmaV a g) || -> V
 pj2-sigmaV-op a g u = (g • (pj1 u)) ‣ (pj2 u)
 
-pj2-sigmaV-ext : (a : V) -> (g :  setoidmap1 (κ a) VV) 
-        -> (u v : ||  κ (sigmaV a g) ||)   
+pj2-sigmaV-ext : (a : V) -> (g :  setoidmap1 (κ a) VV)
+        -> (u v : ||  κ (sigmaV a g) ||)
         -> < κ (sigmaV a g) > u ~ v
         -> pj2-sigmaV-op a g u ≐ pj2-sigmaV-op a g v
 pj2-sigmaV-ext a g u v p = prj2 (pairV-inv-1 (>< p))
@@ -63,11 +63,11 @@ pj2-sigmaV-ext a g u v p = prj2 (pairV-inv-1 (>< p))
 
 pj2-sigmaV : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
             setoidmap1 (κ (sigmaV a g)) VV
-pj2-sigmaV a g = record { op = pj2-sigmaV-op a g 
-                        ; ext = λ x y p → <<>> (pj2-sigmaV-ext a g x y p) 
+pj2-sigmaV a g = record { op = pj2-sigmaV-op a g
+                        ; ext = λ x y p → <<>> (pj2-sigmaV-ext a g x y p)
                         }
 
-pj2-sigmaV-prop : (a : V) -> (g :  setoidmap1 (κ a) VV)  
+pj2-sigmaV-prop : (a : V) -> (g :  setoidmap1 (κ a) VV)
             -> (u :  || κ (sigmaV a g) ||)
             -> pj2-sigmaV a g • u ∈ g •  (pj1 u)
 pj2-sigmaV-prop a g u = (pj2 u) , (refV _)
@@ -76,32 +76,32 @@ pj2-sigmaV-prop a g u = (pj2 u) , (refV _)
 
 -- Characterization of equality
 
-sigmaV-eq-lm1 :  (a : V) 
-           ->  (g :  setoidmap1 (κ a) VV) 
+sigmaV-eq-lm1 :  (a : V)
+           ->  (g :  setoidmap1 (κ a) VV)
            ->  (z z' : || κ (sigmaV a g) ||)
            ->  (< κ (sigmaV a g) >  z ~ z')
-           ->  and (a ‣ (pj1 z)  ≐  a ‣ (pj1 z')) 
+           ->  and (a ‣ (pj1 z)  ≐  a ‣ (pj1 z'))
                    ((g • (pj1 z)) ‣ (pj2 z)  ≐  (g • (pj1 z')) ‣ (pj2 z'))
-sigmaV-eq-lm1 a g z z' p = pairV-inv-1 (>< p) 
+sigmaV-eq-lm1 a g z z' p = pairV-inv-1 (>< p)
 
-sigmaV-eq-lm2 :  (a : V) 
-           ->  (g :  setoidmap1 (κ a) VV) 
+sigmaV-eq-lm2 :  (a : V)
+           ->  (g :  setoidmap1 (κ a) VV)
            ->  (z z' : || κ (sigmaV a g) ||)
-           ->  (a ‣ (pj1 z)  ≐  a ‣ (pj1 z')) 
+           ->  (a ‣ (pj1 z)  ≐  a ‣ (pj1 z'))
            ->  ((g • (pj1 z)) ‣ (pj2 z)  ≐  (g • (pj1 z')) ‣ (pj2 z'))
            ->  (< κ (sigmaV a g) >  z ~ z')
-sigmaV-eq-lm2 a g z z' p q = <> (pairV-ext p q) 
+sigmaV-eq-lm2 a g z z' p q = <> (pairV-ext p q)
 
 
 
 
 sigmaV-lm : (a : V) -> (g :  setoidmap1 (κ a) VV)
-      -> (x y : V) -> (< x , y > ∈ sigmaV a g) -> 
+      -> (x y : V) -> (< x , y > ∈ sigmaV a g) ->
           Σ (x ∈ a)  (\p -> (y ∈ (g • (pj1 p))))
-sigmaV-lm a g x y p = 
-    let  
+sigmaV-lm a g x y p =
+    let
         lm : Σ (# (sigmaV a g)) (\z ->  < x , y > ≐ (sigmaV a g) ‣ z)
-        lm = p 
+        lm = p
         lm1 : Σ (# a) (λ z → # (ap1 g z))
         lm1 = pj1 p
         lm2 : < x , y > ≐ < (a ‣ (pj1 lm1)) , ((g • (pj1 lm1)) ‣ (pj2 lm1)) >
@@ -111,7 +111,7 @@ sigmaV-lm a g x y p =
         lm2a = prj1 (pairV-inv-1 lm2)
         lm2b : y ≐ (bV (g • (pj1 lm1)) (pj2 lm1))
         lm2b = prj2 (pairV-inv-1 lm2)
-     
+
         lm3 : x ∈ a
         lm3 = (pj1 lm1) , lm2a
         lm4 :  y ∈ g • (pj1 (pj1 p))
@@ -126,22 +126,22 @@ sigmaV-pair-lm : (a : V) -> (g :  setoidmap1 (κ a) VV)
 sigmaV-pair-lm a g u p = let q = memV-expand u (sigmaV a g) p
                              q1 = pj1 q
                              q2 = pj2 q
-                         in record { cp1 =  a ‣ (pj1 (pj1 p)) 
-                                   ; cp2 = (g • (pj1 (pj1 p))) ‣ (pj2 (pj1 p)) 
-                                   ; eqp = q2 } 
+                         in record { cp1 =  a ‣ (pj1 (pj1 p))
+                                   ; cp2 = (g • (pj1 (pj1 p))) ‣ (pj2 (pj1 p))
+                                   ; eqp = q2 }
 
 
 sigmaV-lm-rev : (a : V) -> (g :  setoidmap1 (κ a) VV)
-      -> (x y : V) -> (p : x ∈ a) -> (y ∈ (g • (pj1 p))) 
+      -> (x y : V) -> (p : x ∈ a) -> (y ∈ (g • (pj1 p)))
       -> (< x , y > ∈ sigmaV a g)
-sigmaV-lm-rev a g x y p q = 
+sigmaV-lm-rev a g x y p q =
   let p1 : Σ (# a) (\z -> x ≐ (a ‣ z))
       p1 = p
       p2 : Σ (# (g • (pj1 p))) (\z -> y ≐ (g • (pj1 p)) ‣ z)
       p2 = q
       lm3 : < x , y > ≐ ((sigmaV a g) ‣ (pj1 p , pj1 q))
       lm3 = pairV-ext (pj2 p) (pj2 q)
-      main : Σ (# (sigmaV a g)) (\z -> < x , y > ≐ (sigmaV a g) ‣ z) 
+      main : Σ (# (sigmaV a g)) (\z -> < x , y > ≐ (sigmaV a g) ‣ z)
       main = ((pj1 p) , (pj1 q)) , lm3
   in main
 
@@ -150,14 +150,14 @@ sigmaV-lm-rev a g x y p q =
 
 
 κ-sigmaV-fwd-op : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
-       || κ (sigmaV a g) ||  ->  || Σ-std (κ a) (κ° g) ||  
-κ-sigmaV-fwd-op a g u = u 
+       || κ (sigmaV a g) ||  ->  || Σ-std (κ a) (κ° g) ||
+κ-sigmaV-fwd-op a g u = u
 
 κ-sigmaV-fwd-ext : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
        (x y :  || κ (sigmaV a g) ||) -> (< κ (sigmaV a g) > x ~ y)
        -> < Σ-std (κ a) (κ° g) >
              κ-sigmaV-fwd-op a g x ~ κ-sigmaV-fwd-op a g y
-κ-sigmaV-fwd-ext a g (x1 , x2) (y1 , y2) p = 
+κ-sigmaV-fwd-ext a g (x1 , x2) (y1 , y2) p =
      let eqp : and (a ‣ x1 ≐ a ‣ y1) ((g • x1) ‣ x2 ≐ (g • y1) ‣ y2)
          eqp = sigmaV-eq-lm1 a g (x1 , x2) (y1 , y2)  p
 
@@ -169,12 +169,12 @@ sigmaV-lm-rev a g x y p q =
          lm1 = <> pr1
 
          lm2b : (g • x1) ‣ x2 ≐ (g • y1) ‣ (ap ((κ° g) ± lm1) x2)
-         lm2b = κ°-trp-prop g x1 y1 lm1 x2    
+         lm2b = κ°-trp-prop g x1 y1 lm1 x2
 
          lm2a :  (g • y1) ‣ (ap ((κ° g) ± lm1) x2)  ≐ (g • y1) ‣ y2
          lm2a = traV (symV lm2b) pr2
          lm2 : < (κ° g) § y1 > (ap ((κ° g) ± lm1) x2) ~ y2
-         lm2 = <> lm2a 
+         lm2 = <> lm2a
          main :  < Σ-std (κ a) (κ° g) > (x1 , x2) ~ (y1 , y2)
          main = <> (lm1 , lm2)
      in main
@@ -183,7 +183,7 @@ sigmaV-lm-rev a g x y p q =
 
 κ-sigmaV-fwd : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
        || κ (sigmaV a g)  =>  Σ-std (κ a) (κ° g) ||
-κ-sigmaV-fwd a g = record { op = κ-sigmaV-fwd-op a g 
+κ-sigmaV-fwd a g = record { op = κ-sigmaV-fwd-op a g
                           ; ext = κ-sigmaV-fwd-ext a g
                           }
 
@@ -194,31 +194,31 @@ sigmaV-lm-rev a g x y p q =
        || Σ-std (κ a) (κ° g) || -> || κ (sigmaV a g)  ||
 κ-sigmaV-rev-op a g u = u
 
-κ-sigmaV-rev-ext :  (a : V) 
-        -> (g :  setoidmap1 (κ a) VV) 
+κ-sigmaV-rev-ext :  (a : V)
+        -> (g :  setoidmap1 (κ a) VV)
         -> (x y : || Σ-std (κ a) (κ° g) ||)
-        -> < Σ-std (κ a) (κ° g) > x ~ y 
+        -> < Σ-std (κ a) (κ° g) > x ~ y
         -> < κ (sigmaV a g) > κ-sigmaV-rev-op a g x ~ κ-sigmaV-rev-op a g y
 κ-sigmaV-rev-ext a g (x1 , x2) (y1 , y2) p =
      let lm0 : < κ a > x1 ~ y1
          lm0 = pj1 (>< p)
          lm1 :  a ‣ x1 ≐ a ‣ y1
-         lm1 = >< (pj1 (>< p)) 
+         lm1 = >< (pj1 (>< p))
 
 
          lm2a : (g • y1) ‣ (ap (κ° g ± lm0) x2) ≐ (g • y1) ‣ y2
-         lm2a = >< (pj2 (>< p))  
+         lm2a = >< (pj2 (>< p))
          lm2b : (g • x1) ‣ x2 ≐ (g • y1) ‣ (ap (κ° g ± lm0) x2)
-         lm2b =  κ°-trp-prop g x1 y1 lm0 x2   
+         lm2b =  κ°-trp-prop g x1 y1 lm0 x2
          lm2 : (g • x1) ‣ x2 ≐ (g • y1) ‣ y2
-         lm2 = traV lm2b lm2a 
+         lm2 = traV lm2b lm2a
      in sigmaV-eq-lm2 a g  (x1 , x2) (y1 , y2) lm1 lm2
- 
+
 
 
 κ-sigmaV-rev : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
        || Σ-std (κ a) (κ° g) => κ (sigmaV a g)  ||
-κ-sigmaV-rev a g = record { op = κ-sigmaV-rev-op a g 
+κ-sigmaV-rev a g = record { op = κ-sigmaV-rev-op a g
                           ; ext = κ-sigmaV-rev-ext a g
                           }
 
@@ -230,9 +230,9 @@ sigmaV-lm-rev a g x y p q =
 
 κ-sigmaV-iso : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
        κ (sigmaV a g)  ≅  Σ-std (κ a) (κ° g)
-κ-sigmaV-iso a g  = (κ-sigmaV-fwd a g) , 
-                            ((κ-sigmaV-rev a g) , 
-                                  pair (λ x → refl (κ (sigmaV a g)) x) 
+κ-sigmaV-iso a g  = (κ-sigmaV-fwd a g) ,
+                            ((κ-sigmaV-rev a g) ,
+                                  pair (λ x → refl (κ (sigmaV a g)) x)
                                        (λ y → refl (Σ-std (κ a) (κ° g)) y))
 
 
@@ -256,7 +256,7 @@ piV a g = sup (piV-iV a g) (piV-bV a g)
 
 
 κ-piV-fwd-op : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
-       || κ (piV a g) ||  ->  || Π-std (κ a) (κ° g) ||  
+       || κ (piV a g) ||  ->  || Π-std (κ a) (κ° g) ||
 κ-piV-fwd-op a g h = (λ x →  (pj1 h) x) , (λ x y p → pj2 h x y p)
 
 
@@ -265,7 +265,7 @@ piV a g = sup (piV-iV a g) (piV-bV a g)
        (f h :  || κ (piV a g) ||) -> (< κ (piV a g) > f ~ h)
        -> < Π-std (κ a) (κ° g) >
              κ-piV-fwd-op a g f ~ κ-piV-fwd-op a g h
-κ-piV-fwd-ext a g f h p = 
+κ-piV-fwd-ext a g f h p =
     <> (\ x ->
     let f1 : (x : # a) → # (g • x)
         f1 = pj1 f
@@ -273,9 +273,9 @@ piV a g = sup (piV-iV a g) (piV-bV a g)
         h1 = pj1 h
         eq :  piV-bV a g f ≐ piV-bV a g h
         eq = >< p
-        eqx1 :  ((x : # a) -> Σ (# a) (\y ->  < a ‣ x , (g • x) ‣ ((pj1 f) x) > ≐  < a ‣ y , (g • y) ‣ ((pj1 h) y) >)) 
-        eqx1 = prj1 (eqV-expand _ _ (>< p)) 
-        eqx2 :  ((y : # a) -> Σ (# a) (\x ->  < a ‣ x , (g • x) ‣ ((pj1 f) x) > ≐  < a ‣ y , (g • y) ‣ ((pj1 h) y) >)) 
+        eqx1 :  ((x : # a) -> Σ (# a) (\y ->  < a ‣ x , (g • x) ‣ ((pj1 f) x) > ≐  < a ‣ y , (g • y) ‣ ((pj1 h) y) >))
+        eqx1 = prj1 (eqV-expand _ _ (>< p))
+        eqx2 :  ((y : # a) -> Σ (# a) (\x ->  < a ‣ x , (g • x) ‣ ((pj1 f) x) > ≐  < a ‣ y , (g • y) ‣ ((pj1 h) y) >))
         eqx2 = prj2 (eqV-expand _ _ (>< p))
         z = pj1 (eqx1 x)
         eqx1a : < a ‣ x , (g • x) ‣ ((pj1 f) x) > ≐  < a ‣ z , (g • z) ‣ ((pj1 h) z) >
@@ -291,7 +291,7 @@ piV a g = sup (piV-iV a g) (piV-bV a g)
         exf' = >< exf
         eq4a :  (g • v) ‣ ((pj1 f) v) ≐  (g • x) ‣ (ap (κ° g ± (<> eq3)) (pj1 f v))
         eq4a = κ°-trp-prop g _ _ (<> eq3) _
-        eq4 :  (g • v) ‣ ((pj1 f) v) ≐  (g • x) ‣ ((pj1 f) x) 
+        eq4 :  (g • v) ‣ ((pj1 f) v) ≐  (g • x) ‣ ((pj1 f) x)
         eq4 = traV eq4a exf'
         eq5 : < a ‣ v , (g • v) ‣ ((pj1 f) v) > ≐ < a ‣ x , (g • x) ‣ ((pj1 f) x) >
         eq5 = pairV-ext eq3 eq4
@@ -319,20 +319,20 @@ piV a g = sup (piV-iV a g) (piV-bV a g)
 
 
 
-κ-piV-rev-ext :  (a : V) 
-        -> (g :  setoidmap1 (κ a) VV) 
+κ-piV-rev-ext :  (a : V)
+        -> (g :  setoidmap1 (κ a) VV)
         -> (f h : || Π-std (κ a) (κ° g) ||)
-        -> < Π-std (κ a) (κ° g) > f ~ h 
+        -> < Π-std (κ a) (κ° g) > f ~ h
         -> < κ (piV a g) > κ-piV-rev-op a g f ~ κ-piV-rev-op a g h
-κ-piV-rev-ext a g (f1 , f2) (h1 , h2) p = 
+κ-piV-rev-ext a g (f1 , f2) (h1 , h2) p =
       <> (
-      let 
+      let
           lm0 = >< p
           lm :  (x : || (κ a) ||) ->  (g • x) ‣ f1 x  ≐  (g • x) ‣ h1 x
           lm = λ x → >< (lm0 x) -- >< p
-          main :  sup (# a) (\x ->  < a ‣ x , (g • x) ‣ (f1 x) >)   
-                  ≐  sup (# a) (\x ->  < a ‣ x , (g • x) ‣ (h1 x) >)    
-          main = pair (λ x → x , (pairV-ext (refV _) (lm x))) 
+          main :  sup (# a) (\x ->  < a ‣ x , (g • x) ‣ (f1 x) >)
+                  ≐  sup (# a) (\x ->  < a ‣ x , (g • x) ‣ (h1 x) >)
+          main = pair (λ x → x , (pairV-ext (refV _) (lm x)))
                       (λ y → y , pairV-ext (refV _) (lm y) )
       in main)
 
@@ -349,7 +349,7 @@ piV a g = sup (piV-iV a g) (piV-bV a g)
 κ-piV-iso : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
        κ (piV a g)  ≅  Π-std (κ a) (κ° g)
 κ-piV-iso a g  = (κ-piV-fwd a g) , ((κ-piV-rev a g) ,
-                     (pair (λ h → <> (refV _)) 
-                           (λ h  → <> (λ x → refl (κ° g § x ) (pj1 h x))) 
+                     (pair (λ h → <> (refV _))
+                           (λ h  → <> (λ x → refl (κ° g § x ) (pj1 h x)))
                           ))
 

--- a/MLTT-and-setoids/iterative-sets-pt3.agda
+++ b/MLTT-and-setoids/iterative-sets-pt3.agda
@@ -32,45 +32,45 @@ Fxx : {A : classoid} -> {F : Fam10 A} -> (u : Par-elts A F) -> setoidmap1 (F §�
 Fxx u =  Par-elts.Fx u
 
 
- 
-Par-eq : {A : classoid} -> {F : Fam10 A} -> (u v : Par-elts A F) -> Set  
+
+Par-eq : {A : classoid} -> {F : Fam10 A} -> (u v : Par-elts A F) -> Set
 Par-eq {A} {F} u v =
      Σ  (<< A >> (Ixx u) ~ (Ixx v))
-      (\p -> (x : || F §§ (Ixx u) ||)  
+      (\p -> (x : || F §§ (Ixx u) ||)
            ->  << A >>  ((Fxx u) • x) ~  ((Fxx v) • (ap (F ±± p) x)))
 
 
 Par-eq-rf' : {A : classoid} -> {F : Fam10 A} -> (u : Par-elts A F) -> Par-eq u u
 Par-eq-rf' {A} {F} u = (refl' A (Ixx u)) ,
         (λ x → extensionality1 (Fxx u)  x  (ap (F ±± (refl' A (Ixx u))) x)
-                    (sym {F §§ Ixx u} (Fam10.id-trp F (refl' A (Ixx u)) x))) 
+                    (sym {F §§ Ixx u} (Fam10.id-trp F (refl' A (Ixx u)) x)))
 
 
 Par-eq-sy' : {A : classoid} -> {F : Fam10 A} -> (u v : Par-elts A F) -> Par-eq u v -> Par-eq v u
-Par-eq-sy' {A} {F} u v p = sym' {A} (pj1 p) , 
+Par-eq-sy' {A} {F} u v p = sym' {A} (pj1 p) ,
         (λ x → let p1 = pj1 p
                    p2 : << A >> Fxx u • ap (F ±± (sym' {A} (pj1 p))) x ~
                            (Fxx v • ap (F ±± (pj1 p)) (ap (F ±± (sym' {A} (pj1 p))) x))
                    p2 = pj2 p (ap (F ±± (sym' {A} (pj1 p))) x)
-               in tra' {A} (sym' {A} (extensionality1 (Fxx v) _ _ (Fam10-inv-eq A F _ _ (pj1 p) x))) 
+               in tra' {A} (sym' {A} (extensionality1 (Fxx v) _ _ (Fam10-inv-eq A F _ _ (pj1 p) x)))
                            (sym' {A} p2))
 
 Par-eq-tr' : {A : classoid} -> {F : Fam10 A} -> (u v z : Par-elts A F)
           -> Par-eq u v -> Par-eq v z -> Par-eq u z
-Par-eq-tr' {A} {F} u v z p q = (tra' {A} (pj1 p) (pj1 q)) , 
+Par-eq-tr' {A} {F} u v z p q = (tra' {A} (pj1 p) (pj1 q)) ,
         (λ x → let p1 = pj1 p
                    p2 = pj2 p x
                    q1 = pj1 q
                    q2 = pj2 q (ap (F ±± (pj1 p)) x)
-               in tra' {A} p2 
-                           (tra' {A} q2 
+               in tra' {A} p2
+                           (tra' {A} q2
                                      (extensionality1 (Fxx z) _ _ (sym {F §§ Ixx z} (Fam10.fn-trp F _ _ _ x)))))
 
 
 
 Par : (A : classoid) -> (F : Fam10 A) -> classoid
-Par A F = record { object = Par-elts A F 
-                 ; _∼_ = Par-eq {A} {F} 
+Par A F = record { object = Par-elts A F
+                 ; _∼_ = Par-eq {A} {F}
                  ; eqrel = record { rf' = Par-eq-rf'
                                   ; sy' = Par-eq-sy'
                                   ; tr' = Par-eq-tr'} }
@@ -92,8 +92,8 @@ e-prop' u v p y = traV (symV (eqV-left-right-prop p y)) (e-prop p y)
 
 
 
-                  
-irr2-lm : (u z v : V)       
+
+irr2-lm : (u z v : V)
            -> (p : u ≐ z)
            -> (q : z ≐ v)
            -> (r : u ≐ v)
@@ -101,7 +101,7 @@ irr2-lm : (u z v : V)
            v ‣ ap (κ-Fam ±± (<<>> q)) (ap (κ-Fam ±± (<<>> p)) x)
                            ≐
            v ‣ (ap (κ-Fam ±± (<<>> r)) x)
-irr2-lm u z v p q r x = 
+irr2-lm u z v p q r x =
    let lm1 : u ‣ x  ≐ v ‣ ap (κ-Fam ±± (<<>> r)) x
        lm1 = e+prop' u v r x
        lm2 : u ‣ x  ≐ z ‣ ap (κ-Fam ±± (<<>> p)) x
@@ -111,24 +111,24 @@ irr2-lm u z v p q r x =
 
    in symV (traV (symV lm1) (traV lm2 lm3))
 
-                  
-irr-lm : (u z v : V)       
+
+irr-lm : (u z v : V)
            -> (p : u ≐ z)
            -> (r : u ≐ v)
             -> (x : # u) ->
            z ‣  (ap (κ-Fam ±± (<<>> p)) x)
                            ≐
            v ‣ (ap (κ-Fam ±± (<<>> r)) x)
-irr-lm u z v p r x = 
+irr-lm u z v p r x =
    let lm1 : u ‣ x  ≐ z ‣ ap (κ-Fam ±± (<<>> p)) x
        lm1 = e+prop' u z p x
        lm2 : u ‣ x  ≐ v ‣ ap (κ-Fam ±± (<<>> r)) x
        lm2 = e+prop' u v r x
-      
+
 
    in  traV (symV lm1) lm2
 
-irr1-lm : (u v : V)       
+irr1-lm : (u v : V)
            -> (p : u ≐ v)
            -> (r : u ≐ v)
             -> (x : # u) ->
@@ -136,13 +136,13 @@ irr1-lm : (u v : V)
                            ≐
            v ‣ (ap (κ-Fam ±± (<<>> r)) x)
 irr1-lm u v p r x = irr-lm u v v p r x
-   
+
 
 
 Fxx-lm : (u v : ||| Par VV κ-Fam |||)
              -> (p : << Par VV κ-Fam >> u ~ v)
              -> (x : # (Ixx v)) ->
-                    << VV >> (Fxx v • ap (κ-Fam ±± pj1 (>><< p)) (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) x)) ~ (Fxx v • x)  
+                    << VV >> (Fxx v • ap (κ-Fam ±± pj1 (>><< p)) (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) x)) ~ (Fxx v • x)
 Fxx-lm u v p x = let lm : < κ-Fam §§ Ixx v > x ~
                                               ap (κ-Fam ±± pj1 (>><< p)) (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) x)
                      lm = sym {κ-Fam §§ Ixx v} (Fam10-inv-eq  VV κ-Fam _ _ (pj1 (>><< p)) x)
@@ -155,20 +155,20 @@ Fxx-lm' : (u v : ||| Par VV κ-Fam |||)
              -> (p : << Par VV κ-Fam >> u ~ v)
              -> (x : # (Ixx v)) ->
                     << VV >> (Fxx u • (ap (κ-Fam ±± (sym' (pj1 (>><< p )))) x))
-                            ~ (Fxx v • x)  
-Fxx-lm' u v p x = 
+                            ~ (Fxx v • x)
+Fxx-lm' u v p x =
                       let  -- p1 : (Ixx u) ≐ (Ixx v)
                            -- p1 = >><< (pj1 (>><< p))
-                           -- -p1 : (Ixx v) ≐ (Ixx u) 
+                           -- -p1 : (Ixx v) ≐ (Ixx u)
                            -- -p1 = symV p1
-                          
-                           p2 :  (x : || κ-Fam §§ (Ixx u) ||)  
+
+                           p2 :  (x : || κ-Fam §§ (Ixx u) ||)
                                     ->  << VV >>  ((Fxx u) • x) ~  ((Fxx v) • (ap (κ-Fam ±±  (pj1 (>><< p))) x))
                            p2 = pj2 (>><< p)
                            p2' : << VV >> Fxx u • ap (κ-Fam ±± sym' (pj1 (>><< p))) x ~
                                  (Fxx v • ap (κ-Fam ±± (pj1 (>><< p))) (ap (κ-Fam ±± sym' (pj1 (>><< p))) x))
                            p2' = p2 (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) x)
-                           p3 : << VV >> 
+                           p3 : << VV >>
                                  (Fxx v • ap (κ-Fam ±± (pj1 (>><< p))) (ap (κ-Fam ±± sym' (pj1 (>><< p))) x))
                                  ~ (Fxx v • x)
                            p3 = Fxx-lm u v p x
@@ -177,8 +177,8 @@ Fxx-lm' u v p x =
                       in p4
 
 
-           
-         
+
+
 
 
 
@@ -191,32 +191,32 @@ sigmaV-ext0-map : (u v : ||| Par VV κ-Fam |||)
              -> << Par VV κ-Fam >> u ~ v
              -> # (sigmaV (Ixx u) (Fxx u))
              -> # (sigmaV (Ixx v) (Fxx v))
-sigmaV-ext0-map u v p x = ap (κ-Fam ±± (pj1 (>><< p))) (pj1 x) , ap (κ-Fam ±± (pj2 (>><< p) (pj1 x))) (pj2 x)       
+sigmaV-ext0-map u v p x = ap (κ-Fam ±± (pj1 (>><< p))) (pj1 x) , ap (κ-Fam ±± (pj2 (>><< p) (pj1 x))) (pj2 x)
 
 
 sigmaV-half-ext : (u v : ||| Par VV κ-Fam |||) -> << Par VV κ-Fam >> u ~ v ->   sigmaV-op u ⊆ sigmaV-op v
-sigmaV-half-ext u v p = 
+sigmaV-half-ext u v p =
                    let p1 : (Ixx u) ≐ (Ixx v)
                        p1 = >><< (pj1 (>><< p))
-                       p2 :  (x : || κ-Fam §§ (Ixx u) ||)  
+                       p2 :  (x : || κ-Fam §§ (Ixx u) ||)
                                    ->  << VV >>  ((Fxx u) • x) ~  ((Fxx v) • (ap (κ-Fam ±± (pj1 (>><< p))) x))
-                       p2 = pj2 (>><< p) 
-                       lm1 :  (x :  Σ (# (Ixx u)) (\y -> # ((Fxx u) • y))) -> 
-                                         Σ (Σ (# (Ixx v)) (\y -> # ((Fxx v) • y))) 
-                                           (\y ->  
-                                            (< (Ixx u) ‣ (pj1 x) , ((Fxx u) • (pj1 x)) ‣ (pj2 x) > 
-                                             ≐ < (Ixx v) ‣ (pj1 y) , ((Fxx v) • (pj1 y)) ‣ (pj2 y) >)) 
+                       p2 = pj2 (>><< p)
+                       lm1 :  (x :  Σ (# (Ixx u)) (\y -> # ((Fxx u) • y))) ->
+                                         Σ (Σ (# (Ixx v)) (\y -> # ((Fxx v) • y)))
+                                           (\y ->
+                                            (< (Ixx u) ‣ (pj1 x) , ((Fxx u) • (pj1 x)) ‣ (pj2 x) >
+                                             ≐ < (Ixx v) ‣ (pj1 y) , ((Fxx v) • (pj1 y)) ‣ (pj2 y) >))
                        lm1 x = let p2b = p2 (pj1 x)
-                                   p2bb =  e+prop (>><< p2b) (pj2 x) 
+                                   p2bb =  e+prop (>><< p2b) (pj2 x)
                                in
                                   (sigmaV-ext0-map u v p x) ,
-                                  (pairV-ext (e+prop p1 (pj1 x)) 
+                                  (pairV-ext (e+prop p1 (pj1 x))
                                              p2bb)
                    in half-eqV-to-inclusion _ _ lm1
 
 sigmaV-ext : (u v : ||| Par VV κ-Fam |||) -> << Par VV κ-Fam >> u ~ v -> << VV >>  sigmaV-op u ~ sigmaV-op v
-sigmaV-ext u v p = <<>> (extensional-eqV (sigmaV-op u) (sigmaV-op v) 
-                        (sigmaV-half-ext u v p)  
+sigmaV-ext u v p = <<>> (extensional-eqV (sigmaV-op u) (sigmaV-op v)
+                        (sigmaV-half-ext u v p)
                         (sigmaV-half-ext v u (sym' {Par VV κ-Fam} {u} {v} p)))
 
 
@@ -243,26 +243,26 @@ piV-ext00 {u} {v} p h x =  ap (κ-Fam ±± (Fxx-lm' u v p x)) (h (ap (κ-Fam ±�
 piV-ext0-lm : (u v : ||| Par VV κ-Fam |||)
              -> (p : << Par VV κ-Fam >> u ~ v)
              -> (h : # (piV (Ixx u) (Fxx u)))
-             -> (x y : # (Ixx v)) 
-             -> (p' : < κ (Ixx v) > x ~ y) 
+             -> (x y : # (Ixx v))
+             -> (p' : < κ (Ixx v) > x ~ y)
              ->  < κ° (Fxx v) § y > ap (κ° (Fxx v) ± p') (piV-ext00 {u} {v} p (pj1 h) x) ~
                                     piV-ext00 {u} {v} p (pj1 h) y
-piV-ext0-lm u v p h x y p' =   
+piV-ext0-lm u v p h x y p' =
        let  q : < κ (Ixx u) > (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) x) ~ (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) y)
             q = extensionality (κ-Fam ±± (sym' (pj1 (>><< p)))) x y p'
             h2 : (x₁ y₁ : # (Ixx u)) (p₁ : < κ (Ixx u) > x₁ ~ y₁) →
                  < κ° (Fxx u) § y₁ > ap (κ° (Fxx u) ± p₁) (pj1 h x₁) ~ pj1 h y₁
-            h2 = pj2 h 
+            h2 = pj2 h
             h2' : < κ° (Fxx u) § ap (κ-Fam ±± sym' (pj1 (>><< p))) y >
                   ap (κ° (Fxx u) ± extensionality (κ-Fam ±± sym' (pj1 (>><< p))) x y p')
                     (pj1 h (ap (κ-Fam ±± sym' (pj1 (>><< p))) x))
                   ~ pj1 h (ap (κ-Fam ±± sym' (pj1 (>><< p))) y)
-            h2' = h2 _ _ q      
+            h2' = h2 _ _ q
             lm :  < κ° (Fxx v) § y >  (ap (κ-Fam ±± (Fxx-lm' u v p y)) (ap (κ° (Fxx u) ± extensionality (κ-Fam ±± sym' (pj1 (>><< p))) x y p')
                                              (pj1 h (ap (κ-Fam ±± sym' (pj1 (>><< p))) x))))
                       ~ (ap (κ-Fam ±± (Fxx-lm' u v p y)) ((pj1 h) (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) y)))
             lm = extensionality (κ-Fam ±± (Fxx-lm' u v p y)) _ _ h2'
-         
+
             lm2 : < κ° (Fxx v) § y >
                    ap (κ° (Fxx v) ± p')
                       (ap (κ-Fam ±± Fxx-lm' u v p x)
@@ -272,20 +272,20 @@ piV-ext0-lm u v p h x y p' =
                       (ap (κ° (Fxx u) ± extensionality (κ-Fam ±± sym' (pj1 (>><< p))) x y p')
                            (pj1 h (ap (κ-Fam ±± sym' (pj1 (>><< p))) x)))
             lm2 = Fam10-trp-fn2 VV κ-Fam (Fxx u • ap (κ-Fam ±± sym' (pj1 (>><< p))) x) (Fxx v • x)  (Fxx v • y) (Fxx u • ap (κ-Fam ±± sym' (pj1 (>><< p))) y)  _ (Fxx-lm' u v p x) (Fxx-lm' u v p y) _  (pj1 h (ap (κ-Fam ±± sym' (pj1 (>><< p))) x))
-            main : < κ° (Fxx v) § y > (ap (κ° (Fxx v) ± p') 
+            main : < κ° (Fxx v) § y > (ap (κ° (Fxx v) ± p')
                                         (ap (κ-Fam ±± (Fxx-lm' u v p x)) ((pj1 h) (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) x)))) ~
-                                        (ap (κ-Fam ±± (Fxx-lm' u v p y)) ((pj1 h) (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) y))) 
-  
+                                        (ap (κ-Fam ±± (Fxx-lm' u v p y)) ((pj1 h) (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) y)))
+
             main = tra lm2 lm
-           
-            
+
+
        in main -- main
 
-{-- 
+{--
 
-Fam10-trp-fn2 : (A : classoid) -> (F : Fam10 A) -> (a b c d : ||| A  |||) 
-          -> (q : << A >>  b ~ c) -> (p : << A >>  a ~ b) 
-          -> (r : << A >>  d ~ c) -> (u : << A >>  a ~ d) 
+Fam10-trp-fn2 : (A : classoid) -> (F : Fam10 A) -> (a b c d : ||| A  |||)
+          -> (q : << A >>  b ~ c) -> (p : << A >>  a ~ b)
+          -> (r : << A >>  d ~ c) -> (u : << A >>  a ~ d)
           -> (x : || F §§ a ||) -> < F §§ c > ap (F ±± q) (ap (F ±± p) x) ~ ap (F ±± r) (ap (F ±± u) x)
 
 --}
@@ -296,16 +296,16 @@ piV-ext0-map : (u v : ||| Par VV κ-Fam |||)
              -> << Par VV κ-Fam >> u ~ v
              -> # (piV (Ixx u) (Fxx u))
              -> # (piV (Ixx v) (Fxx v))
-piV-ext0-map u v p h = piV-ext00 {u} {v} p (pj1 h) , \x -> \y -> piV-ext0-lm u v p h x y 
+piV-ext0-map u v p h = piV-ext00 {u} {v} p (pj1 h) , \x -> \y -> piV-ext0-lm u v p h x y
 
 
 
 
-piV-half-ext-lm : (u v : ||| Par VV κ-Fam |||) -> (p : << Par VV κ-Fam >> u ~ v) 
+piV-half-ext-lm : (u v : ||| Par VV κ-Fam |||) -> (p : << Par VV κ-Fam >> u ~ v)
              -> (h : # (piV (Ixx u) (Fxx u)))
              -> piV (Ixx u) (Fxx u) ‣ h ≐
                 piV (Ixx v) (Fxx v) ‣ piV-ext0-map u v p h
-piV-half-ext-lm u v p (h , he) = 
+piV-half-ext-lm u v p (h , he) =
    let q : << VV >> (Ixx u) ~ (Ixx v)
        q = pj1 (>><< p)
        he'   : (x y : # (Ixx u)) -> (r : < κ (Ixx u) > x ~ y) ->
@@ -315,7 +315,7 @@ piV-half-ext-lm u v p (h , he) =
                   < κ ((Fxx u) • y) >  (ap (κ-Fam ±± (extensionality1 (Fxx u) x y r)) (h x))  ~ (h y)
        he'' = he'
 
-       eq :  (x : ||  κ-Fam §§ (Ixx u) ||)  
+       eq :  (x : ||  κ-Fam §§ (Ixx u) ||)
                 ->  << VV >>  ((Fxx u) • x) ~  ((Fxx v) • (ap (κ-Fam ±± q) x))
        eq = pj2 (>><< p)
        lm1 : (x : # (Ixx u)) →
@@ -323,45 +323,45 @@ piV-half-ext-lm u v p (h , he) =
                     (λ y →
                        < Ixx u ‣ x , (Fxx u • x) ‣ h x > ≐
                        < Ixx v ‣ y , (Fxx v • y) ‣ piV-ext00 {u} {v} p h y >)
-       lm1 x =  let 
+       lm1 x =  let
                     eq1 : << VV >> Fxx u • x ~ (Fxx v • e+ (>><< (pj1 (>><< p))) x)
                     eq1 = eq x
- 
+
                     eq1c : < κ (Ixx u) > (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x)) ~ x
-                    eq1c = Fam10-inv-gen VV κ-Fam (Ixx v) (Ixx u) _ _ x 
+                    eq1c = Fam10-inv-gen VV κ-Fam (Ixx v) (Ixx u) _ _ x
 
                     eq1d : < κ° (Fxx u) § x > h x ~ (ap (κ° (Fxx u) ± eq1c) (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+  (>><< (pj1 (>><< p))) x))))
                     eq1d = sym {κ° (Fxx u) § x} (he' _ _ eq1c)
                     eq1e : (Fxx u • x) ‣ h x ≐
                            (Fxx u • x) ‣ (ap (κ° (Fxx u) ± eq1c) (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x))))
                     eq1e = >< eq1d
-         
+
                     eq1b : (Fxx u • x) ‣  (ap (κ° (Fxx u) ± eq1c) (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x)))) ≐
                              (Fxx v •  e+ (>><< (pj1 (>><< p))) x) ‣ e+ (>><< (pj2 (>><< p) x))  (ap (κ° (Fxx u) ± eq1c) (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x))))
                     eq1b = e+prop (>><< eq1)  (ap (κ° (Fxx u) ± eq1c) (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x))))
- 
-                    eq1faa : < κ° (Fxx v) § (e+ (>><< (pj1 (>><< p))) x) >  
+
+                    eq1faa : < κ° (Fxx v) § (e+ (>><< (pj1 (>><< p))) x) >
                                 (e+ (>><< (pj2 (>><< p) x)) (ap (κ° (Fxx u) ± eq1c) (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x)))))
-                               ~ (ap (κ-Fam ±± (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x))) 
+                               ~ (ap (κ-Fam ±± (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x)))
                                                                 (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x))))
-                    eq1faa = sym  -- {κ° (Fxx v) § e+ (pj1 p) x} 
-                                 (Fam10.fn-trp κ-Fam  _ (extensionality1 (Fxx u) _ _ eq1c) (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x)) 
-                                               (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x)))) 
+                    eq1faa = sym  -- {κ° (Fxx v) § e+ (pj1 p) x}
+                                 (Fam10.fn-trp κ-Fam  _ (extensionality1 (Fxx u) _ _ eq1c) (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x))
+                                               (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x))))
 -- to revise
 
                     eq1fa : (Fxx v • e+ (>><< (pj1 (>><< p))) x) ‣ e+ (>><< (pj2 (>><< p) x))  (ap (κ° (Fxx u) ± eq1c) (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x))))
                              ≐
-                            (Fxx v • e+ (>><< (pj1 (>><< p))) x) ‣ ap (κ-Fam ±± (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x))) 
+                            (Fxx v • e+ (>><< (pj1 (>><< p))) x) ‣ ap (κ-Fam ±± (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x)))
                                                                 (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x)))
                     eq1fa = >< eq1faa
                     eq1f : (Fxx u • x) ‣ (ap (κ° (Fxx u) ± eq1c) (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x))))
                              ≐
-                           (Fxx v • e+ (>><< (pj1 (>><< p))) x) ‣ ap (κ-Fam ±± (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x))) 
+                           (Fxx v • e+ (>><< (pj1 (>><< p))) x) ‣ ap (κ-Fam ±± (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x)))
                                                                 (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x)))
                     eq1f = traV eq1b eq1fa
 
                     lm1e : (Fxx u • x) ‣ h x ≐
-                           (Fxx v • e+ (>><< (pj1 (>><< p))) x) ‣ ap (κ-Fam ±± (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x))) 
+                           (Fxx v • e+ (>><< (pj1 (>><< p))) x) ‣ ap (κ-Fam ±± (Fxx-lm' u v p (e+ (>><< (pj1 (>><< p))) x)))
                                                                 (h (ap (κ-Fam ±± (sym' (pj1 (>><< p)))) (e+ (>><< (pj1 (>><< p))) x)))
                     lm1e = traV eq1e eq1f
 
@@ -369,8 +369,8 @@ piV-half-ext-lm u v p (h , he) =
                            (Fxx v • e+ (>><< (pj1 (>><< p))) x) ‣ piV-ext00 {u} {v} p h (e+ (>><< (pj1 (>><< p))) x)
                     lm1f = lm1e
 
-                in   (e+ (>><< q) x) , 
-                        pairV-ext (e+prop (>><< q) x) 
+                in   (e+ (>><< q) x) ,
+                        pairV-ext (e+prop (>><< q) x)
                                 lm1f
 
 
@@ -383,7 +383,7 @@ piV-half-ext-lm u v p (h , he) =
                     p1 = pj1 (>><< p)
                     -p1 = sym' (pj1 (>><< p))
                     x' : # (Ixx u)
-                    x' = ap (κ-Fam ±± -p1) y  
+                    x' = ap (κ-Fam ±± -p1) y
 
                     r : << VV >> Fxx u • ap (κ-Fam ±± -p1) y ~ (Fxx v • y)
                     r = Fxx-lm' u v p y
@@ -391,7 +391,7 @@ piV-half-ext-lm u v p (h , he) =
                     eq' = >><< (eq x')
 
 
-                    lm2h : (Fxx u • x') ‣ (h x') ≐                  
+                    lm2h : (Fxx u • x') ‣ (h x') ≐
                          (Fxx v • ap (κ-Fam ±± pj1 (>><< p)) x') ‣
                           (ap (κ-Fam ±± (pj2 (>><< p) x')) (h x'))
                     lm2h = e+prop' _ _ eq' (h x')
@@ -419,15 +419,15 @@ piV-half-ext-lm u v p (h , he) =
                                            (h x'))
                     lm2k = e+prop' _ _ (>><< lmm) (ap (κ-Fam ±± (pj2 (>><< p) x')) (h x'))
                     lm2g : (Fxx v • ap (κ-Fam ±± pj1 (>><< p)) x') ‣ (ap (κ-Fam ±± (pj2 (>><< p) x')) (h x'))
-                           ≐ 
+                           ≐
                           (Fxx v • y) ‣ (ap (κ-Fam ±± r) (h (ap (κ-Fam ±± -p1) y)))
                     lm2g = traV lm2k lm2l
                     lm2f :  (Fxx u • x') ‣ h x' ≐
                             (Fxx v • y) ‣ (ap (κ-Fam ±± r) (h (ap (κ-Fam ±± -p1) y)))
 
-                    lm2f = traV lm2h lm2g 
+                    lm2f = traV lm2h lm2g
 
-                in  x' , pairV-ext (e-prop' _ _ (>><< p1) y) lm2f 
+                in  x' , pairV-ext (e-prop' _ _ (>><< p1) y) lm2f
 
 
 
@@ -439,19 +439,19 @@ piV-half-ext-lm u v p (h , he) =
 
 
 piV-half-eqV : (u v : ||| Par VV κ-Fam |||) -> << Par VV κ-Fam >> u ~ v ->  piV-op u ≤ piV-op v
-piV-half-eqV u v p = let  lm1 :  (h : # (piV (Ixx u) (Fxx u))) -> 
-                                         Σ (# (piV (Ixx v) (Fxx v))) 
-                                           (\k ->  
-                                            (piV (Ixx u) (Fxx u) ‣ h ≐ (piV (Ixx v) (Fxx v)) ‣ k)) 
+piV-half-eqV u v p = let  lm1 :  (h : # (piV (Ixx u) (Fxx u))) ->
+                                         Σ (# (piV (Ixx v) (Fxx v)))
+                                           (\k ->
+                                            (piV (Ixx u) (Fxx u) ‣ h ≐ (piV (Ixx v) (Fxx v)) ‣ k))
                           lm1 h = piV-ext0-map u v p h , piV-half-ext-lm u v p h
-                     in lm1 
+                     in lm1
 
 piV-half-ext : (u v : ||| Par VV κ-Fam |||) -> << Par VV κ-Fam >> u ~ v ->  piV-op u ⊆ piV-op v
 piV-half-ext u v p = half-eqV-to-inclusion _ _ (piV-half-eqV u v p)
 
 piV-ext : (u v : ||| Par VV κ-Fam |||) -> << Par VV κ-Fam >> u ~ v -> << VV >>  piV-op u ~ piV-op v
-piV-ext u v p =  <<>> (extensional-eqV (piV-op u) (piV-op v) 
-                                 (piV-half-ext u v p)  
+piV-ext u v p =  <<>> (extensional-eqV (piV-op u) (piV-op v)
+                                 (piV-half-ext u v p)
                                  (piV-half-ext v u (sym' {Par VV κ-Fam} {u} {v} p)))
 
 

--- a/MLTT-and-setoids/iterative-sets-pt4.agda
+++ b/MLTT-and-setoids/iterative-sets-pt4.agda
@@ -21,7 +21,7 @@ open import iterative-sets-pt3
 -- encoded as 0, {0}, {{0}}, ...
 
 br-zeroV :  N₀ -> V
-br-zeroV () 
+br-zeroV ()
 
 zeroV : V
 zeroV = sup N₀ br-zeroV
@@ -31,8 +31,8 @@ supN1-lm : (f g : N₁ -> V) -> (f 0₁ ≐ g 0₁) -> (sup N₁ f) ≐ (sup N�
 supN1-lm f g p = easy-eqV  N₁ f g (λ x → R₁ {\y ->  f y ≐ g y } p x)
 
 
-supN1-lm-rev : (f g : N₁ -> V) -> (sup N₁ f) ≐ (sup N₁ g)  -> (f 0₁ ≐ g 0₁) 
-supN1-lm-rev f g p = 
+supN1-lm-rev : (f g : N₁ -> V) -> (sup N₁ f) ≐ (sup N₁ g)  -> (f 0₁ ≐ g 0₁)
+supN1-lm-rev f g p =
   let lm = eqV-expand (sup N₁ f) (sup N₁ g) p
       lm2 = prj1 lm 0₁
       lm3 = pj2 lm2
@@ -45,7 +45,7 @@ br-singV x  0₁ = x
 singV : V -> V
 singV x = sup N₁ (br-singV x)
 
-singV-ext : (x y : V) 
+singV-ext : (x y : V)
     -> x ≐ y -> singV x ≐ singV y
 singV-ext x y p = supN1-lm _ _ p
 
@@ -57,12 +57,12 @@ singV-inj x y p = supN1-lm-rev (br-singV x)  (br-singV y) p
 succV : V -> V
 succV x = singV x
 
-succV-ext : (x y : V) 
+succV-ext : (x y : V)
     -> x ≐ y -> succV x ≐ succV y
 succV-ext x y p = singV-ext x y p
 
-succV-inj : (x y : V) 
-   -> succV x ≐ succV y  -> x ≐ y 
+succV-inj : (x y : V)
+   -> succV x ≐ succV y  -> x ≐ y
 succV-inj x y p = singV-inj x y p
 
 Peano4 : (x : V)
@@ -91,21 +91,21 @@ succ-op x =   s x
 
 
 succ-fun : || κ natV  => κ natV ||
-succ-fun = record { op = succ-op 
+succ-fun = record { op = succ-op
                   ; ext = λ x y p → <> (succV-ext (nV x) (nV y) (>< p))
                   }
 
 succ-inj : (x y : || κ natV ||) -> (< κ natV > succ-op x ~ succ-op y) -> < κ natV > x ~  y
-succ-inj x y p = <> (succV-inj _ _ (>< p)) 
+succ-inj x y p = <> (succV-inj _ _ (>< p))
 
--- succV-inj : (x y : V) 
---   -> succV x ≐ succV y  -> x ≐ y 
+-- succV-inj : (x y : V)
+--   -> succV x ≐ succV y  -> x ≐ y
 
 eqN : N -> N -> Set
 eqN O O = True
-eqN O (s y)  = False 
+eqN O (s y)  = False
 eqN (s x) O = False
-eqN (s x) (s y) = eqN x y 
+eqN (s x) (s y) = eqN x y
 
 eqN-refl : (x : N) -> eqN x x
 eqN-refl O = 0₁
@@ -126,15 +126,15 @@ eqN-tra (s x) (s y) O p q = q
 eqN-tra (s x) (s y) (s z) p q = eqN-tra x y z p q
 
 N-std : setoid
-N-std = record { object = N 
-               ; _∼_ = eqN 
+N-std = record { object = N
+               ; _∼_ = eqN
                ; eqrel = pair eqN-refl (pair eqN-sym eqN-tra) }
 
 N-to-natV-ext : (x y : || N-std ||) -> < N-std > x ~ y  -> < κ natV > x ~ y
 N-to-natV-ext O O p = <> (refV _)
 N-to-natV-ext O (s y) p = exfalso _ (>< p)
 N-to-natV-ext (s x) O p = exfalso _ (>< p)
-N-to-natV-ext (s x) (s y) p =  
+N-to-natV-ext (s x) (s y) p =
     let lm : < N-std > x ~ y
         lm = <> (>< p)
         lm2 :  < κ natV > x ~ y
@@ -143,7 +143,7 @@ N-to-natV-ext (s x) (s y) p =
 
 
 N-to-natV : || N-std  => κ natV ||
-N-to-natV = record { op = λ x → x 
+N-to-natV = record { op = λ x → x
                    ; ext = N-to-natV-ext }
 
 natV-to-N-ext : (x y : || N-std ||)  -> < κ natV > x ~ y -> < N-std > x ~ y
@@ -155,26 +155,26 @@ natV-to-N-ext (s x) (s y) p =
         p' = succ-inj _ _ p
         lm :  < N-std > x ~ y
         lm = natV-to-N-ext x y p'
-    in <> (>< lm)  
+    in <> (>< lm)
 
 natV-to-N : || κ natV => N-std ||
-natV-to-N = record { op = λ x → x 
+natV-to-N = record { op = λ x → x
                    ; ext = natV-to-N-ext }
 
 
 N-isomorphism : N-std ≅ κ natV
-N-isomorphism = N-to-natV , (natV-to-N  , 
+N-isomorphism = N-to-natV , (natV-to-N  ,
                            (pair (λ x → refl (N-std) x ) (λ y → refl (κ natV) y )))
 
 preserve-0-natV-to-N  : < N-std > ap natV-to-N O ~ O
 preserve-0-natV-to-N  = refl (N-std) O
-preserve-s-natV-to-N : (x : || κ natV ||) 
+preserve-s-natV-to-N : (x : || κ natV ||)
      ->  < N-std > ap natV-to-N (succ-op x) ~ s (ap natV-to-N x)
 preserve-s-natV-to-N x = refl (N-std) _
 
 preserve-0-N-to-natV  : < κ natV > ap N-to-natV O ~ O
 preserve-0-N-to-natV  = refl (κ natV) O
-preserve-s-N-to-natV : (x : || N-std ||) 
+preserve-s-N-to-natV : (x : || N-std ||)
      ->  < κ natV > ap  N-to-natV (s x) ~ succ-op (ap N-to-natV x)
 preserve-s-N-to-natV x = refl (κ natV) _
 
@@ -184,7 +184,7 @@ preserve-s-N-to-natV x = refl (κ natV) _
 -- dependent recursion - what is the most natural formulation for V ?
 
 
-natV-rec : 
+natV-rec :
          (C : setoidmap1 (κ natV) VV)
       -> (d : || κ (ap1 C O) ||)
       -> (e : (m : || κ natV ||) -> (z :  || κ (ap1 C m) ||) ->  || κ (ap1 C (s m)) ||)
@@ -196,7 +196,7 @@ natV-rec :
 natV-rec C d e xt O = d
 natV-rec C d e xt (s m) = e m (natV-rec C d e xt m)
 
-natV-rec-ext : 
+natV-rec-ext :
          (C : setoidmap1 (κ natV) VV)
       -> (d : || κ (ap1 C O) ||)
       -> (e : (m : || κ natV ||) -> (z :  || κ (ap1 C m) ||) ->  || κ (ap1 C (s m)) ||)
@@ -209,12 +209,12 @@ natV-rec-ext :
 natV-rec-ext C d e xt O O         p = refV _
 natV-rec-ext C d e xt  O (s k)    p = exfalso _ (Peano4 (nV k) (symV (>< p)))
 natV-rec-ext C d e xt (s m) O     p = exfalso _ (Peano4 (nV m) (>< p))
-natV-rec-ext C d e xt (s m) (s k) p = 
-        xt m k (natV-rec C d e xt m) (natV-rec C d e xt k) 
+natV-rec-ext C d e xt (s m) (s k) p =
+        xt m k (natV-rec C d e xt m) (natV-rec C d e xt k)
                (succ-inj _ _ p) (natV-rec-ext C d e xt m k ((succ-inj _ _ p)))
 
 
-natV-rec-ext2 : 
+natV-rec-ext2 :
          (C C' : setoidmap1 (κ natV) VV)
       -> (d : || κ (ap1 C O) ||)
       -> (d' : || κ (ap1 C' O) ||)
@@ -239,6 +239,6 @@ natV-rec-ext2 C C' d d' e xt e' xt' O O          p1 p2 p3 = p2
 natV-rec-ext2 C C' d d' e xt e' xt' (s m) O      p1 p2 p3 = exfalso _ (Peano4 (nV m) (>< p1))
 natV-rec-ext2 C C' d d' e xt e' xt' O (s m')     p1 p2 p3 = exfalso _ (Peano4 (nV m') (symV (>< p1)))
 natV-rec-ext2 C C' d d' e xt e' xt' (s m) (s m') p1 p2 p3 =
-      p3 m m' (natV-rec C d e xt m) (natV-rec C' d' e' xt' m') (succ-inj _ _ p1) 
+      p3 m m' (natV-rec C d e xt m) (natV-rec C' d' e' xt' m') (succ-inj _ _ p1)
                   (natV-rec-ext2 C C' d d' e xt e' xt' m m' (succ-inj _ _ p1) p2 p3)
-  
+

--- a/MLTT-and-setoids/iterative-sets-pt5.agda
+++ b/MLTT-and-setoids/iterative-sets-pt5.agda
@@ -44,13 +44,13 @@ bsV I F (sup A f) = f
 -- fails termination check
 
 -- eq-sV : sV -> sV -> U
--- eq-sV u v =  
+-- eq-sV u v =
 --           (π (isV u) (\x -> σ (isV v) (\y -> eq-sV (bsV u x) (bsV v y))))
 --            ⊗
 --           (π (isV v) (\y -> σ (isV u) (\x -> eq-sV (bsV u x) (bsV v y))))
 
 eq-sV : (I : Set) -> (F : I -> Set)  -> sV I F -> sV I F -> Uo I F
-eq-sV I F (sup A f) (sup B g) =  
+eq-sV I F (sup A f) (sup B g) =
            (π A (\x -> σ B (\y -> eq-sV I F (f x) (g y))))
             ⊗
            (π B (\y -> σ A (\x -> eq-sV I F (f x) (g y))))
@@ -61,7 +61,7 @@ memb-sV :  (I : Set) -> (F : I -> Set) -> sV I F -> sV I F -> Uo I F
 memb-sV I F u (sup B g) = σ B (\y -> eq-sV I F u (g y))
 
 br-zero-sV :  (I : Set) -> (F : I -> Set) -> N₀ -> sV I F
-br-zero-sV I F () 
+br-zero-sV I F ()
 
 zero-sV : (I : Set) -> (F : I -> Set) -> sV I F
 zero-sV I F = sup n₀ (br-zero-sV I F)
@@ -81,7 +81,7 @@ unord-sV-branch I F x y (inl _)  = x
 
 
 
--- 
+--
 
 bool :  (I : Set) -> (F : I -> Set) -> Uo I F
 bool I F = n₁ ⊕ n₁
@@ -98,13 +98,13 @@ pair-sV I F x y = unord-sV I F (unord-sV I F x x) (unord-sV I F x y)
 -- embedd sV in V
 
 
-emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V 
+emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V
 emb I F (sup A f) = sup (To {I} {F} A) (\x -> emb I F (f x))
 
 emb+ : (I : Set) -> (F : I -> Set) -> (u : sV I F) -> To {I} {F} (isV I F u) -> iV (emb I F u)
 emb+ I F (sup A f) x = x
 
-emb- : (I : Set) -> (F : I -> Set) -> (u : sV I F) -> iV (emb I F u) -> To {I} {F} (isV I F u) 
+emb- : (I : Set) -> (F : I -> Set) -> (u : sV I F) -> iV (emb I F u) -> To {I} {F} (isV I F u)
 emb- I F (sup A f) x = x
 
 
@@ -114,7 +114,7 @@ emb+- : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (x : iV (emb I F a))
     -> < κ (emb I F a) > x ~ emb+ I F a (emb- I F a x)
 emb+- I F (sup A f) x = refl (κ (emb I F (sup A f))) x
 
-emb-x :  (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (x y : iV (emb I F a)) 
+emb-x :  (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (x y : iV (emb I F a))
    -> emb I F a ‣ x ≐ emb I F a ‣ y
    -> emb I F (bsV I F a (emb- I F a x)) ≐ emb I F (bsV I F a (emb- I F a y))
 emb-x I F (sup A f) x y p = p
@@ -123,7 +123,7 @@ emb-x I F (sup A f) x y p = p
 
 
 emb-ext : (I : Set) -> (F : I -> Set) -> (u v : sV I F) -> To {I} {F} (eq-sV I F u v) -> emb I F u ≐ emb I F v
-emb-ext I F (sup A f) (sup B g) p = eqV-unexpand 
+emb-ext I F (sup A f) (sup B g) p = eqV-unexpand
                                     (sup (To {I} {F} A) (λ x → emb I F (f x)))
                                     (sup (To {I} {F} B) (λ x → emb I F (g x)))
                                  (λ x → (pj1 (prj1 p x)) , (emb-ext I F _ _ (pj2 (prj1 p x))))
@@ -133,20 +133,20 @@ emb-ext I F (sup A f) (sup B g) p = eqV-unexpand
 
 
 emb+x : (I : Set) -> (F : I -> Set) -> (a b : sV I F) -> (x : To {I} {F} (isV I F a)) -> (y : To {I} {F} (isV I F b))
-      -> To {I} {F} (eq-sV I F (bsV I F a x) (bsV I F b y)) 
-      -> emb I F a ‣ (emb+ I F a x) ≐ emb I F b ‣ (emb+ I F b y ) 
+      -> To {I} {F} (eq-sV I F (bsV I F a x) (bsV I F b y))
+      -> emb I F a ‣ (emb+ I F a x) ≐ emb I F b ‣ (emb+ I F b y )
 emb+x I F (sup A f) (sup B g) x y p = emb-ext I F _ _ p
 
-emb-bsV : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (x : To {I} {F} (isV I F a)) 
+emb-bsV : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (x : To {I} {F} (isV I F a))
                -> emb I F (bsV I F a x) ≐ (emb I F a ‣ (emb+ I F a x))
-emb-bsV I F (sup A f) x = refV (emb I F (f x)) 
+emb-bsV I F (sup A f) x = refV (emb I F (f x))
 
 
 
 
-emb-inj : (I : Set) -> (F : I -> Set) -> (u v : sV I F)  
+emb-inj : (I : Set) -> (F : I -> Set) -> (u v : sV I F)
                 -> emb I F u ≐ emb I F v -> To {I} {F} (eq-sV I F u v)
-emb-inj I F (sup A f) (sup B g) p = 
+emb-inj I F (sup A f) (sup B g) p =
    let  lm : and
             ((x : # (sup (To {I} {F} A) (λ x₁ → emb I F (f x₁)))) →
               Σ (# (sup (To {I} {F} B) (λ x₁ → emb I F (g x₁))))
@@ -158,7 +158,7 @@ emb-inj I F (sup A f) (sup B g) p =
              (λ x →
               sup (To {I} {F} A) (λ x₁ → emb I F (f x₁)) ‣ x ≐
               sup (To {I} {F} B) (λ x₁ → emb I F (g x₁)) ‣ y))
-        lm = eqV-expand  (sup (To {I} {F} A) (λ x → emb I F (f x))) 
+        lm = eqV-expand  (sup (To {I} {F} A) (λ x → emb I F (f x)))
                          (sup (To {I} {F} B) (λ x → emb I F (g x))) p
    in pair (λ x →   pj1 (prj1 lm x) , emb-inj I F _ _ (pj2 (prj1 p x)))
            (λ x → (pj1 (prj2 lm x)) , (emb-inj I F _ _ (pj2 (prj2 p x))))
@@ -167,12 +167,12 @@ emb-inj I F (sup A f) (sup B g) p =
 
 
 sVV :  (I : Set) -> (F : I -> Set) -> setoid
-sVV I F = 
+sVV I F =
       record { object = sV I F
-             ; _∼_ = λ x y → To {I} {F} (eq-sV I F x y) 
-             ; eqrel = pair (λ x → emb-inj I F x x (refV (emb I F x))) 
+             ; _∼_ = λ x y → To {I} {F} (eq-sV I F x y)
+             ; eqrel = pair (λ x → emb-inj I F x x (refV (emb I F x)))
                             (pair (λ x y p → emb-inj I F y x (symV (emb-ext I F x y p)))
-                                  (λ x y z p q → emb-inj I F x z (traV (emb-ext I F x y p) (emb-ext I F y z q)))) 
+                                  (λ x y z p q → emb-inj I F x z (traV (emb-ext I F x y p) (emb-ext I F y z q))))
              }
 
 embVV : (I : Set) -> (F : I -> Set) -> setoidmap1 (sVV I F) VV
@@ -181,23 +181,23 @@ embVV I F = record { op = emb I F
 
 
 
-emb-memb-fwd : (I : Set) -> (F : I -> Set) -> (u v : sV I F) 
+emb-memb-fwd : (I : Set) -> (F : I -> Set) -> (u v : sV I F)
             -> To {I} {F} (memb-sV I F u v) -> emb I F u ∈ emb I F v
 emb-memb-fwd I F u (sup A f) p = (pj1 p) , (emb-ext I F _ _ (pj2 p))
 
-emb-memb-rev : (I : Set) -> (F : I -> Set) -> (u v : sV I F) 
-            -> emb I F u ∈ emb I F v -> To {I} {F} (memb-sV I F u v) 
+emb-memb-rev : (I : Set) -> (F : I -> Set) -> (u v : sV I F)
+            -> emb I F u ∈ emb I F v -> To {I} {F} (memb-sV I F u v)
 emb-memb-rev I F u (sup A f) (p1 , p2) = p1 , (emb-inj I F _ _ p2)
 
 emb-zero : (I : Set) -> (F : I -> Set) -> emb I F (zero-sV I F) ≐ zeroV
-emb-zero I F = eqV-unexpand 
-                  (emb I F (zero-sV I F)) 
-                  zeroV 
-                  (λ x → exfalso _ x) 
+emb-zero I F = eqV-unexpand
+                  (emb I F (zero-sV I F))
+                  zeroV
+                  (λ x → exfalso _ x)
                   (λ y → exfalso _ y)
 
 emb-succ : (I : Set) -> (F : I -> Set) -> (u : sV I F) -> emb I F (succ-sV I F u) ≐ succV (emb I F u)
-emb-succ I F u = supN1-lm _ _ (refV (emb I F u)) 
+emb-succ I F u = supN1-lm _ _ (refV (emb I F u))
 
 
 
@@ -220,12 +220,12 @@ BoolE : {C : Bool -> Set}
 BoolE {C} p q (inl 0₁) = p
 BoolE {C} p q (inr 0₁) = q
 
-emb-unord : (I : Set) -> (F : I -> Set) -> (u v : sV I F) 
+emb-unord : (I : Set) -> (F : I -> Set) -> (u v : sV I F)
         -> emb I F (unord-sV I F u v) ≐ unord (emb I F u) (emb I F v)
 emb-unord I F (sup A f) (sup B g) = easy-eqV Bool _ _ (BoolE (refV _) (refV _))
 
 
-emb-pair : (I : Set) -> (F : I -> Set) -> (u v : sV I F) 
+emb-pair : (I : Set) -> (F : I -> Set) -> (u v : sV I F)
     -> emb I F (pair-sV I F u v) ≐ pairV (emb I F u) (emb I F v)
 emb-pair I F u v = traV (emb-unord I F (unord-sV I F u u) (unord-sV I F u v))
                         (unord-ext (emb-unord I F u u) (emb-unord I F u v))
@@ -244,7 +244,7 @@ uV I F = sup (sV I F) (emb I F)
 
 -- emb is onto uV
 
-emb-surj-uV : (I : Set) -> (F : I -> Set) -> (u : V) -> (u ∈ uV I F) 
+emb-surj-uV : (I : Set) -> (F : I -> Set) -> (u : V) -> (u ∈ uV I F)
             -> Σ (sV I F) (\v -> emb I F v ≐ u)
 emb-surj-uV I F u p = (pj1 p) , (symV (pj2 p))
 
@@ -260,9 +260,9 @@ tV I F = record { op = emb I F ;
 zeroV-in-uV : (I : Set) -> (F : I -> Set) -> zeroV ∈ uV I F
 zeroV-in-uV I F =  zero-sV I F , (symV (emb-zero I F))
 
-uV-is-succV-closed : (I : Set) -> (F : I -> Set) -> (x : V) -> (x ∈ uV I F) -> (succV x ∈ uV I F) 
+uV-is-succV-closed : (I : Set) -> (F : I -> Set) -> (x : V) -> (x ∈ uV I F) -> (succV x ∈ uV I F)
 uV-is-succV-closed I F x p =  (succ-sV I F (pj1 p)) , (traV (singV-ext _ _ (pj2 p)) (symV (emb-succ I F (pj1 p))))
-   
+
 
 
 
@@ -272,14 +272,14 @@ n-to-sV I F (s x)  = succ-sV I F (n-to-sV I F x)
 
 nat-sV-V  :  (I : Set) -> (F : I -> Set) -> (x : N) → emb I F (n-to-sV I F x) ≐ nV x
 nat-sV-V I F O = emb-zero I F
-nat-sV-V I F (s x) = 
+nat-sV-V I F (s x) =
    let    ih : emb I F (n-to-sV I F x) ≐ nV x
           ih = nat-sV-V I F x
           sih :  succV (emb I F (n-to-sV I F x)) ≐ succV (nV x)
           sih = succV-ext _ _ ih
-          lm2 : emb I F (n-to-sV I F (s x)) ≐ emb I F (succ-sV I F (n-to-sV I F x)) 
-          lm2 = emb-ext I F (n-to-sV I F (s x)) (succ-sV I F (n-to-sV I F x)) 
-                      (emb-inj I F (n-to-sV I F (s x)) (succ-sV I F (n-to-sV I F x)) (refV _))  
+          lm2 : emb I F (n-to-sV I F (s x)) ≐ emb I F (succ-sV I F (n-to-sV I F x))
+          lm2 = emb-ext I F (n-to-sV I F (s x)) (succ-sV I F (n-to-sV I F x))
+                      (emb-inj I F (n-to-sV I F (s x)) (succ-sV I F (n-to-sV I F x)) (refV _))
 
 -- emb-inj : (u v : sV)  -> emb u ≐ emb v -> T (eq-sV u v)
 -- emb-ext : (u v : sV) -> T (eq-sV u v) -> emb u ≐ emb v
@@ -303,20 +303,20 @@ natV-in-uV I F = nat-sV I F , symV (emb-nat I F)
 
 
 
-fnk : (I : Set) -> (F : I -> Set) -> (a : V) -> (p1 : # (uV I F)) 
+fnk : (I : Set) -> (F : I -> Set) -> (a : V) -> (p1 : # (uV I F))
            -> (p2 :  a ≐ (uV I F) ‣ p1 ) -> To {I} {F} (isV I F p1) -> || κ a ||
 fnk I F (sup B g) (sup A f) p2 x =  e+ (symV p2) x
 
-bnk : (I : Set) -> (F : I -> Set) -> (a : V) -> (p1 : # (uV I F)) 
+bnk : (I : Set) -> (F : I -> Set) -> (a : V) -> (p1 : # (uV I F))
            -> (p2 :  a ≐ (uV I F) ‣ p1 ) ->  || κ a || -> To {I} {F} (isV I F p1)
 bnk I F (sup B g) (sup A f) p2 x =  e+  p2 x
 
-fnkbnk-eq : (I : Set) -> (F : I -> Set) -> (a : V) -> (p1 : # (uV I F)) 
-          -> (p2 :  a ≐ (uV I F) ‣ p1 ) -> (x : || κ a ||) 
+fnkbnk-eq : (I : Set) -> (F : I -> Set) -> (a : V) -> (p1 : # (uV I F))
+          -> (p2 :  a ≐ (uV I F) ‣ p1 ) -> (x : || κ a ||)
           -> a ‣ (fnk I F a p1 p2 (bnk I F a p1 p2 x)) ≐ a ‣ x
-fnkbnk-eq I F (sup B g) (sup A f) p2 x = 
-         traV (e+fun p2 (symV p2) (refV (sup B g)) x) 
-              (symV (e+prop (refV (sup B g)) x)) 
+fnkbnk-eq I F (sup B g) (sup A f) p2 x =
+         traV (e+fun p2 (symV p2) (refV (sup B g)) x)
+              (symV (e+prop (refV (sup B g)) x))
 
 
 
@@ -325,7 +325,7 @@ fnkbnk-eq I F (sup B g) (sup A f) p2 x =
 -- emb-surj-uV u p = (pj1 p) , (symV (pj2 p))
 
 
--- bnkfnk-eq : (a : V) -> (p1 : # uV) -> (p2 :  a ≐ uV ‣ p1 ) -> (x : || κ a ||) 
+-- bnkfnk-eq : (a : V) -> (p1 : # uV) -> (p2 :  a ≐ uV ‣ p1 ) -> (x : || κ a ||)
 --          -> {! uV ‣ p1 ‣ (bnk a p1 p2 (fnk a p1 p2 x)) ≐ uV ‣ p1 ‣ x!}
 -- bnkfnk-eq (sup B g) (ssup A f) p2 x = {!!}
 
@@ -338,7 +338,7 @@ fnkbnk-eq I F (sup B g) (sup A f) p2 x =
 -- compare:
 --
 -- sigmaV : (a : V) -> (g :  setoidmap1 (κ a) VV) -> V
--- sigmaV a g =  sup (Σ (# a) (\y -> # (g • y))) 
+-- sigmaV a g =  sup (Σ (# a) (\y -> # (g • y)))
 --                     (\u -> < a ‣ (pj1 u) , (g • (pj1 u)) ‣ (pj2 u) >)
 
 -- embVV : setoidmap1 sVV VV
@@ -352,16 +352,16 @@ sigma-sV I F a g = sup  (σ (isV I F a) (λ y → isV I F (ap g (emb+ I F a y)))
                         (λ u → pair-sV I F (bsV I F a (pj1 u)) (bsV I F (ap g (emb+ I F a (pj1 u))) (pj2 u)))
 
 
- 
+
 
 emb-sigma-sV-half1-lm2 :   (I : Set) -> (F : I -> Set) -> (z : sV I F) -> (u2 : To {I} {F} (isV I F z))
    ->  emb I F (bsV I F z u2) ≐ ap1 (embVV I F) z ‣ (emb+ I F z u2)
 emb-sigma-sV-half1-lm2 I F (sup A f) u2 = refV (emb I F (f u2))
 
 
-emb-sigma-sV-half1-lm :  (I : Set) -> (F : I -> Set) -> (A  : Uo I F) -> (f  : To {I} {F} A -> sV I F) 
+emb-sigma-sV-half1-lm :  (I : Set) -> (F : I -> Set) -> (A  : Uo I F) -> (f  : To {I} {F} A -> sV I F)
     -> (g  : setoidmap (κ (sup (To {I} {F} A) (λ x → emb I F (f x)))) (sVV  I F))
-    -> (u1 : To {I} {F} A) -> (u2 : To {I} {F} (isV I F (ap g u1))) 
+    -> (u1 : To {I} {F} A) -> (u2 : To {I} {F} (isV I F (ap g u1)))
     ->  emb I F (bsV I F (ap g u1) u2) ≐
         ap1 (embVV I F) (ap g u1) ‣ emb+ I F (ap g u1) u2
 emb-sigma-sV-half1-lm I F  A f g u1 u2 = emb-sigma-sV-half1-lm2 I F (ap g u1) u2
@@ -375,9 +375,9 @@ emb-sigma-sV-half1 I F (sup A f) g (u1 , u2) =
       lm2 = emb-sigma-sV-half1-lm I F A f g u1 u2
       lm : emb I F (bsV I F (ap g u1) u2) ≐ (comp1 (embVV I F) g • u1) ‣ emb+ I F (ap g u1) u2
       lm = lm2
-  in (u1 , (emb+ I F (ap g u1) u2)) , 
-     traV (emb-pair I F _ _) 
-          (pairV-ext (refV (emb I F (f u1))) 
+  in (u1 , (emb+ I F (ap g u1) u2)) ,
+     traV (emb-pair I F _ _)
+          (pairV-ext (refV (emb I F (f u1)))
                      lm)
 
 
@@ -386,9 +386,9 @@ emb-sigma-sV-half2-lm2 :  (I : Set) -> (F : I -> Set) -> (z : sV I F) -> (u2 : #
    ->  emb I F (bsV I F z (emb- I F z u2)) ≐ ap1 (embVV I F) z ‣ u2
 emb-sigma-sV-half2-lm2 I F (sup A f) u2 = refV (emb I F (f u2))
 
-emb-sigma-sV-half2-lm :  (I : Set) -> (F : I -> Set) -> (A : Uo I F) -> (f  : To {I} {F} A -> sV I F) 
+emb-sigma-sV-half2-lm :  (I : Set) -> (F : I -> Set) -> (A : Uo I F) -> (f  : To {I} {F} A -> sV I F)
     -> (g  : setoidmap (κ (sup (To {I} {F} A) (λ x → emb I F (f x)))) (sVV I F))
-    -> (u1 : To {I} {F} A) -> (u2 : # (comp1 (embVV I F) g • u1)) 
+    -> (u1 : To {I} {F} A) -> (u2 : # (comp1 (embVV I F) g • u1))
     -> emb I F (bsV I F (ap g u1) (emb- I F (ap g u1) u2)) ≐
         ap1 (embVV I F) (ap g u1) ‣ u2
 emb-sigma-sV-half2-lm I F A f g u1 u2 = emb-sigma-sV-half2-lm2 I F (ap g u1) u2
@@ -397,19 +397,19 @@ emb-sigma-sV-half2-lm I F A f g u1 u2 = emb-sigma-sV-half2-lm2 I F (ap g u1) u2
 
 emb-sigma-sV-half2 :  (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
       -> emb I F (sigma-sV I F a g) ≥ sigmaV (emb I F a) (comp1 (embVV I F) g)
-emb-sigma-sV-half2 I F (sup A f) g (u1 , u2) = 
+emb-sigma-sV-half2 I F (sup A f) g (u1 , u2) =
   let lm2 :  emb I F (bsV I F (ap g u1) (emb- I F (ap g u1) u2)) ≐  (ap1 (embVV I F) (ap g  u1)) ‣ u2
       lm2 = emb-sigma-sV-half2-lm I F A f g u1 u2
-      lm : emb I F (bsV I F (ap g u1) (emb- I F (ap g u1) u2)) ≐ (comp1 (embVV I F) g • u1) ‣ u2 
+      lm : emb I F (bsV I F (ap g u1) (emb- I F (ap g u1) u2)) ≐ (comp1 (embVV I F) g • u1) ‣ u2
       lm = lm2
   in
-     (u1 , emb-  I F (ap g u1) u2) , 
-     traV (emb-pair I F _ _) 
+     (u1 , emb-  I F (ap g u1) u2) ,
+     traV (emb-pair I F _ _)
           (pairV-ext (refV (emb I F (f u1))) lm)
 
 emb-sigma-sV : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb  I F a)) (sVV I F))
       -> emb I F (sigma-sV  I F a g) ≐ sigmaV (emb  I F a) (comp1 (embVV I F) g)
-emb-sigma-sV I F a g = pair (emb-sigma-sV-half1 I F a g)  (emb-sigma-sV-half2 I F a g) 
+emb-sigma-sV I F a g = pair (emb-sigma-sV-half1 I F a g)  (emb-sigma-sV-half2 I F a g)
 
 
 
@@ -417,13 +417,13 @@ emb-sigma-sV I F a g = pair (emb-sigma-sV-half1 I F a g)  (emb-sigma-sV-half2 I 
 
 pi-sV-iV : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g :  setoidmap (κ (emb  I F a)) (sVV I F)) -> Uo I F
 pi-sV-iV I F a g = σ (π (isV I F a) (λ y → isV I F (ap g (emb+ I F a y))))
-                     (λ f → π (isV I F a) (λ x → 
-                            π (isV I F a) (λ y → 
-                            π (eq-sV I F (bsV I F a x) (bsV I F a y)) 
+                     (λ f → π (isV I F a) (λ x →
+                            π (isV I F a) (λ y →
+                            π (eq-sV I F (bsV I F a x) (bsV I F a y))
                                      (λ p → eq-sV I F (bsV I F (ap g (emb+ I F a x)) (f x))
                                                                        (bsV I F (ap g (emb+ I F a y)) (f y))))))
 
-pi-sV-bV : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g :  setoidmap (κ (emb I F a)) (sVV I F)) 
+pi-sV-bV : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g :  setoidmap (κ (emb I F a)) (sVV I F))
           ->  To {I} {F} (pi-sV-iV I F a g) -> sV I F
 pi-sV-bV I F a g h =  sup (isV I F a) (λ x → pair-sV I F (bsV I F a x) (bsV I F (ap g (emb+ I F a x)) (pj1 h x)))
 
@@ -434,9 +434,9 @@ pi-sV I F a g = sup (pi-sV-iV I F a g) (pi-sV-bV I F a g)
 
 
 
-emb-pi-sV-half1-ix-fn :  (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F)) 
+emb-pi-sV-half1-ix-fn :  (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
     ->  To {I} {F} (pi-sV-iV I F a g) ->  (x : # (emb I F a)) → # (comp1 (embVV I F) g • x)
-emb-pi-sV-half1-ix-fn I F a g (f , fx) x = 
+emb-pi-sV-half1-ix-fn I F a g (f , fx) x =
   let lm  : To {I} {F} (isV I F (ap g (emb+ I F a (emb- I F a x))))
       lm = f (emb- I F a x)
       lm3 : To {I} {F} (eq-sV I F (ap g x) (ap g (emb+ I F a (emb- I F a x))))
@@ -444,7 +444,7 @@ emb-pi-sV-half1-ix-fn I F a g (f , fx) x =
       lm4 : emb I F (ap g x) ≐ emb I F (ap g (emb+ I F a (emb- I F a x)))
       lm4 = emb-ext I F _ _ lm3
       lm2 : # (emb I F (ap g x))
-      lm2 = e+ (symV lm4) (emb+ I F (ap g (emb+ I F a (emb- I F a x))) lm) 
+      lm2 = e+ (symV lm4) (emb+ I F (ap g (emb+ I F a (emb- I F a x))) lm)
       main : # (comp1 (embVV I F) g • x)
       main = lm2
   in main
@@ -454,17 +454,17 @@ emb-pi-sV-half1-ix-fn I F a g (f , fx) x =
 -- emb+ : (u : sV) -> T (isV u) -> iV (emb u)
 -- emb+ (ssup A f) x = x
 
--- emb- : (u : sV) -> iV (emb u) -> T (isV u) 
+-- emb- : (u : sV) -> iV (emb u) -> T (isV u)
 -- emb- (ssup A f) x = x
 
 -- emb : sV -> V
 -- emb (ssup A f) = sup (T A) (\x -> emb (f x))
 
--- emb-pi-sV-half1-ix-fn : (a : sV) -> (g : setoidmap (κ (emb a)) sVV) 
+-- emb-pi-sV-half1-ix-fn : (a : sV) -> (g : setoidmap (κ (emb a)) sVV)
 --    ->  T (pi-sV-iV a g)
 
 -- emb-inj : (u v : sV)  -> emb u ≐ emb v -> T (eq-sV u v)
--- emb-x : (a : sV) -> (x y : iV (emb a)) 
+-- emb-x : (a : sV) -> (x y : iV (emb a))
 --   -> emb a ‣ x ≐ emb a ‣ y
 --   -> emb (bsV a (emb- a x)) ≐ emb (bsV a (emb- a y))
 
@@ -472,7 +472,7 @@ emb-pi-sV-half1-ix-fn I F a g (f , fx) x =
 
 
 
-ag-setoid-lm :  (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F)) 
+ag-setoid-lm :  (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
           -> (y : # (emb I F a))
           -> (u v :  || κ° (comp1 (embVV  I F) g) § y ||)
           -- -> < κ (emb I F (ap g y)) > u ~ v
@@ -483,44 +483,44 @@ ag-setoid-lm I F a g y u v p = <> p
 
 
 
-κ-trp-fn2 : {a b  c : V} -> (q : b ≐ c) -> (p : a ≐ b) 
+κ-trp-fn2 : {a b  c : V} -> (q : b ≐ c) -> (p : a ≐ b)
       -> (x : || κ a ||)
-      ->  < κ c >   κ-trp-op q (κ-trp-op p x) ~ κ-trp-op (traV p q) x 
+      ->  < κ c >   κ-trp-op q (κ-trp-op p x) ~ κ-trp-op (traV p q) x
 κ-trp-fn2 {a} {b} {c} q p x = sym (κ-trp-fn q p (traV p q) x)
 
 κ-trp-ext-irr : {a b : V} -> (p q : a ≐ b) ->  (x y : || κ a ||)
       ->  < κ a > x ~ y ->  < κ b > κ-trp-op p x ~ κ-trp-op q y
 κ-trp-ext-irr {a} {b} p q x y r = <> (traV (traV (symV (e+prop p x)) (>< r)) (e+prop q y))
- 
+
 κ-trp-ext-irr2 : {a b c : V} -> (p : a ≐ c) -> (q : b ≐ c) ->  (x : || κ a ||)
            ->  (y : || κ b ||)  ->  a ‣ x ≐ b ‣ y ->  < κ c > κ-trp-op p x ~ κ-trp-op q y
 κ-trp-ext-irr2 {a} {b} {c} p q x y r =  <> (traV (traV (symV (e+prop p x)) r) (e+prop q y))
 
 
 
-emb-pi-sV-half1-ix : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F)) 
-      -> To {I} {F} (pi-sV-iV I F a g) -> piV-iV (emb I F a) (comp1 (embVV I F) g) 
-emb-pi-sV-half1-ix I F a g (f , fx) = 
+emb-pi-sV-half1-ix : (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
+      -> To {I} {F} (pi-sV-iV I F a g) -> piV-iV (emb I F a) (comp1 (embVV I F) g)
+emb-pi-sV-half1-ix I F a g (f , fx) =
        emb-pi-sV-half1-ix-fn I F a g (f , fx) ,
-       (λ x y p → 
+       (λ x y p →
        let p' : (emb I F a) ‣ x ≐  (emb I F a) ‣ y
            p' = >< p
            lmq : To {I} {F} (eq-sV I F (bsV I F a (emb- I F a x)) (bsV I F a (emb- I F a y)))
            lmq = emb-inj I F (bsV I F a (emb- I F a x)) (bsV I F a (emb- I F a y)) (emb-x I F a _ _ p')
            lmx : To {I} {F} (eq-sV I F (bsV I F (ap g (emb+ I F a (emb- I F a x))) (f (emb- I F a x)))
-                          (bsV I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y))))   
+                          (bsV I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y))))
            lmx = fx (emb- I F a x) (emb- I F a y) lmq
            lmx1 : emb I F (ap g (emb+ I F a (emb- I F a x))) ‣
                    emb+ I F (ap g (emb+ I F a (emb- I F a x))) (f (emb- I F a x))
                      ≐
                   emb I F (ap g (emb+ I F a (emb- I F a y))) ‣
                     emb+ I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y))
-           lmx1 = emb+x I F (ap g (emb+ I F a (emb- I F a x))) (ap g (emb+ I F a (emb- I F a y))) 
+           lmx1 = emb+x I F (ap g (emb+ I F a (emb- I F a x))) (ap g (emb+ I F a (emb- I F a y)))
                     (f (emb- I F a x))  (f (emb- I F a y)) lmx
-           lmx2 : emb I F (bsV I F (ap g (emb+ I F a (emb- I F a x))) (f (emb- I F a x))) 
+           lmx2 : emb I F (bsV I F (ap g (emb+ I F a (emb- I F a x))) (f (emb- I F a x)))
                    ≐ emb I F (bsV I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y)))
            lmx2 = traV (emb-bsV I F (ap g (emb+ I F a (emb- I F a x))) (f (emb- I F a x)))
-                       (traV lmx1 (symV (emb-bsV I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y))))) 
+                       (traV lmx1 (symV (emb-bsV I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y)))))
            tsp1 : emb I F (ap g (emb+ I F a (emb- I F a x))) ≐ emb I F (ap g y) -- comp1 (embVV I F) g • y
            tsp1 = (traV
                  (symV
@@ -546,8 +546,8 @@ emb-pi-sV-half1-ix I F a g (f , fx) =
                  (emb-ext I F (ap g y) (ap g (emb+ I F a (emb- I F a y)))
                   (>< (extensionality g y (emb+ I F a (emb- I F a y)) (emb+- I F a y)))))
                 (emb+ I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y)))
-           lm4 = κ-trp-ext-irr2 tsp1 tsp2 
-                   (emb+ I F (ap g (emb+ I F a (emb- I F a x))) (f (emb- I F a x))) 
+           lm4 = κ-trp-ext-irr2 tsp1 tsp2
+                   (emb+ I F (ap g (emb+ I F a (emb- I F a x))) (f (emb- I F a x)))
                    (emb+ I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y))) lmx1
            lm3 :  < κ (comp1 (embVV I F) g • y) >
                 κ-trp-op
@@ -581,77 +581,77 @@ emb-pi-sV-half1-ix I F a g (f , fx) =
                (emb+ I F (ap g (emb+ I F a (emb- I F a y))) (f (emb- I F a y)))
            main = tra (κ-trp-fn2 _ (symV
                  (emb-ext I F (ap g x) (ap g (emb+ I F a (emb- I F a x)))
-                  (>< (extensionality g x (emb+ I F a (emb- I F a x)) (emb+- I F a x)))))  
+                  (>< (extensionality g x (emb+ I F a (emb- I F a x)) (emb+- I F a x)))))
                          (emb+ I F (ap g (emb+ I F a (emb- I F a x))) (f (emb- I F a x))))
                   lm3
-                       
+
        in main)
 
 
 
 emb-pi-sV-half1 :  (I : Set) -> (F : I -> Set) -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
       -> emb I F (pi-sV I F a g) ≤ piV (emb I F a) (comp1 (embVV I F) g)
-emb-pi-sV-half1 I F (sup A f) g (h , hx) = 
-  let lm2 : (x : To {I} {F} A) -> 
+emb-pi-sV-half1 I F (sup A f) g (h , hx) =
+  let lm2 : (x : To {I} {F} A) ->
          emb I F (pair-sV I F (bsV I F (sup A f) x) (bsV I F (ap g (emb+ I F (sup A f) x)) (h x)))
-                  ≐ < (emb I F (sup A f)) ‣ x , 
+                  ≐ < (emb I F (sup A f)) ‣ x ,
                     (ap1 (comp1 (embVV I F) g) x) ‣ (pj1 (emb-pi-sV-half1-ix I F (sup A f) g (h , hx)) x)   >
-                   
-      lm2 = λ x → traV (emb-pair I F _ _) 
-                       (pairV-ext (refV (emb I F (f x))) 
-                                  (traV (emb-bsV I F (ap g x) (h x)) 
+
+      lm2 = λ x → traV (emb-pair I F _ _)
+                       (pairV-ext (refV (emb I F (f x)))
+                                  (traV (emb-bsV I F (ap g x) (h x))
                                         ((e+prop (symV
                                                    (emb-ext I F (ap g x) (ap g x)
                                                     (><
                                                      (extensionality g x x
-                                                      (refl (κ (sup (To {I} {F} A) (λ x₁ → emb I F (f x₁)))) x))))) 
+                                                      (refl (κ (sup (To {I} {F} A) (λ x₁ → emb I F (f x₁)))) x)))))
                                                  (emb+ I F (ap g x) (h x))))))
-  
 
-      lm : (emb I F (pi-sV I F (sup A f) g)) ‣ (h , hx) ≐ 
+
+      lm : (emb I F (pi-sV I F (sup A f) g)) ‣ (h , hx) ≐
              (piV (emb I F (sup A f)) (comp1 (embVV I F) g)) ‣ (emb-pi-sV-half1-ix I F (sup A f) g (h , hx))
-      lm = easy-eqV (To {I} {F} A) _ _ lm2 
-  in 
+      lm = easy-eqV (To {I} {F} A) _ _ lm2
+  in
          emb-pi-sV-half1-ix  I F (sup A f) g (h , hx) ,  lm
 
 
 
 
-emb-pi-sV-half2-ix-fn :  (I : Set) -> (F : I -> Set) 
-    -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F)) 
-    ->   piV-iV (emb I F a) (comp1 (embVV I F) g) -> (x : To {I} {F} (isV I F a)) 
+emb-pi-sV-half2-ix-fn :  (I : Set) -> (F : I -> Set)
+    -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
+    ->   piV-iV (emb I F a) (comp1 (embVV I F) g) -> (x : To {I} {F} (isV I F a))
     -> To {I} {F} (isV I F (ap g (emb+ I F a x)))
-emb-pi-sV-half2-ix-fn I F a g (h , hx) x = 
+emb-pi-sV-half2-ix-fn I F a g (h , hx) x =
    let h' :  # (emb I F (ap g (emb+ I F a x)))
        h' = h (emb+ I F a x)
        main :  To {I} {F} (isV I F (ap g (emb+ I F a x)))
        main = emb- I F (ap g (emb+ I F a x)) h'
-   in main 
+   in main
 
 
 
-emb-pi-sV-half2-ix :  (I : Set) -> (F : I -> Set) 
-      -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F)) 
+emb-pi-sV-half2-ix :  (I : Set) -> (F : I -> Set)
+      -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
       -> piV-iV (emb I F a) (comp1 (embVV I F) g) -> To {I} {F} (pi-sV-iV I F a g)
-emb-pi-sV-half2-ix I F a g (h , hx) =  
+emb-pi-sV-half2-ix I F a g (h , hx) =
      emb-pi-sV-half2-ix-fn  I F a g (h , hx) ,
-      (λ x y p -> 
+      (λ x y p ->
          let p'' : emb I F (bsV I F a x) ≐ emb I F (bsV I F a y)
-             p'' = emb-ext I F _ _ p 
+             p'' = emb-ext I F _ _ p
              p' = < κ (emb I F a) > emb+ I F a x ~ emb+ I F a y
              p' = <> (traV (symV (emb-bsV I F a x)) (traV p'' (emb-bsV I F a y)))
-             hx' : < κ (emb I F (ap g (emb+ I F a y))) > 
+             hx' : < κ (emb I F (ap g (emb+ I F a y))) >
                      (ap  (κ° (comp1 (embVV I F) g) ±
                      (<> (traV (symV (emb-bsV I F a x))
                         (traV (emb-ext I F (bsV I F a x) (bsV I F a y) p) (emb-bsV I F a y)))))
-                          (h (emb+ I F a x)))  
-                     ~ (h (emb+ I F a y)) 
+                          (h (emb+ I F a x)))
+                     ~ (h (emb+ I F a y))
              hx' = hx (emb+ I F a x) (emb+ I F a y) p'
              hx2 : (emb I F (ap g (emb+ I F a y))) ‣
                      (ap  (κ° (comp1 (embVV I F) g) ±
                      (<> (traV (symV (emb-bsV I F a x))
                         (traV (emb-ext I F (bsV I F a x) (bsV I F a y) p) (emb-bsV I F a y)))))
-                          (h (emb+ I F a x)))  
+                          (h (emb+ I F a x)))
                           ≐
                    (emb I F (ap g (emb+ I F a y))) ‣ (h (emb+ I F a y))
              hx2 = >< hx'
@@ -661,68 +661,64 @@ emb-pi-sV-half2-ix I F a g (h , hx) =
                      (ap  (κ° (comp1 (embVV I F) g) ±
                      (<> (traV (symV (emb-bsV I F a x))
                         (traV (emb-ext I F (bsV I F a x) (bsV I F a y) p) (emb-bsV I F a y)))))
-                          (h (emb+ I F a x))) 
-             lm4 = e+prop {emb I F (ap g (emb+ I F a x))} {emb I F (ap g (emb+ I F a y))} _ (h (emb+ I F a x))  
+                          (h (emb+ I F a x)))
+             lm4 = e+prop {emb I F (ap g (emb+ I F a x))} {emb I F (ap g (emb+ I F a y))} _ (h (emb+ I F a x))
 
-             lm3 : (emb I F (ap g (emb+ I F a x))) ‣ 
+             lm3 : (emb I F (ap g (emb+ I F a x))) ‣
                     (emb+ I F (ap g (emb+ I F a x)) (emb- I F (ap g (emb+ I F a x)) (h (emb+ I F a x))))
                           ≐
                    (emb I F (ap g (emb+ I F a y))) ‣
                      (ap  (κ° (comp1 (embVV I F) g) ±
                      (<> (traV (symV (emb-bsV I F a x))
                         (traV (emb-ext I F (bsV I F a x) (bsV I F a y) p) (emb-bsV I F a y)))))
-                          (h (emb+ I F a x)))  
-             lm3 = traV (symV (>< (emb+- I F (ap g (emb+ I F a x)) _))) lm4    
-             lm2 : (emb I F (ap g (emb+ I F a x))) ‣ 
+                          (h (emb+ I F a x)))
+             lm3 = traV (symV (>< (emb+- I F (ap g (emb+ I F a x)) _))) lm4
+             lm2 : (emb I F (ap g (emb+ I F a x))) ‣
                     (emb+ I F (ap g (emb+ I F a x)) (emb- I F (ap g (emb+ I F a x)) (h (emb+ I F a x))))
                           ≐
-                   (emb I F (ap g (emb+ I F a y))) ‣ 
+                   (emb I F (ap g (emb+ I F a y))) ‣
                     (emb+ I F (ap g (emb+ I F a y)) (emb- I F (ap g (emb+ I F a y)) (h (emb+ I F a y))))
              lm2 = traV (traV lm3 hx2) (>< (emb+- I F (ap g (emb+ I F a y)) (h (emb+ I F a y))))
-             lm : emb I F (bsV I F (ap g (emb+ I F a x)) (emb- I F (ap g (emb+ I F a x)) (h (emb+ I F a x)))) 
+             lm : emb I F (bsV I F (ap g (emb+ I F a x)) (emb- I F (ap g (emb+ I F a x)) (h (emb+ I F a x))))
                 ≐ emb I F (bsV I F (ap g (emb+ I F a y)) (emb- I F (ap g (emb+ I F a y)) (h (emb+ I F a y))))
              lm = traV (emb-bsV I F (ap g (emb+ I F a x)) _) (traV lm2 (symV (emb-bsV I F (ap g (emb+ I F a y)) _)))
              main : To {I} {F} (eq-sV I F
                        (bsV I F (ap g (emb+ I F a x)) (emb- I F (ap g (emb+ I F a x)) (h (emb+ I F a x))))
                        (bsV I F (ap g (emb+ I F a y)) (emb- I F (ap g (emb+ I F a y)) (h (emb+ I F a y)))))
              main = emb-inj I F _ _ lm
-         in main 
+         in main
 
       )
 
 
-emb-pi-sV-half2 :  (I : Set) -> (F : I -> Set) 
+emb-pi-sV-half2 :  (I : Set) -> (F : I -> Set)
       -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
       -> emb I F (pi-sV I F a g) ≥ piV (emb I F a) (comp1 (embVV I F) g)
-emb-pi-sV-half2 I F (sup A f) g (h , hx) = 
- 
-  let lm2 : (x : To {I} {F} A) -> emb I F (pair-sV I F (bsV I F (sup A f) x) (bsV I F (ap g (emb+ I F (sup A f) x)) 
+emb-pi-sV-half2 I F (sup A f) g (h , hx) =
+
+  let lm2 : (x : To {I} {F} A) -> emb I F (pair-sV I F (bsV I F (sup A f) x) (bsV I F (ap g (emb+ I F (sup A f) x))
                                 (pj1 (emb-pi-sV-half2-ix I F (sup A f) g (h , hx)) x)))
-                  ≐ < (emb I F (sup A f)) ‣ x , 
+                  ≐ < (emb I F (sup A f)) ‣ x ,
                     (ap1 (comp1 (embVV I F) g) x) ‣ (h x)   >
-                   
-      lm2 = λ x -> traV (emb-pair I F _ _) 
-                        (pairV-ext (refV (emb I F (f x))) 
-                                   (traV (emb-bsV I F (ap g x) (emb- I F (ap g x) (h x))) 
-                                         (symV (>< (emb+- I F (ap g x) (h x))) ))) 
+
+      lm2 = λ x -> traV (emb-pair I F _ _)
+                        (pairV-ext (refV (emb I F (f x)))
+                                   (traV (emb-bsV I F (ap g x) (emb- I F (ap g x) (h x)))
+                                         (symV (>< (emb+- I F (ap g x) (h x))) )))
 
 
       lm : (emb I F (pi-sV I F (sup A f) g)) ‣ (emb-pi-sV-half2-ix I F (sup A f) g (h , hx))
            ≐ (piV (emb I F (sup A f)) (comp1 (embVV I F) g)) ‣ (h , hx)
       lm = easy-eqV (To {I} {F} A) _ _ lm2
-  in 
+  in
          (emb-pi-sV-half2-ix I F (sup A f) g (h , hx)) ,  lm
 
 
 
 
 
-emb-pi-sV :  (I : Set) -> (F : I -> Set) 
+emb-pi-sV :  (I : Set) -> (F : I -> Set)
       -> (a : sV I F) -> (g : setoidmap (κ (emb I F a)) (sVV I F))
       -> emb I F (pi-sV I F a g) ≐ piV (emb I F a) (comp1 (embVV I F) g)
-emb-pi-sV I F a g = pair (emb-pi-sV-half1 I F a g)  (emb-pi-sV-half2 I F a g) 
-
-
-
-
+emb-pi-sV I F a g = pair (emb-pi-sV-half1 I F a g)  (emb-pi-sV-half2 I F a g)
 

--- a/MLTT-and-setoids/iterative-sets-pt6.agda
+++ b/MLTT-and-setoids/iterative-sets-pt6.agda
@@ -34,7 +34,7 @@ open import iterative-sets-pt5
 reflect-set :  (I : Set) -> (F : I -> Set) -> (a : V) -> (a ∈ uV I F) -> sV I F
 reflect-set I F a p = pj1 (emb-surj-uV I F a p)
 
-reflect-set-prop :  (I : Set) -> (F : I -> Set) -> (a : V) -> (p : a ∈ uV I F) 
+reflect-set-prop :  (I : Set) -> (F : I -> Set) -> (a : V) -> (p : a ∈ uV I F)
                     -> emb I F (reflect-set I F a p) ≐ a
 reflect-set-prop I F a p = pj2 (emb-surj-uV I F a p)
 
@@ -44,43 +44,43 @@ reflect-set-map I F a p = κ-trp (reflect-set-prop I F a p)
 
 -- κ-trp : {a b : V} -> (p : a ≐ b) -> || κ a  => κ b ||
 
-reflect-family-op : (I : Set) -> (F : I -> Set) 
+reflect-family-op : (I : Set) -> (F : I -> Set)
             -> (a : sV I F) -> (g :  setoidmap1 (κ (emb I F a)) VV)
             -> ((x : || κ (emb I F a)||) -> ap1 g x ∈ uV I F)
             ->  || (κ (emb I F a)) || -> || sVV I F ||
 reflect-family-op I F a g p x = pj1 (p x)
 
 
-reflect-family :  (I : Set) -> (F : I -> Set) 
+reflect-family :  (I : Set) -> (F : I -> Set)
             -> (a : sV I F) -> (g :  setoidmap1 (κ (emb I F a)) VV)
             -> ((x : || κ (emb I F a)||) -> ap1 g x ∈ uV I F)
             ->  setoidmap (κ (emb I F a)) (sVV I F)
-reflect-family I F a g p = 
-  record { op = reflect-family-op I F a g p 
+reflect-family I F a g p =
+  record { op = reflect-family-op I F a g p
          ; ext = λ x y q → (
               let px = pj2 (p x)
                   py = pj2 (p y)
                   lm : emb I F (pj1 (p x))  ≐ emb I F (pj1 (p y))
                   lm = traV (symV px) (traV (>><< (extensionality1 g x y q)) py)
                   main : < sVV I F >  pj1 (p x) ~  pj1 (p y)
-                  main = <> (emb-inj I F _ _ lm) 
+                  main = <> (emb-inj I F _ _ lm)
                in main)
           }
 
-sigmaV-refl-code :  (I : Set) -> (F : I -> Set) 
-    -> (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (a ∈ uV I F) 
+sigmaV-refl-code :  (I : Set) -> (F : I -> Set)
+    -> (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (a ∈ uV I F)
     -> ((x : || κ a ||) -> ap1 g x ∈ uV I F)
     -> # (uV I F)
-sigmaV-refl-code I F a g p q = 
+sigmaV-refl-code I F a g p q =
      let  g' :  setoidmap1 (κ (emb I F (reflect-set I F a p))) VV
           g' = comp1 g (reflect-set-map I F a p)
           lm : ((x : || κ (emb I F (reflect-set I F a p))||) -> ap1 g' x ∈ uV I F)
           lm = λ x → (pj1 (q (ap (reflect-set-map I F a p) x))) ,
-                     (pj2 (q (ap (reflect-set-map I F a p) x))) 
+                     (pj2 (q (ap (reflect-set-map I F a p) x)))
           main : # (uV I F)
           main = sigma-sV I F (reflect-set I F a p) (reflect-family I F (reflect-set I F a p) g' lm)
-     in main 
+     in main
 
 -- emb-sigma-sV : (a : sV) -> (g : setoidmap (κ (emb a)) sVV)
 --      -> emb (sigma-sV a g) ≐ sigmaV (emb a) (comp1 embVV g)
@@ -92,28 +92,28 @@ sigmaV-refl-code I F a g p q =
 -- sigmaV-ext : (u v : ||| Par VV κ-Fam |||) -> << Par VV κ-Fam >> u ~ v -> << VV >>  sigmaV-op u ~ sigmaV-op v
 
 mk-Par-V-κ-Fam : (a : V) -> (g :  setoidmap1 (κ a) VV) ->  ||| Par VV κ-Fam |||
-mk-Par-V-κ-Fam a g = record { Ix = a ; 
+mk-Par-V-κ-Fam a g = record { Ix = a ;
                               Fx = g }
 
-mk-Par-V-κ-Fam-ext :  (a b : V) -> (p : a ≐ b) 
-    ->  (g :  setoidmap1 (κ a) VV) ->  (h :  setoidmap1 (κ b) VV) 
-    -> << setoidmaps1 (κ a) VV >> g  ~ comp1 h (κ-trp p)             
+mk-Par-V-κ-Fam-ext :  (a b : V) -> (p : a ≐ b)
+    ->  (g :  setoidmap1 (κ a) VV) ->  (h :  setoidmap1 (κ b) VV)
+    -> << setoidmaps1 (κ a) VV >> g  ~ comp1 h (κ-trp p)
     ->   << Par VV κ-Fam >> (mk-Par-V-κ-Fam a g)  ~ (mk-Par-V-κ-Fam b h)
 mk-Par-V-κ-Fam-ext a b p g h r = <<>> ((<<>> p) , (λ t → <<>> (traV (>><< (>><< r t)) (refV _))))
 
 
-mk-Par-V-κ-Fam-sigmaV : (a : V) -> (g :  setoidmap1 (κ a) VV) 
+mk-Par-V-κ-Fam-sigmaV : (a : V) -> (g :  setoidmap1 (κ a) VV)
             -> sigmaV-op (mk-Par-V-κ-Fam a g) ≐  sigmaV a g
 mk-Par-V-κ-Fam-sigmaV a g = refV _
 
 
-sigmaV-ext2 :  (a b : V) -> (p : a ≐ b) 
-    ->  (g :  setoidmap1 (κ a) VV) ->  (h :  setoidmap1 (κ b) VV) 
+sigmaV-ext2 :  (a b : V) -> (p : a ≐ b)
+    ->  (g :  setoidmap1 (κ a) VV) ->  (h :  setoidmap1 (κ b) VV)
     -> << setoidmaps1 (κ a) VV >> g  ~ comp1 h (κ-trp p)
     ->  sigmaV a g ≐  sigmaV b h
-sigmaV-ext2 a b p g h q = 
-    >><< (sigmaV-ext (mk-Par-V-κ-Fam a g) (mk-Par-V-κ-Fam b h) 
-                     (mk-Par-V-κ-Fam-ext a b p g h q))    
+sigmaV-ext2 a b p g h q =
+    >><< (sigmaV-ext (mk-Par-V-κ-Fam a g) (mk-Par-V-κ-Fam b h)
+                     (mk-Par-V-κ-Fam-ext a b p g h q))
 
 
 -- κ-trp-irr : {a b : V} -> (p q : a ≐ b) ->  (x : || κ a ||)
@@ -128,14 +128,14 @@ e+irr {a} {b} p q x = (traV (symV (e+prop p x)) (e+prop q x))
 
 
 
-g-lm2 :  (I : Set) -> (F : I -> Set) 
-    -> (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (p : a ∈ uV I F) 
+g-lm2 :  (I : Set) -> (F : I -> Set)
+    -> (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (p : a ∈ uV I F)
     -> (q : (x : || κ a ||) -> ap1 g x ∈ uV I F)
     -> (x : || κ (emb I F (reflect-set I F a p)) ||)
     -> emb I F (pj1 (q (ap (κ-trp (reflect-set-prop I F a p)) x))) ≐
         ap1 g (ap (κ-trp (reflect-set-prop I F a p)) x)
-g-lm2 I F a g p q x = 
+g-lm2 I F a g p q x =
    let  lmq1 = pj1 (q (ap (κ-trp (reflect-set-prop I F a p)) x))
         lmq2 = pj2 (q (ap (κ-trp (reflect-set-prop I F a p)) x))
         main : emb I F (pj1 (q (ap (κ-trp (reflect-set-prop I F a p)) x))) ≐
@@ -147,9 +147,9 @@ g-lm2 I F a g p q x =
 
 -- reflect-set-map a p = κ-trp (reflect-set-prop a p)
 
-g-lm :  (I : Set) -> (F : I -> Set) 
-    -> (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (p : a ∈ uV I F) 
+g-lm :  (I : Set) -> (F : I -> Set)
+    -> (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (p : a ∈ uV I F)
     -> (q : (x : || κ a ||) -> ap1 g x ∈ uV I F)
     -> (x : || κ (emb I F (reflect-set I F a p)) ||)
     ->
@@ -161,7 +161,7 @@ g-lm :  (I : Set) -> (F : I -> Set)
            pj2 (q (ap (reflect-set-map I F a p) x₁))))
        x)
       ≐ ap1 g (ap (κ-trp (reflect-set-prop I F a p)) x)
-g-lm I F a g p q x = 
+g-lm I F a g p q x =
    let lm : emb  I F (pj1 (q (ap (reflect-set-map I F a p) x)))
             ≐ ap1 g (ap (κ-trp (reflect-set-prop I F a p)) x)
        lm = g-lm2 I F a g p q x
@@ -180,30 +180,30 @@ g-lm I F a g p q x =
 
 -- reflect-family-op a g p x = pj1 (p x)
 
-emb-sigma-refl-code :  (I : Set) -> (F : I -> Set) 
-    -> (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (p : a ∈ uV I F) 
+emb-sigma-refl-code :  (I : Set) -> (F : I -> Set)
+    -> (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (p : a ∈ uV I F)
     -> (q : (x : || κ a ||) -> ap1 g x ∈ uV I F)
     -> sigmaV a g ≐ emb I F (sigmaV-refl-code I F a g p q)
-emb-sigma-refl-code I F a g p q = 
+emb-sigma-refl-code I F a g p q =
    let  g' :  setoidmap1 (κ (emb I F (reflect-set I F a p))) VV
         g' = comp1 g (reflect-set-map I F a p)
         lm : ((x : || κ (emb I F (reflect-set I F a p))||) -> ap1 g' x ∈ uV I F)
         lm = λ x → (pj1 (q (ap (reflect-set-map I F a p) x))) ,
-                     (pj2 (q (ap (reflect-set-map I F a p) x)))  
-        lm2 : emb I F (sigma-sV I F (reflect-set I F a p) (reflect-family I F (reflect-set I F a p) g' lm)) 
-               ≐ 
-              sigmaV (emb I F (reflect-set I F a p)) 
+                     (pj2 (q (ap (reflect-set-map I F a p) x)))
+        lm2 : emb I F (sigma-sV I F (reflect-set I F a p) (reflect-family I F (reflect-set I F a p) g' lm))
+               ≐
+              sigmaV (emb I F (reflect-set I F a p))
                      (comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm))
         lm2 = emb-sigma-sV I F (reflect-set I F a p) (reflect-family I F (reflect-set I F a p) g' lm)
 
-        geq : << setoidmaps1 (κ (emb I F (reflect-set I F a p))) VV >> 
-               (comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm)) ~ 
+        geq : << setoidmaps1 (κ (emb I F (reflect-set I F a p))) VV >>
+               (comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm)) ~
                 comp1 g (κ-trp (reflect-set-prop I F a p))
         geq = <<>> (λ x → <<>>  (
-                                let  
-                                    lm :   emb I F (ap 
-                                              (reflect-family I F (reflect-set I F a p) 
+                                let
+                                    lm :   emb I F (ap
+                                              (reflect-family I F (reflect-set I F a p)
                                                              (comp1 g (reflect-set-map I F a p))
                                                (λ x₁ →
                                                   pj1 (q (ap (reflect-set-map I F a p) x₁)) ,
@@ -213,7 +213,7 @@ emb-sigma-refl-code I F a g p q =
                                     lm = g-lm I F a g p q x
 
                                     main :   (comp1 (embVV I F)
-                                              (reflect-family I F (reflect-set I F a p) 
+                                              (reflect-family I F (reflect-set I F a p)
                                                           (comp1 g (reflect-set-map I F a p))
                                                (λ x₁ →
                                                   pj1 (q (ap (reflect-set-map I F a p) x₁)) ,
@@ -224,40 +224,40 @@ emb-sigma-refl-code I F a g p q =
                                 in main
                                  )
                    )
-        lm3 : sigmaV a g 
-                 ≐ 
-              sigmaV (emb I F (reflect-set I F a p)) 
+        lm3 : sigmaV a g
+                 ≐
+              sigmaV (emb I F (reflect-set I F a p))
                      (comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm))
-        lm3 = symV (sigmaV-ext2 (emb I F (reflect-set I F a p)) a (reflect-set-prop I F a p) 
-                  ((comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm))) g geq ) 
+        lm3 = symV (sigmaV-ext2 (emb I F (reflect-set I F a p)) a (reflect-set-prop I F a p)
+                  ((comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm))) g geq )
         main :  sigmaV a g ≐ emb I F (sigmaV-refl-code I F a g p q)
         main =  traV lm3 (symV lm2)
-   in main 
+   in main
 
 
 
-sigmaV-reflection :  (I : Set) -> (F : I -> Set) 
-    -> (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (a ∈ uV I F) 
+sigmaV-reflection :  (I : Set) -> (F : I -> Set)
+    -> (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (a ∈ uV I F)
     -> ((x : || κ a ||) -> ap1 g x ∈ uV I F)
     -> sigmaV a g ∈ uV I F
-sigmaV-reflection I F a g p q = 
+sigmaV-reflection I F a g p q =
          sigmaV-refl-code I F a g p q , emb-sigma-refl-code I F a g p q
 
 
 
 
-piV-refl-code :  (I : Set) -> (F : I -> Set) 
-    -> (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (a ∈ uV I F) 
+piV-refl-code :  (I : Set) -> (F : I -> Set)
+    -> (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (a ∈ uV I F)
     -> ((x : || κ a ||) -> ap1 g x ∈ uV I F)
     -> # (uV I F)
-piV-refl-code I F a g p q = 
+piV-refl-code I F a g p q =
      let  g' :  setoidmap1 (κ (emb I F (reflect-set I F a p))) VV
           g' = comp1 g (reflect-set-map I F a p)
           lm : ((x : || κ (emb I F (reflect-set I F a p))||) -> ap1 g' x ∈ uV I F)
           lm = λ x → (pj1 (q (ap (reflect-set-map I F a p) x))) ,
-                     (pj2 (q (ap (reflect-set-map I F a p) x))) 
+                     (pj2 (q (ap (reflect-set-map I F a p) x)))
           main : # (uV I F)
           main = pi-sV I F (reflect-set I F a p) (reflect-family I F (reflect-set I F a p) g' lm)
      in main
@@ -265,39 +265,39 @@ piV-refl-code I F a g p q =
 
 
 
-piV-ext2 : (a b : V) -> (p : a ≐ b) 
-    ->  (g :  setoidmap1 (κ a) VV) ->  (h :  setoidmap1 (κ b) VV) 
+piV-ext2 : (a b : V) -> (p : a ≐ b)
+    ->  (g :  setoidmap1 (κ a) VV) ->  (h :  setoidmap1 (κ b) VV)
     -> << setoidmaps1 (κ a) VV >> g  ~ comp1 h (κ-trp p)
     ->  piV a g ≐  piV b h
-piV-ext2 a b p g h q = 
-    >><< (piV-ext (mk-Par-V-κ-Fam a g) (mk-Par-V-κ-Fam b h) 
-                     (mk-Par-V-κ-Fam-ext a b p g h q))    
+piV-ext2 a b p g h q =
+    >><< (piV-ext (mk-Par-V-κ-Fam a g) (mk-Par-V-κ-Fam b h)
+                     (mk-Par-V-κ-Fam-ext a b p g h q))
 
 
 
-emb-pi-refl-code :  (I : Set) -> (F : I -> Set) 
-    -> (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (p : a ∈ uV I F) 
+emb-pi-refl-code :  (I : Set) -> (F : I -> Set)
+    -> (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (p : a ∈ uV I F)
     -> (q : (x : || κ a ||) -> ap1 g x ∈ uV I F)
     -> piV a g ≐ emb I F (piV-refl-code I F a g p q)
-emb-pi-refl-code I F a g p q = 
+emb-pi-refl-code I F a g p q =
    let  g' :  setoidmap1 (κ (emb I F (reflect-set I F a p))) VV
         g' = comp1 g (reflect-set-map I F a p)
         lm : ((x : || κ (emb I F (reflect-set I F a p))||) -> ap1 g' x ∈ uV I F)
         lm = λ x → (pj1 (q (ap (reflect-set-map I F a p) x))) ,
-                     (pj2 (q (ap (reflect-set-map I F a p) x)))  
-        lm2 : emb I F (pi-sV I F (reflect-set I F a p) (reflect-family I F (reflect-set I F a p) g' lm)) 
-               ≐ 
+                     (pj2 (q (ap (reflect-set-map I F a p) x)))
+        lm2 : emb I F (pi-sV I F (reflect-set I F a p) (reflect-family I F (reflect-set I F a p) g' lm))
+               ≐
               piV (emb I F (reflect-set I F a p)) (comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm))
         lm2 = emb-pi-sV I F (reflect-set I F a p) (reflect-family I F (reflect-set I F a p) g' lm)
 
-        geq : << setoidmaps1 (κ (emb I F (reflect-set I F a p))) VV >> 
-               (comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm)) ~ 
+        geq : << setoidmaps1 (κ (emb I F (reflect-set I F a p))) VV >>
+               (comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm)) ~
                 comp1 g (κ-trp (reflect-set-prop I F a p))
         geq = <<>> (λ x → <<>>  (
-                                let  
-                                    lm :   emb I F (ap 
-                                              (reflect-family I F (reflect-set I F a p) 
+                                let
+                                    lm :   emb I F (ap
+                                              (reflect-family I F (reflect-set I F a p)
                                                               (comp1 g (reflect-set-map I F a p))
                                                (λ x₁ →
                                                   pj1 (q (ap (reflect-set-map I F a p) x₁)) ,
@@ -307,7 +307,7 @@ emb-pi-refl-code I F a g p q =
                                     lm = g-lm I F a g p q x
 
                                     main :   (comp1 (embVV I F)
-                                              (reflect-family I F (reflect-set I F a p) 
+                                              (reflect-family I F (reflect-set I F a p)
                                                                (comp1 g (reflect-set-map I F a p))
                                                (λ x₁ →
                                                   pj1 (q (ap (reflect-set-map I F a p) x₁)) ,
@@ -318,21 +318,21 @@ emb-pi-refl-code I F a g p q =
                                 in main
                                  )
                    )
-        lm3 : piV a g 
-                 ≐ 
-              piV (emb I F (reflect-set I F a p)) 
+        lm3 : piV a g
+                 ≐
+              piV (emb I F (reflect-set I F a p))
                   (comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm))
-        lm3 = symV (piV-ext2 (emb I F (reflect-set I F a p)) a (reflect-set-prop I F a p) 
-                  ((comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm))) g geq ) 
+        lm3 = symV (piV-ext2 (emb I F (reflect-set I F a p)) a (reflect-set-prop I F a p)
+                  ((comp1 (embVV I F) (reflect-family I F (reflect-set I F a p) g' lm))) g geq )
         main :  piV a g ≐ emb I F (piV-refl-code I F a g p q)
         main =  traV lm3 (symV lm2)
-   in main 
+   in main
 
 
 
-piV-reflection :  (I : Set) -> (F : I -> Set) 
-    -> (a : V) -> (g :  setoidmap1 (κ a) VV) 
-    -> (a ∈ uV I F) 
+piV-reflection :  (I : Set) -> (F : I -> Set)
+    -> (a : V) -> (g :  setoidmap1 (κ a) VV)
+    -> (a ∈ uV I F)
     -> ((x : || κ a ||) -> ap1 g x ∈ uV I F)
     -> piV a g ∈ uV I F
 piV-reflection I F a g p q = piV-refl-code I F a g p q , emb-pi-refl-code I F a g p q
@@ -347,38 +347,38 @@ idV a x y = sup (a ‣ x ≐ a ‣ y) (\u -> a ‣ x)
 
 
 
-id-sV :  (I : Set) -> (F : I -> Set) 
+id-sV :  (I : Set) -> (F : I -> Set)
     -> (a : sV I F) -> (x y : || κ (emb I F a) ||) -> sV I F
-id-sV I F a x y = sup (eq-sV I F (bsV I F a (emb- I F a x)) (bsV I F a (emb- I F a y))) 
-                   (\u ->  (bsV I F a (emb- I F a x))) 
+id-sV I F a x y = sup (eq-sV I F (bsV I F a (emb- I F a x)) (bsV I F a (emb- I F a y)))
+                   (\u ->  (bsV I F a (emb- I F a x)))
 
-emb-idV :  (I : Set) -> (F : I -> Set) 
-    -> (a : sV I F) -> (x y : || κ (emb I F a) ||) 
+emb-idV :  (I : Set) -> (F : I -> Set)
+    -> (a : sV I F) -> (x y : || κ (emb I F a) ||)
      -> emb I F (id-sV I F a x y) ≐ idV (emb I F a) x y
-emb-idV I F (sup A f) x y = 
-    let main : sup (To {I} {F} (eq-sV I F (f x) (f y))) (λ x₁ → emb I F (f x)) 
+emb-idV I F (sup A f) x y =
+    let main : sup (To {I} {F} (eq-sV I F (f x) (f y))) (λ x₁ → emb I F (f x))
                 ≐ sup (emb I F (f x) ≐ emb I F (f y)) (\u -> emb I F (f x))
-        main = pair (λ p → (emb-ext I F (f x) (f y) p) , (refV _)) 
+        main = pair (λ p → (emb-ext I F (f x) (f y) p) , (refV _))
                     (λ p → (emb-inj I F (f x) (f y) p) , (refV _))
     in main
 
 
 
 
-idV-reflection-lm0 :  (I : Set) -> (F : I -> Set) 
-           -> (a : V) -> (x : || κ a ||) 
+idV-reflection-lm0 :  (I : Set) -> (F : I -> Set)
+           -> (a : V) -> (x : || κ a ||)
            -> (p : a ∈ uV I F)
            -> a ‣ x ≐ emb I F (bsV I F (pj1 p) (emb- I F (pj1 p) (κ-trp-op (pj2 p) x)))
 idV-reflection-lm0 I F a x p =
   let lm :  a ‣ x ≐ (emb I F (pj1 p)) ‣ (κ-trp-op (pj2 p) x)
       lm = e+prop (pj2 p) x
-  in  symV (traV (emb-bsV I F (pj1 p) (emb- I F (pj1 p) (κ-trp-op (pj2 p) x))) 
+  in  symV (traV (emb-bsV I F (pj1 p) (emb- I F (pj1 p) (κ-trp-op (pj2 p) x)))
                          (symV (traV lm (>< (emb+- I F (pj1 p) (κ-trp-op (pj2 p) x))))))
 
 
 
-idV-reflection-lm1 :  (I : Set) -> (F : I -> Set) 
-           -> (a : V) -> (x y : || κ a ||) 
+idV-reflection-lm1 :  (I : Set) -> (F : I -> Set)
+           -> (a : V) -> (x y : || κ a ||)
            -> (p : a ∈ uV I F)
            -> a ‣ x ≐ a ‣ y
            ->  To {I} {F} (eq-sV I F (bsV I F (pj1 p) (emb- I F (pj1 p) (κ-trp-op (pj2 p) x)))
@@ -390,23 +390,23 @@ idV-reflection-lm1 I F a x y p q = emb-inj I F (bsV I F (pj1 p) (emb- I F (pj1 p
 
 
 
-idV-reflection-lm2 :  (I : Set) -> (F : I -> Set) 
-           -> (a : V) -> (x y : || κ a ||) 
+idV-reflection-lm2 :  (I : Set) -> (F : I -> Set)
+           -> (a : V) -> (x y : || κ a ||)
            -> (p : a ∈ uV I F)
            ->  To {I} {F} (eq-sV I F (bsV I F (pj1 p) (emb- I F (pj1 p) (κ-trp-op (pj2 p) x)))
                         (bsV I F (pj1 p) (emb- I F (pj1 p) (κ-trp-op (pj2 p) y))))
            -> a ‣ x ≐ a ‣ y
-idV-reflection-lm2 I F a x y p q = traV (idV-reflection-lm0 I F a x p) 
-                                        (traV (emb-ext I F _ _ q) (symV (idV-reflection-lm0 I F a y p))) 
+idV-reflection-lm2 I F a x y p q = traV (idV-reflection-lm0 I F a x p)
+                                        (traV (emb-ext I F _ _ q) (symV (idV-reflection-lm0 I F a y p)))
 
 
-idV-reflection :   (I : Set) -> (F : I -> Set) 
-           -> (a : V) -> (x y : || κ a ||) 
+idV-reflection :   (I : Set) -> (F : I -> Set)
+           -> (a : V) -> (x y : || κ a ||)
            -> (a ∈ uV I F)
            -> idV a x y ∈ uV I F
 idV-reflection I F a x y p =
      (id-sV I F (pj1 p)  (κ-trp-op (pj2 p) x) (κ-trp-op (pj2 p) y)) ,
-              pair (λ q → idV-reflection-lm1 I F a x y p q , idV-reflection-lm0 I F a x p) 
+              pair (λ q → idV-reflection-lm1 I F a x y p q , idV-reflection-lm0 I F a x p)
                    (λ q → idV-reflection-lm2 I F a x y p q , idV-reflection-lm0 I F a x p)
 
 
@@ -414,19 +414,19 @@ idV-reflection I F a x y p =
 -- empty set
 
 
-zeroV-reflection :  (I : Set) -> (F : I -> Set) 
+zeroV-reflection :  (I : Set) -> (F : I -> Set)
                  -> zeroV ∈ uV I F
 zeroV-reflection I F = zeroV-in-uV I F
 
 -- unit set
 
-oneV-refl-lm :  (I : Set) -> (F : I -> Set) 
+oneV-refl-lm :  (I : Set) -> (F : I -> Set)
     -> (x : N₁) ->  (br-singV zeroV x)  ≐ (emb I F (br-sing-sV I F (zero-sV I F) x))
 oneV-refl-lm  I F 0₁ = easy-eqV N₀ _ _ (λ x → exfalso _ x)
 
-oneV-reflection :  (I : Set) -> (F : I -> Set) 
+oneV-reflection :  (I : Set) -> (F : I -> Set)
               -> oneV ∈ uV I F
-oneV-reflection I F = (succ-sV I F (zero-sV I F) , 
+oneV-reflection I F = (succ-sV I F (zero-sV I F) ,
                   (pair (λ x → x , oneV-refl-lm I F x)
                         (λ y → y , oneV-refl-lm I F y)))
 
@@ -439,54 +439,54 @@ oneV-reflection I F = (succ-sV I F (zero-sV I F) ,
 bV-sumV : (a b : V) -> (# a + #  b) -> V
 bV-sumV a b (inl x) = < zeroV ,  a ‣ x >
 bV-sumV a b (inr y) = < oneV , b ‣ y >
- 
+
 -- make disjoint by pairing with zeroV and oneV
 
 sumV : (a b : V) -> V
 sumV a b = sup (# a + # b) (bV-sumV a b)
 
 
-inl-ext :  (a b : V) -> (x y : # a) 
+inl-ext :  (a b : V) -> (x y : # a)
          ->  a ‣ x ≐  a ‣ y
-         ->  (sumV a b) ‣ inl x ≐  (sumV a b) ‣ inl y 
+         ->  (sumV a b) ‣ inl x ≐  (sumV a b) ‣ inl y
 inl-ext a b x y p = pairV-ext (refV _) p
 
-inl-ext-gen :  (a b  a' b' : V) -> (x : # a) -> (y : # a') 
+inl-ext-gen :  (a b  a' b' : V) -> (x : # a) -> (y : # a')
          ->  a ‣ x ≐  a' ‣ y
-         ->  (sumV a b) ‣ inl x ≐  (sumV a' b') ‣ inl y 
-inl-ext-gen a b a' b' x y p = pairV-ext (refV _) p 
+         ->  (sumV a b) ‣ inl x ≐  (sumV a' b') ‣ inl y
+inl-ext-gen a b a' b' x y p = pairV-ext (refV _) p
 
-inl-inj :  (a b : V) -> (x y : # a) 
-         ->  (sumV a b) ‣ inl x ≐  (sumV a b) ‣ inl y 
+inl-inj :  (a b : V) -> (x y : # a)
+         ->  (sumV a b) ‣ inl x ≐  (sumV a b) ‣ inl y
          ->  a ‣ x ≐  a ‣ y
-inl-inj a b x y p = 
+inl-inj a b x y p =
     let lm = pairV-inv-1 p
     in prj2 lm
 
-inl-inj-gen :  (a b a' b' : V) -> (x : # a) -> (y : # a') 
-         ->  (sumV a b) ‣ inl x ≐  (sumV a' b') ‣ inl y 
+inl-inj-gen :  (a b a' b' : V) -> (x : # a) -> (y : # a')
+         ->  (sumV a b) ‣ inl x ≐  (sumV a' b') ‣ inl y
          ->  a ‣ x ≐  a' ‣ y
-inl-inj-gen a b a' b' x y p = 
+inl-inj-gen a b a' b' x y p =
     let lm = pairV-inv-1 p
     in prj2 lm
 
 
-inr-ext-gen :  (a b a' b' : V) -> (x : # b) -> (y : # b') 
+inr-ext-gen :  (a b a' b' : V) -> (x : # b) -> (y : # b')
          ->  b ‣ x ≐  b' ‣ y
-         ->  (sumV a b) ‣ inr x ≐  (sumV a' b') ‣ inr y 
+         ->  (sumV a b) ‣ inr x ≐  (sumV a' b') ‣ inr y
 inr-ext-gen a b a' b' x y p = pairV-ext (refV _) p
 
-inr-inj :  (a b : V) -> (x y : # b) 
-         ->  (sumV a b) ‣ inr x ≐  (sumV a b) ‣ inr y 
+inr-inj :  (a b : V) -> (x y : # b)
+         ->  (sumV a b) ‣ inr x ≐  (sumV a b) ‣ inr y
          ->  b ‣ x ≐  b ‣ y
-inr-inj a b x y p = 
+inr-inj a b x y p =
     let lm = pairV-inv-1 p
     in prj2 lm
 
-inr-inj-gen :  (a b a' b' : V) -> (x : # b) -> (y : # b') 
-         ->  (sumV a b) ‣ inr x ≐  (sumV a' b') ‣ inr y 
+inr-inj-gen :  (a b a' b' : V) -> (x : # b) -> (y : # b')
+         ->  (sumV a b) ‣ inr x ≐  (sumV a' b') ‣ inr y
          ->  b ‣ x ≐  b' ‣ y
-inr-inj-gen a b a' b' x y p = 
+inr-inj-gen a b a' b' x y p =
     let lm = pairV-inv-1 p
     in prj2 lm
 
@@ -497,29 +497,29 @@ inr-inj-gen a b a' b' x y p =
 --    -> succV x ≐ zeroV -> N₀
 
 
-inl-inr-dis :  (a b a' b' : V) -> (x : # a) -> (y : # b') 
+inl-inr-dis :  (a b a' b' : V) -> (x : # a) -> (y : # b')
          -> not ((sumV a b) ‣ inl x ≐  (sumV a' b') ‣ inr y)
-inl-inr-dis a b a' b' x y p = 
+inl-inr-dis a b a' b' x y p =
    let lm = prj1 (pairV-inv-1 p)
-   in Peano4 zeroV (symV lm) 
+   in Peano4 zeroV (symV lm)
 
 
-inr-inl-dis :  (a b a' b' : V) -> (x : # a') -> (y : # b) 
+inr-inl-dis :  (a b a' b' : V) -> (x : # a') -> (y : # b)
          -> not ((sumV a b) ‣ inr y ≐  (sumV a' b') ‣ inl x)
-inr-inl-dis a b a' b' x y p = 
+inr-inl-dis a b a' b' x y p =
   let lm = prj1 (pairV-inv-1 p)
   in Peano4 zeroV lm
 
 
 sumV-ext-half1  : (a b a' b' : V) -> a ≐ a' -> b ≐ b' -> sumV a b ≤ sumV a' b'
-sumV-ext-half1 a b a' b' p q (inl x) = 
+sumV-ext-half1 a b a' b' p q (inl x) =
   let lm2 : a ‣ x ≐ a' ‣ (e+ p x)
       lm2 = e+prop p x
       lm : sumV a b ‣ inl x ≐ sumV a' b' ‣ inl (e+ p x)
       lm = inl-ext-gen a b a' b' _ _ lm2
   in (inl (e+ p x)) , lm
- 
-sumV-ext-half1 a b a' b' p q (inr y) = 
+
+sumV-ext-half1 a b a' b' p q (inr y) =
   let lm2 : b ‣ y ≐ b' ‣ (e+ q y)
       lm2 = e+prop q y
       lm : sumV a b ‣ inr y ≐ sumV a' b' ‣ inr (e+ q y)
@@ -532,8 +532,8 @@ sumV-ext-half1 a b a' b' p q (inr y) =
 ≤-to-≥ u v p x = (pj1 (p x)) , (symV (pj2 (p x)))
 
 sumV-ext-half2  : (a b a' b' : V) -> a ≐ a' -> b ≐ b' -> sumV a b ≥ sumV a' b'
-sumV-ext-half2 a b a' b' p q = ≤-to-≥ (sumV a' b') (sumV a b) (sumV-ext-half1 a' b' a b (symV p) (symV q)) 
-  
+sumV-ext-half2 a b a' b' p q = ≤-to-≥ (sumV a' b') (sumV a b) (sumV-ext-half1 a' b' a b (symV p) (symV q))
+
 sumV-ext : (a b a' b' : V) -> a ≐ a' -> b ≐ b' -> sumV a b ≐ sumV a' b'
 sumV-ext a b a' b' p q = pair (sumV-ext-half1 a b a' b' p q) (sumV-ext-half2 a b a' b' p q)
 
@@ -542,22 +542,22 @@ sumV-ext a b a' b' p q = pair (sumV-ext-half1 a b a' b' p q) (sumV-ext-half2 a b
 -- zero-sV : sV
 -- zero-sV = ssup n₀ br-zero-sV
 
-one-sV :  (I : Set) -> (F : I -> Set) 
+one-sV :  (I : Set) -> (F : I -> Set)
            -> sV I F
 one-sV I F = succ-sV I F (zero-sV I F)
 
-emb0 : (I : Set) -> (F : I -> Set) 
+emb0 : (I : Set) -> (F : I -> Set)
        -> emb I F (zero-sV I F) ≐ zeroV
 emb0 I F = emb-zero I F
 
-emb1 :  (I : Set) -> (F : I -> Set) 
+emb1 :  (I : Set) -> (F : I -> Set)
        -> emb I F (one-sV I F) ≐ oneV
 emb1 I F =  traV (emb-succ I F (zero-sV I F)) (succV-ext _ _ (emb0 I F))
 
 
 
 
-bsV-sum-sV : (I : Set) -> (F : I -> Set) 
+bsV-sum-sV : (I : Set) -> (F : I -> Set)
            -> (a b : sV I F) -> To {I} {F} ((isV I F a) ⊕ (isV I F b)) -> sV I F
 bsV-sum-sV I F a b (inl x) = pair-sV I F (zero-sV I F) (bsV I F a x)
 bsV-sum-sV I F a b (inr y) = pair-sV I F (one-sV I F) (bsV I F b y)
@@ -567,7 +567,7 @@ bsV-sum-sV I F a b (inr y) = pair-sV I F (one-sV I F) (bsV I F b y)
 -- bV-sumV a b (inl x) = < zeroV ,  a ‣ x >
 -- bV-sumV a b (inr y) = < oneV , b ‣ y >
 
-sum-sV : (I : Set) -> (F : I -> Set) 
+sum-sV : (I : Set) -> (F : I -> Set)
            -> (a b : sV I F) -> sV I F
 sum-sV I F a b = sup ((isV I F a) ⊕ (isV I F b)) (bsV-sum-sV I F a b)
 
@@ -575,12 +575,12 @@ sum-sV I F a b = sup ((isV I F a) ⊕ (isV I F b)) (bsV-sum-sV I F a b)
 
 
 
-emb-sum-lm1 :  (I : Set) -> (F : I -> Set) 
+emb-sum-lm1 :  (I : Set) -> (F : I -> Set)
            -> (a b : sV I F) -> To {I} {F} (isV I F a) + To {I} {F} (isV I F b) -> # (emb I F a) + # (emb I F b)
 emb-sum-lm1 I F a b (inl x) = inl (emb+ I F a x)
 emb-sum-lm1 I F a b (inr y) = inr (emb+ I F b y)
 
-emb-sum-lm1-eq :  (I : Set) -> (F : I -> Set) 
+emb-sum-lm1-eq :  (I : Set) -> (F : I -> Set)
            -> (a b : sV I F) -> (x : To {I} {F} (isV I F a) + To {I} {F} (isV I F b)) ->
              (emb I F (bsV-sum-sV I F a b x)) ≐  (bV-sumV (emb I F a) (emb I F b) (emb-sum-lm1 I F a b x))
 emb-sum-lm1-eq I F a b (inl x) = traV (emb-pair I F _ _) (pairV-ext (emb0 I F) (emb-bsV I F a x)) -- emb-bsV a x
@@ -591,27 +591,27 @@ emb-sum-lm1-eq I F a b (inr y) = traV (emb-pair I F _ _) (pairV-ext (emb1 I F) (
 
 
 
-emb-sum-lm2 :   (I : Set) -> (F : I -> Set) 
+emb-sum-lm2 :   (I : Set) -> (F : I -> Set)
            -> (a b : sV I F)  -> # (emb I F a) + # (emb I F b) -> To {I} {F} (isV I F a) + To {I} {F}(isV I F b)
 emb-sum-lm2 I F a b (inl x) = inl (emb- I F a x)
 emb-sum-lm2 I F a b (inr y) = inr (emb- I F b y)
 
-emb-sum-lm2-eq :   (I : Set) -> (F : I -> Set) 
+emb-sum-lm2-eq :   (I : Set) -> (F : I -> Set)
            -> (a b : sV I F) -> (y : # (emb I F a) + # (emb I F b)) ->
     (emb I F (bsV-sum-sV I F a b (emb-sum-lm2 I F a b y))) ≐ (bV-sumV (emb I F a) (emb I F b) y)
-emb-sum-lm2-eq I F a b (inl x) = 
-        traV (emb-pair I F _ _) 
+emb-sum-lm2-eq I F a b (inl x) =
+        traV (emb-pair I F _ _)
              (pairV-ext (emb0 I F) (traV (emb-bsV I F a (emb- I F a x)) (symV (>< (emb+- I F a x)))))
 emb-sum-lm2-eq I F a b (inr y) =
-        traV (emb-pair I F _ _) 
+        traV (emb-pair I F _ _)
              (pairV-ext (emb1 I F) (traV (emb-bsV I F b (emb- I F b y)) (symV (>< (emb+- I F b y)))))
 
 
 
-emb-sum :  (I : Set) -> (F : I -> Set) 
+emb-sum :  (I : Set) -> (F : I -> Set)
            -> (a b : sV I F) ->
      emb I F (sum-sV I F a b) ≐ sumV (emb I F a) (emb I F b)
-emb-sum I F a b = pair (λ x → (emb-sum-lm1 I F a b x) , emb-sum-lm1-eq I F a b x) 
+emb-sum I F a b = pair (λ x → (emb-sum-lm1 I F a b x) , emb-sum-lm1-eq I F a b x)
                        (λ y → (emb-sum-lm2 I F a b y) , emb-sum-lm2-eq I F a b y)
 
 
@@ -623,40 +623,40 @@ sum-map {A} {B} {C} {D} f g (inr y) = inr (g y)
 
 
 
-sumV-refl-lm1 :  (I : Set) -> (F : I -> Set) 
-              -> (a  b : V) 
+sumV-refl-lm1 :  (I : Set) -> (F : I -> Set)
+              -> (a  b : V)
               -> (p : a ∈ uV I F) -> (q : b ∈ uV I F)
               -> (u : # (emb I F (pj1 p)) + # (emb I F (pj1 q)))
               -> (bV-sumV (emb I F (pj1 p)) (emb I F (pj1 q)) u) ≐
-                 (bV-sumV a b (sum-map (e+ (symV (pj2 p))) (e+ (symV (pj2 q))) u)) 
-sumV-refl-lm1 I F a b p q (inl x) = pairV-ext (refV _) (e+prop (symV (pj2 p)) x) 
-sumV-refl-lm1 I F a b p q (inr y) = pairV-ext (refV _) (e+prop (symV (pj2 q)) y) 
+                 (bV-sumV a b (sum-map (e+ (symV (pj2 p))) (e+ (symV (pj2 q))) u))
+sumV-refl-lm1 I F a b p q (inl x) = pairV-ext (refV _) (e+prop (symV (pj2 p)) x)
+sumV-refl-lm1 I F a b p q (inr y) = pairV-ext (refV _) (e+prop (symV (pj2 q)) y)
 
 
 
-sumV-refl-lm2 :  (I : Set) -> (F : I -> Set) 
-              -> (a  b : V) 
+sumV-refl-lm2 :  (I : Set) -> (F : I -> Set)
+              -> (a  b : V)
               -> (p : a ∈ uV I F) -> (q : b ∈ uV I F)
               -> (v : # a + # b)
               ->  (bV-sumV (emb I F (pj1 p)) (emb I F (pj1 q))
                            (sum-map (e+ (pj2 p)) (e+ (pj2 q)) v))
                   ≐  (bV-sumV a b v)
-sumV-refl-lm2 I F a b p q (inl x) = pairV-ext (refV _) (symV (e+prop (pj2 p) x)) 
-sumV-refl-lm2 I F a b p q (inr y) = pairV-ext (refV _) (symV (e+prop (pj2 q) y)) 
+sumV-refl-lm2 I F a b p q (inl x) = pairV-ext (refV _) (symV (e+prop (pj2 p) x))
+sumV-refl-lm2 I F a b p q (inr y) = pairV-ext (refV _) (symV (e+prop (pj2 q) y))
 
 
 
-sumV-reflection :  (I : Set) -> (F : I -> Set) 
-              -> (a  b : V) 
+sumV-reflection :  (I : Set) -> (F : I -> Set)
+              -> (a  b : V)
               -> (a ∈ uV I F) -> (b ∈ uV I F)
               -> sumV a b ∈ uV I F
-sumV-reflection I F a b p q = 
+sumV-reflection I F a b p q =
   let p2 : a ≐ (uV I F) ‣ pj1 p
       p2 = pj2 p
       q2 : b ≐ (uV I F) ‣ pj1 q
       q2 = pj2 q
-  in        (sum-sV I F (pj1 p) (pj1 q)) , 
-            symV (traV (emb-sum I F (pj1 p) (pj1 q)) 
-             (pair (λ u → (sum-map (e+ (symV p2)) (e+ (symV q2)) u) , sumV-refl-lm1 I F a b p q u) 
+  in        (sum-sV I F (pj1 p) (pj1 q)) ,
+            symV (traV (emb-sum I F (pj1 p) (pj1 q))
+             (pair (λ u → (sum-map (e+ (symV p2)) (e+ (symV q2)) u) , sumV-refl-lm1 I F a b p q u)
                    (λ v → (sum-map (e+ p2) (e+ q2) v) , sumV-refl-lm2 I F a b p q v)))
-   
+

--- a/MLTT-and-setoids/iterative-sets-pt7.agda
+++ b/MLTT-and-setoids/iterative-sets-pt7.agda
@@ -25,50 +25,50 @@ V-extensional : (a : V) -> (R : # a -> # a -> Set) -> (pf : Eqrel (# a) R) -> Se
 V-extensional a R pf = (x y : # a) -> (a ‣ x ≐ a ‣ y) -> R x y
 
 
-quot : (a : V) -> (R : # a -> # a -> Set) -> (pf : Eqrel (# a) R) -> (V-extensional a R pf) 
+quot : (a : V) -> (R : # a -> # a -> Set) -> (pf : Eqrel (# a) R) -> (V-extensional a R pf)
    -> V
 quot a R epf xpf = sup (# a) (λ x → sup (Σ (# a) (R x)) (λ z → a ‣ (pj1 z)))
 
-qmap-op : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
+qmap-op : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
  -> (xpf : V-extensional a R epf) -> (|| κ a ||) -> || κ (quot a R epf xpf) ||
 qmap-op a R epf xpf x = x
 
-qmap-ext : (a : V) -> (R : # a -> # a -> Set) 
-  -> (epf : Eqrel (# a) R) 
-  -> (xpf : V-extensional a R epf) 
-  -> (x y :  || κ a ||) 
+qmap-ext : (a : V) -> (R : # a -> # a -> Set)
+  -> (epf : Eqrel (# a) R)
+  -> (xpf : V-extensional a R epf)
+  -> (x y :  || κ a ||)
   -> < κ a > x ~ y
   ->  < κ (quot a R epf xpf) > qmap-op a R epf xpf x ~
                                qmap-op a R epf xpf y
-qmap-ext a R epf xpf x y p = 
+qmap-ext a R epf xpf x y p =
   let lm2 : sup (Σ (# a) (R x)) (λ z → a ‣ (pj1 z)) ≐
             sup (Σ (# a) (R y)) (λ z → a ‣ (pj1 z))
-      lm2 = pair (λ x' → ((pj1 x') , 
+      lm2 = pair (λ x' → ((pj1 x') ,
                   (let lm3 = pj2 x'
                    in Tra epf _ _ _ (xpf _ _ (symV (>< p))) lm3)) ,
                     refV (a ‣ pj1 x'))
                  (λ y' → ((pj1 y') ,
                    (let lm3 = pj2 y'
-                    in Tra epf _ _ _ (xpf _ _  (>< p)) lm3)) , 
+                    in Tra epf _ _ _ (xpf _ _  (>< p)) lm3)) ,
                     refV (a ‣ pj1 y'))
-      lm :  (quot a R epf xpf) ‣ x ≐  (quot a R epf xpf) ‣ y 
+      lm :  (quot a R epf xpf) ‣ x ≐  (quot a R epf xpf) ‣ y
       lm = lm2
   in  <> lm
 
-qmap : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
+qmap : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
  -> (xpf : V-extensional a R epf) -> || (κ a) => (κ (quot a R epf xpf)) ||
-qmap a R epf xpf = record { op = qmap-op a R epf xpf 
+qmap a R epf xpf = record { op = qmap-op a R epf xpf
                           ; ext = qmap-ext a R epf xpf
                           }
 
 
-qmap-prop1 : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
-  -> (xpf : V-extensional a R epf) 
-  -> (x y : # a) -> R x y 
+qmap-prop1 : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
+  -> (xpf : V-extensional a R epf)
+  -> (x y : # a) -> R x y
   ->  < κ (quot a R epf xpf) > ap (qmap a R epf xpf) x ~ ap (qmap a R epf xpf) y
 qmap-prop1 a R epf xpf x y p =
-   <> (pair (λ z → ( 
-                   let 
+   <> (pair (λ z → (
+                   let
                        z2  : R x (pj1 z)
                        z2 = pj2 z
                        u1 : Σ (# a) (R y) -- (ap (qmap a R epf xpf) y) = y
@@ -77,7 +77,7 @@ qmap-prop1 a R epf xpf x y p =
                                   (λ y₁ → eqV (a ‣ pj1 z) (a ‣ pj1 y₁))
                        main = u1 , refV (a ‣ pj1 z)
                    in main))
-            (λ z → let 
+            (λ z → let
                        z2  : R y (pj1 z)
                        z2 = pj2 z
                        u1 : Σ (# a) (R x) -- (ap (qmap a R epf xpf) x) = x
@@ -87,21 +87,21 @@ qmap-prop1 a R epf xpf x y p =
                        main = u1 , refV (a ‣ pj1 z)
                    in main
         )
-                     ) 
-      
+                     )
 
-qmap-prop2 : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
-  -> (xpf : V-extensional a R epf) 
+
+qmap-prop2 : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
+  -> (xpf : V-extensional a R epf)
   -> (x y : # a)
   -> < κ (quot a R epf xpf) > ap (qmap a R epf xpf) x ~ ap (qmap a R epf xpf) y
-  -> R x y 
-qmap-prop2 a R epf xpf x y p = 
+  -> R x y
+qmap-prop2 a R epf xpf x y p =
    let lm : < κ (quot a R epf xpf) > ap (qmap a R epf xpf) x ~
                                      ap (qmap a R epf xpf) y
        lm = p
        lm2 : (quot a R epf xpf) ‣ x ≐ (quot a R epf xpf) ‣ y
        lm2 = >< lm
-       lm3 : sup (Σ (# a) (R x)) (λ z → a ‣ (pj1 z)) ≐ 
+       lm3 : sup (Σ (# a) (R x)) (λ z → a ‣ (pj1 z)) ≐
              sup (Σ (# a) (R y)) (λ z → a ‣ (pj1 z))
        lm3 = lm2
        lm4 : (x₁ : Σ (# a) (R x)) →
@@ -117,45 +117,45 @@ qmap-prop2 a R epf xpf x y p =
        lm7 = pj2 lm61
        lm8 : R x (pj1 (pj1 (prj1 (>< p) (x , Refl epf x))))
        lm8 = xpf _ _ lm62
- 
+
    in  Tra epf _ _ _ lm8 (Sym epf _ _ lm7)
 
 
 -- representatives exists
 
-qmap-prop3 : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
-  -> (xpf : V-extensional a R epf) 
+qmap-prop3 : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
+  -> (xpf : V-extensional a R epf)
   -> (u : # (quot a R epf xpf))
   -> Σ (# a) (\x ->  < κ (quot a R epf xpf) > ap (qmap a R epf xpf) x ~ u)
-qmap-prop3 a R epf xpf u = u , refl (κ (quot a R epf xpf)) u 
+qmap-prop3 a R epf xpf u = u , refl (κ (quot a R epf xpf)) u
 
 -- universal properties
 
-qmap-univ-map-op :  (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
+qmap-univ-map-op :  (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
     -> (xpf : V-extensional a R epf)
     -> (b : V)
     -> (f : || κ a => κ b ||)
     -> (rpf : (x y : # a) -> R x y -> < κ b > ap f x ~ ap f y)
     -> || κ (quot a R epf xpf) ||
-    -> || κ b ||  
+    -> || κ b ||
 qmap-univ-map-op a R epf xpf b f rpf x = ap f x
 
-qmap-univ-map :  (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
+qmap-univ-map :  (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
     -> (xpf : V-extensional a R epf)
     -> (b : V)
     -> (f : || κ a => κ b ||)
     -> (rpf : (x y : # a) -> R x y -> < κ b > ap f x ~ ap f y)
     -> || κ (quot a R epf xpf) => κ b  ||
-qmap-univ-map a R epf xpf b f rpf = 
-         record { op = qmap-univ-map-op a R epf xpf b f rpf 
-                ; ext = λ x y q → rpf x y 
-                                  (let 
-                                       main : R x y 
+qmap-univ-map a R epf xpf b f rpf =
+         record { op = qmap-univ-map-op a R epf xpf b f rpf
+                ; ext = λ x y q → rpf x y
+                                  (let
+                                       main : R x y
                                        main = qmap-prop2 a R epf xpf x y q
-                                    in main) 
+                                    in main)
                 }
 
-qmap-universal :  (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
+qmap-universal :  (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
     -> (xpf : V-extensional a R epf)
     -> (b : V)
     -> (f : || κ a => κ b ||)
@@ -163,7 +163,7 @@ qmap-universal :  (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
     -> < κ a => κ b > f ~ ((qmap-univ-map a R epf xpf b f rpf) ° (qmap a R epf xpf))
 qmap-universal a R epf xpf b f rpf = <> (λ x → <>  (refV _))
 
-qmap-epi : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R) 
+qmap-epi : (a : V) -> (R : # a -> # a -> Set) -> (epf : Eqrel (# a) R)
     -> (xpf : V-extensional a R epf)
     -> (b : V)
     -> (g h : || κ (quot a R epf xpf) => κ b ||)

--- a/MLTT-and-setoids/iterative-sets-pt8.agda
+++ b/MLTT-and-setoids/iterative-sets-pt8.agda
@@ -26,7 +26,7 @@ open import iterative-sets-pt6
 
 
 -- br-zeroV :  N₀ -> V
--- br-zeroV () 
+-- br-zeroV ()
 
 -- zeroV : V
 -- zeroV = sup N₀ br-zeroV
@@ -48,12 +48,12 @@ sqV-prop-3 :  (u : V) -> sqV u ≤ singV zeroV
 sqV-prop-3 u x = 0₁ , refV _
 
 sqV-ext-half : (a b : V) -> a ≤ b -> sqV a ≤ sqV b
-sqV-ext-half (sup A f) (sup B g) p  x = 
+sqV-ext-half (sup A f) (sup B g) p  x =
     let p1 = pj1 (p x)
         p2 = pj2 (p x)
     in p1 , refV _
 
--- eqV-unexpand' : (u v : V) ->   (u ≤ v) -> (u ≥ v) ->  (u ≐ v) 
+-- eqV-unexpand' : (u v : V) ->   (u ≤ v) -> (u ≥ v) ->  (u ≐ v)
 
 
 
@@ -64,8 +64,8 @@ singV-zeroV-lm : (x : # (singV zeroV)) -> singV zeroV ‣ x ≐ zeroV
 singV-zeroV-lm 0₁ = refV _
 
 sqV-prop-4 : (u : V) -> u ≤ singV zeroV -> sqV u ≐ u
-sqV-prop-4 (sup A f) p =  
-       eqV-unexpand' (sqV (sup A f)) (sup A f) 
+sqV-prop-4 (sup A f) p =
+       eqV-unexpand' (sqV (sup A f)) (sup A f)
                 (λ x → x , (let  px = p x
                                  px2 = pj2 px
                                  lm : sup A f ‣ x ≐ zeroV
@@ -73,7 +73,7 @@ sqV-prop-4 (sup A f) p =
                                  main : sqV (sup A f) ‣ x ≐ sup A f ‣ x
                                  main = symV lm
                             in main
-                             )) 
+                             ))
                 (λ y → y , (let  py = p y
                                  py2 = pj2 py
                                  lm : sup A f ‣ y ≐ zeroV
@@ -87,12 +87,12 @@ sqV-prop-5 :  (u : V) -> sqV (sqV u) ≐ sqV u
 sqV-prop-5 u = sqV-prop-4 (sqV u) (sqV-prop-3 u)
 
 sqV-ext : (a b : V) -> a ≐ b -> sqV a ≐ sqV b
-sqV-ext a b p = pair (sqV-ext-half a b (prj1 (eqV-expand' a b p))) 
-                     (sqV-ext-half b a (≥-≤-lm a b (prj2 (eqV-expand' a b p)))) 
+sqV-ext a b p = pair (sqV-ext-half a b (prj1 (eqV-expand' a b p)))
+                     (sqV-ext-half b a (≥-≤-lm a b (prj2 (eqV-expand' a b p))))
 
 
 
-sqV-sV : (I : Set) -> (F : I -> Set) 
+sqV-sV : (I : Set) -> (F : I -> Set)
            -> (u : sV I F) -> sV I F
 sqV-sV I F u =  sup (isV I F u) (\x -> zero-sV I F)
 
@@ -100,13 +100,13 @@ sqV-sV I F u =  sup (isV I F u) (\x -> zero-sV I F)
 {--
 
 
-emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V 
+emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V
 emb I F (sup A f) = sup (To {I} {F} A) (\x -> emb I F (f x))
 
 emb+ : (I : Set) -> (F : I -> Set) -> (u : sV I F) -> To {I} {F} (isV I F u) -> iV (emb I F u)
 emb+ I F (sup A f) x = x
 
-emb- : (I : Set) -> (F : I -> Set) -> (u : sV I F) -> iV (emb I F u) -> To {I} {F} (isV I F u) 
+emb- : (I : Set) -> (F : I -> Set) -> (u : sV I F) -> iV (emb I F u) -> To {I} {F} (isV I F u)
 emb- I F (sup A f) x = x
 
 
@@ -116,17 +116,17 @@ uV I F = sup (sV I F) (emb I F)
 --}
 
 
-sqV-reflection-lm-half1 : (I : Set) -> (F : I -> Set) 
-              -> (a : V) 
-              -> (p : a ∈ uV I F) 
+sqV-reflection-lm-half1 : (I : Set) -> (F : I -> Set)
+              -> (a : V)
+              -> (p : a ∈ uV I F)
               -> sqV a ≤ uV I F ‣ sqV-sV I F (pj1 p)
 sqV-reflection-lm-half1 I F (sup A f) (p1 , p2) x =
       let  lm5 = prj1 (eqV-expand' _ _ p2)
-           lm : # (uV I F ‣ sqV-sV I F p1) 
+           lm : # (uV I F ‣ sqV-sV I F p1)
               -- # (emb I F (sqV-sV I F p1))
-              -- # (emb I F (sup (isV I F p1) (\x -> zero-sV I F))) 
+              -- # (emb I F (sup (isV I F p1) (\x -> zero-sV I F)))
               -- To {I} {F}  (isV I F p1)
-               
+
               -- sqV-sV I F u =  sup (isV I F u) (\x -> zero-sV I F)
            lm = emb- I F p1 (pj1 (lm5 x))
            lm4 : sqV (sup A f) ‣ x ≐  zeroV
@@ -152,11 +152,11 @@ sqV-reflection-lm-half1 I F (sup A f) (p1 , p2) x =
       in  lm , lm2
 
 
-sqV-reflection-lm-half2 : (I : Set) -> (F : I -> Set) 
-              -> (a : V) 
-              -> (p : a ∈ uV I F) 
+sqV-reflection-lm-half2 : (I : Set) -> (F : I -> Set)
+              -> (a : V)
+              -> (p : a ∈ uV I F)
               -> sqV a ≥ uV I F ‣ sqV-sV I F (pj1 p)
-sqV-reflection-lm-half2 I F (sup A f) (p1 , p2) x = 
+sqV-reflection-lm-half2 I F (sup A f) (p1 , p2) x =
      let lm6 = prj2 (eqV-expand' _ _ p2)
          u : To {I} {F} (isV I F p1)
          u = x
@@ -164,7 +164,7 @@ sqV-reflection-lm-half2 I F (sup A f) (p1 , p2) x =
          x' = emb+ I F p1 u
 
 -- emb+ : (I : Set) -> (F : I -> Set) -> (u : sV I F) -> To {I} {F} (isV I F u) -> iV (emb I F u)
---    # (uV I F ‣ sqV-sV I F p1) 
+--    # (uV I F ‣ sqV-sV I F p1)
 --  = # ( (emb I F) (sqV-sV I F p1))
 --  = # ((emb I F) (sup (isV I F p1) (\x -> zero-sV I F))
 --  = (To {I} {F} (isV I F p1))
@@ -178,26 +178,26 @@ sqV-reflection-lm-half2 I F (sup A f) (p1 , p2) x =
      in y , lm2
 
 
-sqV-reflection-lm : (I : Set) -> (F : I -> Set) 
-              -> (a : V) 
-              -> (p : a ∈ uV I F) 
+sqV-reflection-lm : (I : Set) -> (F : I -> Set)
+              -> (a : V)
+              -> (p : a ∈ uV I F)
               -> sqV a ≐ uV I F ‣ sqV-sV I F (pj1 p)
 sqV-reflection-lm I F a p =
       pair  (sqV-reflection-lm-half1 I F a p) (sqV-reflection-lm-half2 I F a p)
 
 
-sqV-reflection :  (I : Set) -> (F : I -> Set) 
-              -> (a : V) 
-              -> (a ∈ uV I F) 
+sqV-reflection :  (I : Set) -> (F : I -> Set)
+              -> (a : V)
+              -> (a ∈ uV I F)
               -> sqV a ∈ uV I F
-sqV-reflection I F a p = 
+sqV-reflection I F a p =
   let p1 : # (uV I F)
       p1 = pj1 p
       p2 : a ≐ (uV I F) ‣ pj1 p
       p2 = pj2 p
       lm : sqV a ≐ uV I F ‣ sqV-sV I F (pj1 p)
       lm = sqV-reflection-lm I F a p
-  in (sqV-sV I F (pj1 p)) , lm 
+  in (sqV-sV I F (pj1 p)) , lm
 
 
 -- Squashing a set of sets
@@ -223,7 +223,7 @@ map-sqV-sV I F a = ImV-sV I F (sqV-sV I F) a
 -- sV : (I : Set) -> (F : I -> Set)  -> Set
 -- sV I F = W (Uo I F) (To {I} {F})
 
--- emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V 
+-- emb :   (I : Set) -> (F : I -> Set) -> sV I F -> V
 -- emb I F (sup A f) = sup (To {I} {F} A) (\x -> emb I F (f x))
 
 -- uV : (I : Set) -> (F : I -> Set) -> V

--- a/MLTT-and-setoids/iterative-sets.agda
+++ b/MLTT-and-setoids/iterative-sets.agda
@@ -33,7 +33,7 @@ bV (sup A f) = f
 # : V -> Set
 # u = iV u
 
-infixl 10 _‣_ -- enter as \bu4 
+infixl 10 _‣_ -- enter as \bu4
 
 _‣_ : (t : V) -> (iV t) ->  V
 _‣_ u a = bV u a
@@ -45,48 +45,48 @@ _‣_ u a = bV u a
 infix 2 _≐_   --  \doteq
 
 eqV : V -> V -> Set
-eqV (sup A f) (sup B g) = and ((x : A) -> Σ B (\y -> eqV (f x) (g y))) 
-                              ((y : B) -> Σ A (\x -> eqV (f x) (g y))) 
+eqV (sup A f) (sup B g) = and ((x : A) -> Σ B (\y -> eqV (f x) (g y)))
+                              ((y : B) -> Σ A (\x -> eqV (f x) (g y)))
 
 _≐_ : V -> V -> Set
 x ≐ y = eqV x y
 
 -- useful expansion/unexpansion of the definition
 
-eqV-expand : (u v : V) -> (u ≐ v) -> 
-          and ((x : # u) -> Σ (# v) (\y ->  u ‣ x ≐ v ‣ y)) 
-              ((y : # v) -> Σ (# u) (\x ->  u ‣ x ≐ v ‣ y)) 
+eqV-expand : (u v : V) -> (u ≐ v) ->
+          and ((x : # u) -> Σ (# v) (\y ->  u ‣ x ≐ v ‣ y))
+              ((y : # v) -> Σ (# u) (\x ->  u ‣ x ≐ v ‣ y))
 eqV-expand (sup A f) (sup B g) p = p
 
 
-eqV-unexpand : (u v : V) -> 
+eqV-unexpand : (u v : V) ->
                ((x : # u) -> Σ (# v) (\y ->  u ‣ x ≐ v ‣ y)) ->
-               ((y : # v) -> Σ (# u) (\x ->  u ‣ x ≐ v ‣ y)) -> 
-               (u ≐ v)  
+               ((y : # v) -> Σ (# u) (\x ->  u ‣ x ≐ v ‣ y)) ->
+               (u ≐ v)
 eqV-unexpand (sup A f) (sup B g) p q = pair p q
 
 -- version of inclusion statement
 
 infix 2 _≤_ -- \le
 _≤_ : V -> V -> Set
-u ≤ v = ((x : # u) -> Σ (# v) (\y ->  u ‣ x ≐ v ‣ y)) 
+u ≤ v = ((x : # u) -> Σ (# v) (\y ->  u ‣ x ≐ v ‣ y))
 
 infix 2 _≥_ -- \ge
 _≥_ : V -> V -> Set
-u ≥ v = ((y : # v) -> Σ (# u) (\x ->  u ‣ x ≐ v ‣ y)) 
+u ≥ v = ((y : # v) -> Σ (# u) (\x ->  u ‣ x ≐ v ‣ y))
 
 eqV-expand' : (u v : V) -> (u ≐ v) ->  and (u ≤ v) (u ≥ v)
-eqV-expand' u v p = eqV-expand u v p           
+eqV-expand' u v p = eqV-expand u v p
 
-eqV-unexpand' : (u v : V) ->   (u ≤ v) -> (u ≥ v) ->  (u ≐ v) 
+eqV-unexpand' : (u v : V) ->   (u ≤ v) -> (u ≥ v) ->  (u ≐ v)
 eqV-unexpand' u v p q = eqV-unexpand u v p q
 
 
-easy-eqV :  (A : Set) -> (f g : A -> V) 
+easy-eqV :  (A : Set) -> (f g : A -> V)
              -> ((x : A) -> f x ≐ g x)
               -> (sup A f) ≐ (sup A g)
 easy-eqV A f g p = pair (λ x → x , p x) (λ y →  y , p y)
-         
+
 
 eqV-right : {u v : V} -> (u ≐ v) -> # u ->  # v
 eqV-right {u} {v} p x = pj1 (prj1 (eqV-expand u v p) x)
@@ -117,7 +117,7 @@ refV : (u : V) -> u ≐ u
 refV u = refl-eqV u
 
 sym-eqV : (u v : V) -> u ≐ v -> v ≐ u
-sym-eqV (sup A f) (sup B g) p = pair (λ x → pj1 (prj2 p x) , sym-eqV (f (pj1 (prj2 p x))) (g x) (pj2 (prj2 p x))) 
+sym-eqV (sup A f) (sup B g) p = pair (λ x → pj1 (prj2 p x) , sym-eqV (f (pj1 (prj2 p x))) (g x) (pj2 (prj2 p x)))
                                      (λ y → pj1 (prj1 p y) , sym-eqV (f y) (g (pj1 (prj1 p y))) (pj2 (prj1 p y)))
 
 symV : {u v : V} -> u ≐ v -> v ≐ u
@@ -131,8 +131,8 @@ tra-eqV (sup A f) (sup B g) (sup C h) p q = pair (λ x → (pj1 (prj1 q (pj1 (pr
                                                              lm2 = pj2 (prj1 q (pj1 (prj1 p x)))
                                                              main : eqV (f x) (h (pj1 (prj1 q (pj1 (prj1 p x)))))
                                                              main = tra-eqV _ _ _ lm1 lm2
-                                                         in main)) 
-                                                 (λ y → (pj1 (prj2 p (pj1 (prj2 q y)))) , 
+                                                         in main))
+                                                 (λ y → (pj1 (prj2 p (pj1 (prj2 q y)))) ,
                                                         (let lm1 : eqV (f (pj1 (prj2 p (pj1 (prj2 q y))))) (g (pj1 (prj2 q y)))
                                                              lm1 = pj2 (prj2 p (pj1 (prj2 q y)))
                                                              lm2 : eqV (g (pj1 (prj2 q y))) (h y)
@@ -157,7 +157,7 @@ eqV-left-right-prop {u} {v} p y = traV (e-prop p y) (e+prop (symV p) y)
 
 e+ext : {u v : V} -> (p : u ≐ v)
       -> (x y : # u) -> u ‣ x ≐ u ‣ y ->  v ‣ (e+ p x) ≐ v ‣ (e+ p y)
-e+ext {u} {v} p x y q = traV (symV (e+prop p x)) (traV q (e+prop p y)) 
+e+ext {u} {v} p x y q = traV (symV (e+prop p x)) (traV q (e+prop p y))
 
 e+fun : {u v z : V} -> (p : u ≐ v) -> (q : v ≐ z) ->  (r : u ≐ z)
       -> (x : # u)  ->  z ‣ (e+ q (e+ p x)) ≐ z ‣ (e+ r x)
@@ -185,22 +185,22 @@ memV-left-ext : (u v x : V) -> u ≐ v -> v ∈ x -> u ∈ x
 memV-left-ext u v (sup A f) p q = (pj1 q) , (traV p (pj2 q))
 
 memV-right-ext : (u x y : V)  -> u ∈ x -> x ≐ y -> u ∈ y
-memV-right-ext u (sup A f) (sup B g) p q = 
+memV-right-ext u (sup A f) (sup B g) p q =
      let p2 : u ≐ (f (pj1 p))
-         p2 = pj2 p 
+         p2 = pj2 p
          q1 = prj1 q (pj1 p)
      in (pj1 q1) , (traV p2 (pj2 q1))
 
-memV-right-ext-lm : (u x y : V)  
+memV-right-ext-lm : (u x y : V)
      -> (p : u ∈ x) -> (q : x ≐ y) -> u ≐ y ‣ (pj1 (memV-right-ext u x y p q))
 memV-right-ext-lm u x y p q =  pj2 (memV-right-ext u x y p q)
 
 -- seems useful :
 
 
-memV-right-ext-lm2 : (u x y : V)  
+memV-right-ext-lm2 : (u x y : V)
       -> (p : u ∈ x) -> (q : x ≐ y) -> u ≐ y ‣ (e+ q (pj1 p))
-memV-right-ext-lm2 u x y p q = traV (pj2 p) (e+prop q (pj1 p)) 
+memV-right-ext-lm2 u x y p q = traV (pj2 p) (e+prop q (pj1 p))
 
 
 memV-right-ext2 : (u x y : V)  -> u ∈ x -> x ≐ y -> u ∈ y
@@ -214,28 +214,28 @@ _⊆_ : (u v : V) -> Set1
 _⊆_ u v = (x : V) -> x ∈ u -> x ∈ v
 
 extensional-eqV : (u v : V) -> u ⊆ v -> v ⊆ u -> u ≐ v
-extensional-eqV (sup A f) (sup B g) p q 
+extensional-eqV (sup A f) (sup B g) p q
     = pair (λ x → let lm = p (f x) (triv-memV A f x)
                       main :  Σ B (λ y → f x ≐ g y)
                       main = lm
-                  in main) 
+                  in main)
            (λ y → let lm :  Σ A (λ z → (g y) ≐ (f z))
                       lm = q (g y) (triv-memV B g y)
                       main : Σ A (λ x → f x ≐ g y)
                       main = (pj1 lm) , (symV (pj2 lm))
                   in main)
 
-trivial-incl : (u v : V) -> u ≐ v  -> u ⊆ v 
+trivial-incl : (u v : V) -> u ≐ v  -> u ⊆ v
 trivial-incl u v p t q = memV-right-ext _ _ _ q p
 
 half-eqV : V -> V -> Set
-half-eqV (sup A f) (sup B g) = (x : A) -> Σ B (\y -> eqV (f x) (g y)) 
+half-eqV (sup A f) (sup B g) = (x : A) -> Σ B (\y -> eqV (f x) (g y))
 
 -- same as (sup A f) ≤  (sup B g)
 
 half-eqV-to-inclusion : (u v : V) -> half-eqV u v -> u ⊆ v
 half-eqV-to-inclusion (sup A f) (sup B g) p = λ x q → pj1 (p (pj1 q)) , traV (pj2 q) (pj2 (p (pj1 q)))
-                            
+
 ≤-to-inclusion : (u v : V) -> u ≤ v -> u ⊆ v
 ≤-to-inclusion u v p =  λ x q → pj1 (p (pj1 q)) , traV (pj2 q) (pj2 (p (pj1 q)))
 
@@ -254,15 +254,15 @@ unord-branch x y (inl _)  = x
 unord : V -> V -> V
 unord x y = sup Bool (unord-branch x y)
 
-unord-propR : (x y : V) -> 
+unord-propR : (x y : V) ->
        (z : V) -> z ∈ (unord x y) -> (or (z ≐ x) (z ≐ y))
 unord-propR x y z (inl u , p) = inl p
-unord-propR x y z (inr u , p) = inr p  
+unord-propR x y z (inr u , p) = inr p
 
-unord-propL : (x y : V) -> 
+unord-propL : (x y : V) ->
        (z : V) -> (or (z ≐ x) (z ≐ y)) -> z ∈ (unord x y)
-unord-propL x y z p = orEweak {z ≐ x} {z ≐ y} {z ∈ (unord x y)} 
-                        (\q -> (inl  0₁ ) , q) 
+unord-propL x y z p = orEweak {z ≐ x} {z ≐ y} {z ∈ (unord x y)}
+                        (\q -> (inl  0₁ ) , q)
                         (\r -> (inr  0₁ ) , r) p
 
 unord-propL2 :  (x y : V) -> x ∈ (unord x y)
@@ -271,22 +271,22 @@ unord-propL2 x y = unord-propL x y x (inl (refV x))
 unord-propL3 :  (x y : V) -> y ∈ (unord x y)
 unord-propL3 x y = unord-propL x y y (inr (refV y))
 
-unord-prop : (x y : V) -> 
+unord-prop : (x y : V) ->
        (z : V) -> (iff (z ∈ (unord x y)) (or (z ≐ x) (z ≐ y)))
 unord-prop x y z = pair (unord-propR x y z) (unord-propL x y z)
 
 unord-ext-lm : (x y z u : V) -> x ≐ z -> y ≐ u -> (unord x y) ⊆ (unord z u)
-unord-ext-lm x y z u p q t (inl m , p') = (inl  0₁) , (traV p' p) 
-unord-ext-lm x y z u p q t (inr m , q') = inr 0₁ , traV q' q 
+unord-ext-lm x y z u p q t (inl m , p') = (inl  0₁) , (traV p' p)
+unord-ext-lm x y z u p q t (inr m , q') = inr 0₁ , traV q' q
 
 
 unord-ext : {x y z u : V} -> x ≐ z -> y ≐ u -> (unord x y) ≐ (unord z u)
-unord-ext {x} {y} {z} {u} p q = extensional-eqV (unord x y) (unord z u) 
+unord-ext {x} {y} {z} {u} p q = extensional-eqV (unord x y) (unord z u)
                                         (unord-ext-lm x y z u p q)
-                                        (unord-ext-lm z u x y (symV p) (symV q)) 
+                                        (unord-ext-lm z u x y (symV p) (symV q))
 
 unord-inv-lm :  (x y u : V) -> (unord x y ≐ unord x u) -> y ≐ u
-unord-inv-lm x y u p = 
+unord-inv-lm x y u p =
    let lm1 : y ∈ (unord x u)
        lm1 = memV-right-ext _ _ _ (unord-propL3 _ _) p
        lm1b : or (y ≐ x) (y ≐ u)
@@ -295,12 +295,12 @@ unord-inv-lm x y u p =
        lm2 = memV-right-ext _ _ _ (unord-propL3 _ _) (symV p)
        lm2b : or (u ≐ x) (u ≐ y)
        lm2b = unord-propR _ _ _ lm2
-   in orEweak {y ≐ x} {y ≐ u} {y ≐ u} 
-              (λ q → orEweak {u ≐ x} {u ≐ y} {y ≐ u} 
-                             (λ r → traV q (symV r)) 
-                             (λ r → symV r) 
-                             lm2b) 
-              (λ q → q) 
+   in orEweak {y ≐ x} {y ≐ u} {y ≐ u}
+              (λ q → orEweak {u ≐ x} {u ≐ y} {y ≐ u}
+                             (λ r → traV q (symV r))
+                             (λ r → symV r)
+                             lm2b)
+              (λ q → q)
               lm1b
 
 
@@ -317,7 +317,7 @@ is-unord : (u : V) -> Set
 is-unord u =   Σ (# u) (\a  -> (Σ (# u) \b -> u ≐ unord (u ‣ a) (u ‣ b)))
 
 is-unord-ext : (u v : V) -> u ≐ v -> is-unord u -> is-unord v
-is-unord-ext (sup A f) (sup B g) p q = 
+is-unord-ext (sup A f) (sup B g) p q =
      let lm : Σ A (\a  -> (Σ A \b -> (sup A f) ≐ unord (f a) (f b)))
          lm = q
          a1 = pj1 lm
@@ -338,16 +338,16 @@ is-unord-ext (sup A f) (sup B g) p q =
 
 
 is-unord1-0 : (u : V) -> (is-unord1 u) -> (is-unord u)
-is-unord1-0 u p = 
+is-unord1-0 u p =
      let lm :  u ≐ unord (is-unord1.cp1 p)  (is-unord1.cp2 p)
          lm =  is-unord1.eqp p
          lm2 : is-unord (unord (is-unord1.cp1 p)  (is-unord1.cp2 p))
-         lm2 = (inl 0₁) , ((inr 0₁) , (refV _))         
+         lm2 = (inl 0₁) , ((inr 0₁) , (refV _))
      in is-unord-ext _ _ (symV lm) lm2
 
 is-unord0-1 : (u : V) -> (is-unord u) -> (is-unord1 u)
-is-unord0-1 (sup A f) p = record { cp1 = f (pj1 p) 
-                                 ; cp2 = f (pj1 (pj2 p)) 
+is-unord0-1 (sup A f) p = record { cp1 = f (pj1 p)
+                                 ; cp2 = f (pj1 (pj2 p))
                                  ; eqp = pj2 (pj2 p) }
 
 
@@ -369,15 +369,15 @@ pairV-lm1 x y  (inl 0₁ , p ) = p
 pairV-lm1 x y  (inr 0₁ , q ) = q
 
 pairV-lm2 : (x y z : V) -> (unord x x) ≐ (unord y z) -> (and (x ≐ y) (x ≐ z))
-pairV-lm2 x y z p = pair (symV (pairV-lm1 y x 
+pairV-lm2 x y z p = pair (symV (pairV-lm1 y x
                                               (let lm : y ∈ unord y z
                                                    lm = unord-propL2 _ _
                                                in memV-right-ext _ _ _ lm (symV p))))
-                         (symV (pairV-lm1 z x 
+                         (symV (pairV-lm1 z x
                                               (let lm : z ∈ unord y z
                                                    lm = unord-propL3 _ _
                                                in memV-right-ext _ _ _ lm (symV p))))
-     
+
 
 pairV-inv-1 : {x y z u : V} -> < x , y > ≐ < z , u > ->  and (x ≐ z) (y ≐ u)
 pairV-inv-1 {x} {y} {z} {u} p =
@@ -385,14 +385,14 @@ pairV-inv-1 {x} {y} {z} {u} p =
                           lm = p
                           lm2 : (unord x x) ∈ unord (unord z z) (unord z u)
                           lm2 =  memV-right-ext _ _ _ (unord-propL2 _ _) lm
-                          lm3 : or ((unord x x) ≐ (unord z z)) ((unord x x) ≐ (unord z u)) 
+                          lm3 : or ((unord x x) ≐ (unord z z)) ((unord x x) ≐ (unord z u))
                           lm3 = unord-propR _ _ _ lm2
                           main1 : x ≐ z
                           main1 = orEweak (λ q → prj1 (pairV-lm2 _ _ _ q))
                                           (λ q → prj1 (pairV-lm2 _ _ _ q)) lm3
                           lm4 :  unord (unord x x) (unord x y) ≐ unord (unord x x) (unord x u)
-                          lm4 = traV lm (unord-ext 
-                                    (symV (unord-ext main1 main1)) 
+                          lm4 = traV lm (unord-ext
+                                    (symV (unord-ext main1 main1))
                                     (symV (unord-ext main1 (refV _))))
                           lm5 :  (unord x y) ≐  (unord x u)
                           lm5 = unord-inv-lm _ _ _ lm4
@@ -409,7 +409,7 @@ unionV v = sup (Σ (# v) (\x -> # (v ‣ x))) (\u -> v ‣ (pj1 u) ‣ (pj2 u))
 
 
 unionV-lm1 : (x y : V) -> x ∈ unionV y -> Σ10 V (\u -> and (x ∈ u) (u ∈ y))
-unionV-lm1 x y p = 
+unionV-lm1 x y p =
   let lm2 :  Σ (# y) (λ v → # (y ‣ v))
       lm2 = pj1 p
       lm3 : x  ≐ ((y ‣ (pj1 (pj1 p))) ‣ (pj2 (pj1 p)))
@@ -438,23 +438,23 @@ record is-pairV1 (u : V) : Set1 where
     eqp :  u ≐ < cp1 , cp2 >
 
 is-pairV1-ext : (u v : V) -> u ≐ v -> is-pairV1 u -> is-pairV1 v
-is-pairV1-ext u v p q = record { cp1 = is-pairV1.cp1 q 
-                               ; cp2 = is-pairV1.cp2 q 
-                               ; eqp = traV (symV p) (is-pairV1.eqp q) 
+is-pairV1-ext u v p q = record { cp1 = is-pairV1.cp1 q
+                               ; cp2 = is-pairV1.cp2 q
+                               ; eqp = traV (symV p) (is-pairV1.eqp q)
                                }
 
 -- small version finding the components inside the tree for u
 
 is-pairV : (u : V) -> Set
-is-pairV u =   Σ (# u) (\a  -> (Σ (# u) \b ->  
+is-pairV u =   Σ (# u) (\a  -> (Σ (# u) \b ->
                 Σ (# (u ‣ a)) (\c ->  Σ (# (u ‣ b)) (\d ->
                        u ≐ < u ‣ a ‣ c , u ‣ b ‣ d >))))
 
--- 
+--
 
 is-pairV-ext : (u v : V) -> u ≐ v -> is-pairV u -> is-pairV v
-is-pairV-ext (sup A f) (sup B g) p q = 
-    let lm : Σ A (\a  -> (Σ A \b ->  
+is-pairV-ext (sup A f) (sup B g) p q =
+    let lm : Σ A (\a  -> (Σ A \b ->
                 Σ (# (f a)) (\c ->  Σ (# (f b)) (\d ->
                        (sup A f) ≐ < (f a) ‣ c , (f b) ‣ d >))))
         lm = q
@@ -487,7 +487,7 @@ is-pairV-ext (sup A f) (sup B g) p q =
               (λ y → ((f a1) ‣ x)  ≐ ((g b1) ‣ y)))
            ((y : # (g b1)) →
            Σ (# (f a1))
-              (λ x → ((f a1) ‣ x)  ≐ ((g b1) ‣ y)))     
+              (λ x → ((f a1) ‣ x)  ≐ ((g b1) ‣ y)))
         ts =  eqV-expand _ _ eq4
         ts2 = eqV-expand _ _ eq5
         d1 : # (g b1)
@@ -495,13 +495,13 @@ is-pairV-ext (sup A f) (sup B g) p q =
         d2 : # (g b2)
         d2 = pj1 (prj1 ts2 c2)
 
-     
+
         eq6 : (f a1) ‣ c1 ≐ (g b1) ‣ d1
         eq6 = pj2 (prj1 ts c1)
         eq7 : (f a2) ‣ c2 ≐ (g b2) ‣ d2
         eq7 = pj2 (prj1 ts2 c2)
 
-        lm2- :  < ((f a1) ‣ c1) , ((f a2) ‣ c2) >  
+        lm2- :  < ((f a1) ‣ c1) , ((f a2) ‣ c2) >
                 ≐ < ((g (pj1 (prj1 p (pj1 q)))) ‣ d1) ,  ((g (pj1 (prj1 p (pj1 (pj2 q))))) ‣ d2) >
         lm2- = pairV-ext eq6 eq7
         lm2 : sup B g ≐ < ((g (pj1 (prj1 p (pj1 q)))) ‣ d1) ,
@@ -514,14 +514,14 @@ is-pairV-ext (sup A f) (sup B g) p q =
                          < (g b1) ‣ c , (g b2) ‣ d >))
         main = d1 , (d2 , lm2)
 
-    in b1 , (b2 , main) 
+    in b1 , (b2 , main)
 
 is-pairV1-0 : (u : V) -> is-pairV1 u -> is-pairV u
-is-pairV1-0 u p = 
+is-pairV1-0 u p =
      let lm :  u ≐ < (is-pairV1.cp1 p) , (is-pairV1.cp2 p) >
          lm =  is-pairV1.eqp p
          lm2 : is-pairV (<  (is-pairV1.cp1 p) , (is-pairV1.cp2 p) > )
-         lm2 = (inl 0₁) , ((inr 0₁) , ((inl 0₁) , ((inr 0₁) , (refV _))))        
+         lm2 = (inl 0₁) , ((inr 0₁) , ((inl 0₁) , ((inr 0₁) , (refV _))))
      in is-pairV-ext _ _ (symV lm) lm2
 
 
@@ -537,16 +537,16 @@ is-functional : (u : V) -> Set1
 is-functional u = (x y z : V) -> < x , y > ∈ u -> < x , z > ∈ u -> y ≐ z
 
 is-total-on : (u a : V) -> Set1
-is-total-on u a = (x  : V) -> x ∈ a -> Σ10 V (\y ->  (< x , y > ∈ u)) 
+is-total-on u a = (x  : V) -> x ∈ a -> Σ10 V (\y ->  (< x , y > ∈ u))
 
 -- Canonical setoids from V
 -- construct the canonical setoid  κ u  corresponding to a set u in V
 
 can-std : V -> setoid
-can-std a = record { object = # a  
+can-std a = record { object = # a
                    ; _∼_ = λ x y → a ‣ x ≐ a ‣ y
-                   ; eqrel = pair (λ x → refV (a ‣ x)) 
-                                  (pair (λ x y p → symV p) 
+                   ; eqrel = pair (λ x → refV (a ‣ x))
+                                  (pair (λ x y p → symV p)
                                         (λ x y z p q → traV p q)) }
 
 κ : V -> setoid  -- \kappa for canonical setoid
@@ -557,8 +557,8 @@ can-std a = record { object = # a
 
 κ-trp-ext : {a b : V} -> (p : a ≐ b) ->  (x y : || κ a ||)
       ->  < κ a > x ~ y ->  < κ b > κ-trp-op p x ~ κ-trp-op p y
-κ-trp-ext {a} {b} p x y q = <> (traV (traV (symV (e+prop p x)) (>< q)) (e+prop p y)) 
-    
+κ-trp-ext {a} {b} p x y q = <> (traV (traV (symV (e+prop p x)) (>< q)) (e+prop p y))
+
 
 
 
@@ -590,11 +590,11 @@ can-std a = record { object = # a
 -- V is a "locally small setoid" i.e. a classoid
 
 VV : classoid
-VV = record { object = V 
-            ; _∼_ = eqV 
-            ; eqrel = record { rf' = refl-eqV 
-                             ; sy' = sym-eqV 
-                             ; tr' = tra-eqV } 
+VV = record { object = V
+            ; _∼_ = eqV
+            ; eqrel = record { rf' = refl-eqV
+                             ; sy' = sym-eqV
+                             ; tr' = tra-eqV }
             }
 
 
@@ -602,17 +602,17 @@ VV = record { object = V
 -- a classoid. The operation  κ  form the main example.
 
 record Fam10 (A : classoid) : Set2 where
-  field 
+  field
      std : ||| A ||| -> setoid
      trp : {a b : ||| A |||} -> (p : << A >> a ~ b) -> || (std a) => (std b) ||
-     id-trp : {a : ||| A |||} -> (p : << A >> a ~ a) -> 
+     id-trp : {a : ||| A |||} -> (p : << A >> a ~ a) ->
                (x : || std a ||) -> < std a > ap (trp p) x ~ x
-     ir-trp : {a b : ||| A |||} -> (p  q : << A >> a ~ b) ->  
+     ir-trp : {a b : ||| A |||} -> (p  q : << A >> a ~ b) ->
                (x : || std a ||) -> < std b > ap (trp p) x ~ ap (trp q) x
      fn-trp : {a b c : ||| A |||} -> (q : << A >> b ~ c) -> (p : << A >> a ~ b) ->  (r : << A >> a ~ c) ->
-               (x : || std a ||) -> < std c >  ap (trp r) x ~ ap (trp q) (ap (trp p) x) 
+               (x : || std a ||) -> < std c >  ap (trp r) x ~ ap (trp q) (ap (trp p) x)
 
-infix 5 _§§_ 
+infix 5 _§§_
 
 _§§_ : {A : classoid} -> (F : Fam10 A) -> (a : ||| A |||) -> setoid
 _§§_ F a = Fam10.std F a
@@ -624,18 +624,18 @@ _±±_ F p = Fam10.trp F p
 
 
 Fam10-flip : (A : classoid) -> (F : Fam10 A) -> (a b : ||| A |||) -> (p : << A >>  a ~ b) ->
-       (x : || F §§ a ||) ->  (y : || F §§ b ||) -> 
-       < F §§ b > ap (F ±± p) x ~ y  ->  < F §§ a >  x  ~  ap (F ±± (sym' p)) y 
-Fam10-flip A F a b p x y q = 
-                           let lm1 : < F §§ a > ap (F ±± (sym' p)) (ap (F ±± p) x) 
+       (x : || F §§ a ||) ->  (y : || F §§ b ||) ->
+       < F §§ b > ap (F ±± p) x ~ y  ->  < F §§ a >  x  ~  ap (F ±± (sym' p)) y
+Fam10-flip A F a b p x y q =
+                           let lm1 : < F §§ a > ap (F ±± (sym' p)) (ap (F ±± p) x)
                                      ~ ap (F ±± (sym' p)) y
                                lm1 = extensionality (F ±± (sym' p)) (ap (F ±± p) x) y q
                                lm2 : < F §§ a > x  ~ ap (F ±± (sym' p)) (ap (F ±± p) x)
-                               lm2 = tra  (sym (Fam10.id-trp F (refl' A a) x)) 
+                               lm2 = tra  (sym (Fam10.id-trp F (refl' A a) x))
                                                        (Fam10.fn-trp F _ _ _ x)
                                main : < F §§ a > x  ~  ap (F ±± (sym' p)) y
                                main = tra lm2 lm1
-                           in  main 
+                           in  main
 
 
 
@@ -644,14 +644,14 @@ Fam10-inv-eq : (A : classoid) -> (F : Fam10 A) -> (a b : ||| A  |||) -> (p : << 
        < F §§ b > ap (F ±± p) (ap (F ±± (sym' p)) x) ~  x
 Fam10-inv-eq A F a b p x = tra (sym (Fam10.fn-trp F _ _ _ x)) (Fam10.id-trp F (refl' A b) x)
 
-Fam10-trp-fn2 : (A : classoid) -> (F : Fam10 A) -> (a b c d : ||| A  |||) 
-          -> (q : << A >>  b ~ c) -> (p : << A >>  a ~ b) 
-          -> (r : << A >>  d ~ c) -> (u : << A >>  a ~ d) 
+Fam10-trp-fn2 : (A : classoid) -> (F : Fam10 A) -> (a b c d : ||| A  |||)
+          -> (q : << A >>  b ~ c) -> (p : << A >>  a ~ b)
+          -> (r : << A >>  d ~ c) -> (u : << A >>  a ~ d)
           -> (x : || F §§ a ||) -> < F §§ c > ap (F ±± q) (ap (F ±± p) x) ~ ap (F ±± r) (ap (F ±± u) x)
-Fam10-trp-fn2 A F a b c d q p r u x = tra (sym (Fam10.fn-trp F q p (tra' p q) x)) 
+Fam10-trp-fn2 A F a b c d q p r u x = tra (sym (Fam10.fn-trp F q p (tra' p q) x))
                                                    (Fam10.fn-trp F r u (tra' p q) x)
-Fam10-inv-gen : (A : classoid) -> (F : Fam10 A) -> (a b : ||| A  |||) 
-       -> (p : << A >>  a ~ b) -> (q : << A >>  b ~ a) 
+Fam10-inv-gen : (A : classoid) -> (F : Fam10 A) -> (a b : ||| A  |||)
+       -> (p : << A >>  a ~ b) -> (q : << A >>  b ~ a)
        ->  (x : || F §§ b ||) ->
        < F §§ b > ap (F ±± p) (ap (F ±±  q) x) ~  x
 Fam10-inv-gen A F a b p q x = tra (sym (Fam10.fn-trp F _ _ _ x)) (Fam10.id-trp F (refl' A b) x)
@@ -662,10 +662,10 @@ Fam10-inv-gen A F a b p q x = tra (sym (Fam10.fn-trp F _ _ _ x)) (Fam10.id-trp F
 
 κ-Fam : Fam10 VV
 κ-Fam = record { std = κ
-               ; trp = λ p →  κ-trp (>><< p) 
-               ; id-trp = λ p x → κ-trp-id (>><< p) x 
-               ; ir-trp = λ p q x → κ-trp-irr (>><< p) (>><< q) x 
-               ; fn-trp = λ q p r x →  κ-trp-fn (>><< q) (>><< p) (>><< r) x 
+               ; trp = λ p →  κ-trp (>><< p)
+               ; id-trp = λ p x → κ-trp-id (>><< p) x
+               ; ir-trp = λ p q x → κ-trp-irr (>><< p) (>><< q) x
+               ; fn-trp = λ q p r x →  κ-trp-fn (>><< q) (>><< p) (>><< r) x
                }
 
 
@@ -675,9 +675,9 @@ infix 5 _⊙⊙_
 -- compose 10-family with 01-function
 
 _⊙⊙_ : {A : setoid} -> {B : classoid} -> (F : Fam10 B) -> (f : setoidmap1 A B) -> Fam A
-_⊙⊙_ {A} {B} F f = 
+_⊙⊙_ {A} {B} F f =
        record{ std = λ x →  F §§ (ap1 f x);
-               trp = λ p → record { op =  λ x →  ap (F ±± (extensionality1 f _ _ p)) x ; 
+               trp = λ p → record { op =  λ x →  ap (F ±± (extensionality1 f _ _ p)) x ;
                                    ext = λ x y q → extensionality (F ±± (extensionality1 f _ _ p)) x y q };
                id-trp = λ p x →  Fam10.id-trp F (extensionality1 f _ _ p) x ;
                ir-trp = λ p q x → Fam10.ir-trp F (extensionality1 f _ _ p) (extensionality1 f _ _ q) x;
@@ -693,20 +693,20 @@ _⊙⊙_ {A} {B} F f =
 
 κ° g = κ-Fam ⊙⊙ g
 
-κ°-trp-prop : {A : setoid} -> (g : setoidmap1 A VV) 
+κ°-trp-prop : {A : setoid} -> (g : setoidmap1 A VV)
              -> (a b : || A ||) -> (p : < A > a ~ b)
              -> (x : || κ (g • a) ||)
              -> ((g • a) ‣ x) ≐ ((g • b) ‣ (ap (κ° g ± p) x))
 κ°-trp-prop {A} g a b p x =
   let lm :  ap1 g a ≐ ap1 g b
-      lm = >><< (extensionality1 g _ _ p) 
-  in  e+prop lm x 
+      lm = >><< (extensionality1 g _ _ p)
+  in  e+prop lm x
 
 
- 
 
 
-κ°-trp-prop2 : {A : setoid} -> (g : setoidmap1 A VV) 
+
+κ°-trp-prop2 : {A : setoid} -> (g : setoidmap1 A VV)
                -> (a b : || A ||) -> (p : < A > a ~ b)
                -> (x : || κ (g • a) ||)
                -> < κ (g • b) >   (ap (κ° g ± p) x) ~  (ap (κ-Fam ±± (extensionality1 g a b p)) x) -- (ap (κ° g ± p) x)
@@ -720,10 +720,10 @@ _⊙⊙_ {A} {B} F f =
 Sub-to-V : (S : subsetoid VV) -> V
 Sub-to-V S = sup (|| δ S ||) (ap1 (ι S))
 
--- the operation is extensional 
+-- the operation is extensional
 
 ext-Sub-to-V-lm : (S T : subsetoid VV) -> (inclusion-subsetoids S T) -> (Sub-to-V S) ⊆ (Sub-to-V T)
-ext-Sub-to-V-lm S T p = 
+ext-Sub-to-V-lm S T p =
     λ x q ->  let q' : Σ || δ S || (λ y → x ≐ (ι S) • y)
                   q' = q
                   y :  || δ S ||
@@ -742,35 +742,35 @@ ext-Sub-to-V-lm S T p =
               in main
 
 -- inclusion-subsetoids : {B : classoid} -> (S  T : subsetoid B) -> Set
--- inclusion-subsetoids {B} S T = Σ (|| δ S => δ T ||) (\f -> exteq1  (ι S) (comp1 (ι T) f)) 
+-- inclusion-subsetoids {B} S T = Σ (|| δ S => δ T ||) (\f -> exteq1  (ι S) (comp1 (ι T) f))
 
 
 
 
 ext-Sub-to-V :  (S T : subsetoid VV) -> equal-subsetoids S T -> (Sub-to-V S) ≐ (Sub-to-V T)
-ext-Sub-to-V S T p = extensional-eqV (Sub-to-V S) (Sub-to-V T) 
-                                     (ext-Sub-to-V-lm S T (prj1 p)) 
+ext-Sub-to-V S T p = extensional-eqV (Sub-to-V S) (Sub-to-V T)
+                                     (ext-Sub-to-V-lm S T (prj1 p))
                                      (ext-Sub-to-V-lm T S (prj2 p))
 V-to-Sub-iota-op : (u : V) -> || κ u || -> V
 V-to-Sub-iota-op u a = u ‣ a
 
-V-to-Sub-iota-ext : (u : V) ->  (a b : || κ u ||) 
-         -> < κ u > a ~ b 
+V-to-Sub-iota-ext : (u : V) ->  (a b : || κ u ||)
+         -> < κ u > a ~ b
          -> << VV >> V-to-Sub-iota-op u a ~ V-to-Sub-iota-op u b
 V-to-Sub-iota-ext u a b p = <<>> (>< p)
 
-V-to-Sub-iota-inj : (u : V) ->  (a b : || κ u ||) 
+V-to-Sub-iota-inj : (u : V) ->  (a b : || κ u ||)
          -> << VV >> V-to-Sub-iota-op u a ~ V-to-Sub-iota-op u b
-         -> < κ u > a ~ b 
+         -> < κ u > a ~ b
 V-to-Sub-iota-inj u a b p = <> (>><< p)
 
 V-to-Sub-iota : (u : V) -> setoidmap1 (κ u) VV
-V-to-Sub-iota u = record { op = V-to-Sub-iota-op u 
+V-to-Sub-iota u = record { op = V-to-Sub-iota-op u
                          ; ext =  V-to-Sub-iota-ext u }
 
-V-to-Sub : V -> subsetoid VV 
-V-to-Sub u = record { delta = κ u 
-                    ; iota = V-to-Sub-iota u 
+V-to-Sub : V -> subsetoid VV
+V-to-Sub u = record { delta = κ u
+                    ; iota = V-to-Sub-iota u
                     ; inj = V-to-Sub-iota-inj u }
 
 
@@ -786,7 +786,7 @@ ext-V-to-Sub-half :  (u v : V) -> u ≐ v -> inclusion-subsetoids (V-to-Sub u) (
 ext-V-to-Sub-half u v q = inclusion-lm-1-0 (V-to-Sub u) (V-to-Sub v)
                                 (λ x p → membV-member x v (memV-right-ext x u v (member-membV x u p) q))
 
-ext-V-to-Sub :  (u v : V) -> u ≐ v -> equal-subsetoids (V-to-Sub u) (V-to-Sub v) 
+ext-V-to-Sub :  (u v : V) -> u ≐ v -> equal-subsetoids (V-to-Sub u) (V-to-Sub v)
 ext-V-to-Sub u v p = pair (ext-V-to-Sub-half u v p) (ext-V-to-Sub-half v u (symV p))
 
 
@@ -796,14 +796,14 @@ ext-V-to-Sub u v p = pair (ext-V-to-Sub-half u v p) (ext-V-to-Sub-half v u (symV
 -- The isomorphism V ≅ Pow(V)
 
 subsetoids-VV :  setoidmap11 (subsetoids VV) VV
-subsetoids-VV = record { op = Sub-to-V 
-                       ; ext = λ x y p → <<>> (ext-Sub-to-V x y (>><< p))  
+subsetoids-VV = record { op = Sub-to-V
+                       ; ext = λ x y p → <<>> (ext-Sub-to-V x y (>><< p))
                        }
 
 
-VV-subsetoids : setoidmap11 VV (subsetoids VV) 
-VV-subsetoids = record { op = V-to-Sub 
-                       ; ext = λ x y p → <<>> ( ext-V-to-Sub x y (>><< p)) 
+VV-subsetoids : setoidmap11 VV (subsetoids VV)
+VV-subsetoids = record { op = V-to-Sub
+                       ; ext = λ x y p → <<>> ( ext-V-to-Sub x y (>><< p))
                        }
 
 VV-subsetoids-inv-right : (u : ||| VV |||) ->
@@ -812,7 +812,7 @@ VV-subsetoids-inv-right (sup a f) = <<>> (refV (sup a f))
 
 VV-subsetoids-inv-left : (A : ||| subsetoids VV |||) ->
   << subsetoids VV >> ap11  VV-subsetoids (ap11 subsetoids-VV A) ~ A
-VV-subsetoids-inv-left A = <<>> (equal-lm-1-0 (ap11 VV-subsetoids (ap11 subsetoids-VV A)) A 
+VV-subsetoids-inv-left A = <<>> (equal-lm-1-0 (ap11 VV-subsetoids (ap11 subsetoids-VV A)) A
                                    (λ x → pair (λ p → p) (λ p → p)))
 
 
@@ -827,40 +827,40 @@ make-function a g = sup (# a) (\x -> < a ‣ x , g • x >)
 
 
 make-function-lm : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
-  (x y : V) -> (< x , y > ∈ make-function a g) -> 
+  (x y : V) -> (< x , y > ∈ make-function a g) ->
   Σ (# a) (\u -> < x , y > ≐ < a ‣ u , g • u >)
-make-function-lm a g x y p = 
+make-function-lm a g x y p =
   let  mf = make-function a g
        u = pj1 p
        lm1 : < x , y > ≐ mf ‣ u
        lm1 = pj2 p
-  in u , lm1 
+  in u , lm1
 
 
 make-function-lm2 : (a : V) -> (g :  setoidmap1 (κ a) VV) ->
-  (x y : V) -> 
+  (x y : V) ->
   Σ (# a) (\u -> < x , y > ≐ < a ‣ u , g • u >) ->
   (< x , y > ∈ make-function a g)
 make-function-lm2 a g x y p = p
 
-make-function-is-set-of-pairs1-lm : (a : V) 
+make-function-is-set-of-pairs1-lm : (a : V)
    -> (g :  setoidmap1 (κ a) VV) -> (y : # (make-function a g))
    -> is-pairV1 ((make-function a g) ‣ y)
 make-function-is-set-of-pairs1-lm (sup A f) g y = record { cp1 = _ ; cp2 = _ ; eqp = refl-eqV _ }
 
-make-function-is-set-of-pairs1 :  (a : V) -> (g :  setoidmap1 (κ a) VV) 
+make-function-is-set-of-pairs1 :  (a : V) -> (g :  setoidmap1 (κ a) VV)
   -> is-set-of-pairs1 (make-function a g)
-make-function-is-set-of-pairs1 a g z p = 
+make-function-is-set-of-pairs1 a g z p =
    let mf = make-function a g
-       y = pj1 p 
+       y = pj1 p
        lm1 : z ≐ (bV mf y)
-       lm1 = pj2 p 
+       lm1 = pj2 p
        lm2 : is-pairV1 (bV mf y)
        lm2 = make-function-is-set-of-pairs1-lm a g y
    in is-pairV1-ext _ _ (symV lm1) lm2
 
 
-make-function-is-functional :  (a : V) -> (g :  setoidmap1 (κ a) VV) 
+make-function-is-functional :  (a : V) -> (g :  setoidmap1 (κ a) VV)
   -> is-functional (make-function a g)
 make-function-is-functional a g x y z p q =
    let q1 : Σ (# a) (\u -> < x , z > ≐ < a ‣ u , g • u >)
@@ -880,26 +880,26 @@ make-function-is-functional a g x y z p q =
        eq3 : a ‣ u ≐ a ‣ v
        eq3 = traV (symV eq1) eq2
        lm : ap1 g u ≐ ap1 g v
-       lm = >><< (extensionality1 g u v (<> eq3)) 
+       lm = >><< (extensionality1 g u v (<> eq3))
        eq4 :  z ≐  ap1 g u
        eq4 = prj2 (pairV-inv-1 q1b)
-       eq5 :  y ≐  ap1 g v   
+       eq5 :  y ≐  ap1 g v
        eq5 = prj2 (pairV-inv-1 p1b)
 
    in symV (traV eq4 (traV lm (symV eq5)))
 
 
-make-function-is-total :  (a : V) -> (g :  setoidmap1 (κ a) VV) 
+make-function-is-total :  (a : V) -> (g :  setoidmap1 (κ a) VV)
   -> is-total-on (make-function a g) a
-make-function-is-total a g x p = 
+make-function-is-total a g x p =
     let  p1 :  Σ (# a) (\y -> x ≐ a ‣ y)
-         p1 = p 
+         p1 = p
          p2 : x ≐ (a  ‣ (pj1 p1))
          p2 = pj2 p1
          lm :  Σ (# a) (λ u →
                  < x , g • (pj1 p) > ≐
                  < a ‣ u , g • u >)
-         lm = pj1 p1 , pairV-ext p2 (refV _) 
+         lm = pj1 p1 , pairV-ext p2 (refV _)
          main : Σ10 V (λ y → < x , y > ∈ make-function a g)
          main = ap1 g (pj1 p1) , make-function-lm2 a g _ _ lm
     in main

--- a/MLTT-and-setoids/subsetoids.agda
+++ b/MLTT-and-setoids/subsetoids.agda
@@ -36,13 +36,13 @@ exteq1 {A} {B} f g = (x : || A ||) ->  << B >> (f • x) ~ (g • x)
 setoidmaps1 : (A : setoid) -> (B : classoid) -> classoid
 setoidmaps1 A B = record {object = setoidmap1 A B
                           ; _∼_  =  exteq1 {A} {B}
-                          ; eqrel = record { rf' = λ f x → refl' B (f • x) 
-                                           ; sy' = λ f g p x → sym' {B} (p x) 
+                          ; eqrel = record { rf' = λ f x → refl' B (f • x)
+                                           ; sy' = λ f g p x → sym' {B} (p x)
                                            ; tr' = λ f g h p q x → tra' {B} (p x) (q x) }
                          }
 
 
-extensionality1 : {A : setoid} -> {B : classoid} -> (f : setoidmap1 A B) -> (x y : || A ||) -> 
+extensionality1 : {A : setoid} -> {B : classoid} -> (f : setoidmap1 A B) -> (x y : || A ||) ->
              (< A > x ~ y) ->  (<< B >> (f • x) ~ (f • y))
 extensionality1 {A} {B} f x y p = (setoidmap1.ext f x y) p
 
@@ -53,11 +53,11 @@ is-injective1 {A} {B} f = (x y : || A ||) -> (<< B >> (f • x) ~ (f • y)) -> 
 
 
 comp1 : {A B : setoid} -> {C : classoid} -> (f : setoidmap1 B C) -> (g : || A => B ||) -> setoidmap1 A C
-comp1 {A} {B} {C} f g =  record { op =   (\x -> ap1 f (ap g x)) 
-                                ; ext = λ x y p → setoidmap1.ext f (ap g x) (ap g y) 
+comp1 {A} {B} {C} f g =  record { op =   (\x -> ap1 f (ap g x))
+                                ; ext = λ x y p → setoidmap1.ext f (ap g x) (ap g y)
                                                                     (setoidmap.ext g x y p)
                                }
-        
+
 
 
 record setoidmap11 (A B : classoid) : Set1 where
@@ -69,29 +69,29 @@ ap11 : {A B : classoid} -> (f : setoidmap11 A B) -> (a : ||| A  |||) -> ||| B ||
 ap11 f a = setoidmap11.op f a
 
 
-extensionality11 : {A B : classoid} -> (f : setoidmap11 A B) -> (x y : ||| A |||) -> 
+extensionality11 : {A B : classoid} -> (f : setoidmap11 A B) -> (x y : ||| A |||) ->
              (<< A >> x ~ y) ->  (<< B >> (ap11 f x) ~ (ap11 f  y))
 extensionality11 {A} {B} f x y p = (setoidmap11.ext f x y) p
 
 
 
 comp11 : {A B C : classoid} -> (f : setoidmap11 B C) -> (g : setoidmap11 A B) -> setoidmap11 A C
-comp11 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap11 g x)) 
-                                ; ext = λ x y p → setoidmap11.ext f (ap11 g x) (ap11 g y) 
+comp11 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap11 g x))
+                                ; ext = λ x y p → setoidmap11.ext f (ap11 g x) (ap11 g y)
                                                                     (setoidmap11.ext g x y p)
                                }
 
 comp01 : {A : setoid} -> {B C : classoid} -> (f : setoidmap11 B C) -> (g : setoidmap1 A B) -> setoidmap1 A C
-comp01 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap1 g x)) 
-                                ; ext = λ x y p → setoidmap11.ext f (ap1 g x) (ap1 g y) 
+comp01 {A} {B} {C} f g =  record { op =   (\x -> ap11 f (ap1 g x))
+                                ; ext = λ x y p → setoidmap11.ext f (ap1 g x) (ap1 g y)
                                                                     (setoidmap1.ext g x y p)
                                }
 
 --}
 
-                          
+
 record subsetoid (B : classoid) : Set1 where
-  field               
+  field
     delta : setoid
     iota : setoidmap1 delta B
     inj : is-injective1 iota
@@ -109,7 +109,7 @@ member : {B : classoid} -> (x : ||| B |||) -> (S : subsetoid B) -> Set
 member {B} x S =  Σ (|| δ S ||) (\u -> << B >>  (ap1 (ι S) u) ~  x)
 
 member-inj-lm : {B : classoid}  -> (S : subsetoid B) -> (u v : || δ S ||) ->
-     << B >>  (ap1 (ι S) u) ~ (ap1 (ι S) v) -> <  δ S > u ~ v 
+     << B >>  (ap1 (ι S) u) ~ (ap1 (ι S) v) -> <  δ S > u ~ v
 member-inj-lm {B} S u v p = subsetoid.inj S u v p
 
 member-inj-lm2 : {B : classoid}  -> (S : subsetoid B) -> (u : || δ S ||) ->
@@ -120,43 +120,43 @@ inclusion-subsetoids1 : {B : classoid} -> (S  T : subsetoid B) -> Set1
 inclusion-subsetoids1 {B} S T = (x : ||| B |||) -> (member x S) -> (member x T)
 
 inclusion-subsetoids : {B : classoid} -> (S  T : subsetoid B) -> Set
-inclusion-subsetoids {B} S T = Σ (|| δ S => δ T ||) (\f -> exteq1  (ι S) (comp1 (ι T) f)) 
+inclusion-subsetoids {B} S T = Σ (|| δ S => δ T ||) (\f -> exteq1  (ι S) (comp1 (ι T) f))
 
 θ : {B : classoid} -> (S  T : subsetoid B) -> inclusion-subsetoids S T -> || δ S => δ T ||
 θ S T p = pj1 p
 
-θ-prop : {B : classoid} -> (S  T : subsetoid B) -> (p : inclusion-subsetoids S T) -> 
+θ-prop : {B : classoid} -> (S  T : subsetoid B) -> (p : inclusion-subsetoids S T) ->
     exteq1 (ι S) (comp1 (ι T) (θ S T p))
 θ-prop S T p =  pj2 p
 
 
 
-θ-id : {B : classoid} -> (S : subsetoid B) -> (p : inclusion-subsetoids S S) -> 
-    < δ S => δ S > θ S S p ~ idmap 
-θ-id {B} S p =  <> (λ x → let lm :   exteq1(ι S)  (comp1 (ι S) (θ S S p)) 
+θ-id : {B : classoid} -> (S : subsetoid B) -> (p : inclusion-subsetoids S S) ->
+    < δ S => δ S > θ S S p ~ idmap
+θ-id {B} S p =  <> (λ x → let lm :   exteq1(ι S)  (comp1 (ι S) (θ S S p))
                               lm = θ-prop S S p
                           in sym {δ S} (ι-inj S _ _ (lm x)))
 
 
 
-θ-ir : {B : classoid} -> (S  T : subsetoid B) -> (p q : inclusion-subsetoids S T) -> 
-    < δ S => δ T > θ S T p ~ θ S T q 
-θ-ir {B} S T p q = 
+θ-ir : {B : classoid} -> (S  T : subsetoid B) -> (p q : inclusion-subsetoids S T) ->
+    < δ S => δ T > θ S T p ~ θ S T q
+θ-ir {B} S T p q =
                  <>  (
-                    let lm :   exteq1 (comp1 (ι T) (θ S T p))  (comp1 (ι T) (θ S T q)) 
+                    let lm :   exteq1 (comp1 (ι T) (θ S T p))  (comp1 (ι T) (θ S T q))
                         lm = λ x → tra' {B} (sym' {B} (θ-prop {B} S T p x)) (θ-prop {B} S T q x)
                     in λ x → ι-inj T _ _ (lm x))
 
 
 
-θ-fn : {B : classoid} -> (R S T : subsetoid B) 
-       -> (p : inclusion-subsetoids R S) 
-       -> (q : inclusion-subsetoids S T) 
+θ-fn : {B : classoid} -> (R S T : subsetoid B)
+       -> (p : inclusion-subsetoids R S)
+       -> (q : inclusion-subsetoids S T)
        -> (r : inclusion-subsetoids R T) ->
-    < δ R => δ T > (θ R T r) ~ ((θ S T q) ° (θ R S p)) 
-θ-fn {B} R S T p q r 
-       = <> (λ x → 
-                (let lm1 : exteq1 (ι R) (comp1 (ι S) (θ R S p))  
+    < δ R => δ T > (θ R T r) ~ ((θ S T q) ° (θ R S p))
+θ-fn {B} R S T p q r
+       = <> (λ x →
+                (let lm1 : exteq1 (ι R) (comp1 (ι S) (θ R S p))
                      lm1 = θ-prop R S p
                      lm2 : exteq1 (ι S) (comp1 (ι T) (θ S T q))
                      lm2 = θ-prop S T q
@@ -165,7 +165,7 @@ inclusion-subsetoids {B} S T = Σ (|| δ S => δ T ||) (\f -> exteq1  (ι S) (co
                      lm :  << B >> ap1 (ι T) (ap (θ R T r) x)  ~ ap1 (ι T) (ap (θ S T q) (ap (θ R S p)  x))
                      lm = tra' {B} (sym' {B} (lm3 x)) (tra' {B} (lm1 x) (lm2 _))
                      main' :  < δ T > ap (θ R T r) x ~ ap (θ S T q) (ap (θ R S p)  x)
-                     main' = ι-inj T _ _ lm                  
+                     main' = ι-inj T _ _ lm
                      main :  < δ T > ap (θ R T r) x ~ ap ((θ S T q) ° (θ R S p))  x
                      main = main'
                  in main))
@@ -174,19 +174,19 @@ inclusion-subsetoids {B} S T = Σ (|| δ S => δ T ||) (\f -> exteq1  (ι S) (co
 
 
 
-inclusion-subsetoids1-op : {B : classoid} -> (S  T : subsetoid B) 
+inclusion-subsetoids1-op : {B : classoid} -> (S  T : subsetoid B)
   -> (p : inclusion-subsetoids1 {B} S T)
   -> || δ S || -> || δ T ||
-inclusion-subsetoids1-op {B} S T p u = pj1 ( p (ap1 (ι S) u) (member-inj-lm2 {B} S u)) 
+inclusion-subsetoids1-op {B} S T p u = pj1 ( p (ap1 (ι S) u) (member-inj-lm2 {B} S u))
 
 
 
-inclusion-subsetoids1-fun : {B : classoid} -> (S  T : subsetoid B) 
+inclusion-subsetoids1-fun : {B : classoid} -> (S  T : subsetoid B)
   -> (p : inclusion-subsetoids1 {B} S T)
-  -> || δ S => δ T ||                                    
-inclusion-subsetoids1-fun {B} S T p 
-    = record { op = inclusion-subsetoids1-op S T p 
-             ; ext = λ x y q → 
+  -> || δ S => δ T ||
+inclusion-subsetoids1-fun {B} S T p
+    = record { op = inclusion-subsetoids1-op S T p
+             ; ext = λ x y q →
                    let q' : < δ S > x ~ y
                        q' = q
                        p' :  (x : ||| B |||) -> (member x S) -> (member x T)
@@ -199,20 +199,20 @@ inclusion-subsetoids1-fun {B} S T p
                        p2 = p' ((ι S) • y) (member-inj-lm2 S y)
                        p22 : << B >> ((ι T) • (pj1 (p ((ι S) • y) (member-inj-lm2 S y))))  ~  ((ι S) • y)
                        p22 = pj2 p2
-                       eq :  << B >>  ((ι S) • x) ~ ((ι S) • y) 
+                       eq :  << B >>  ((ι S) • x) ~ ((ι S) • y)
                        eq = extensionality1 (ι S) x y q'
                        lm :  << B >> ap1 (ι T) (pj1 (p (ap1 (ι S) x) (member-inj-lm2 S x)))  ~
-                                     ap1 (ι T) (pj1 (p (ap1 (ι S) y) (member-inj-lm2 S y))) 
+                                     ap1 (ι T) (pj1 (p (ap1 (ι S) y) (member-inj-lm2 S y)))
                        lm = tra' {B} p12 (tra' {B} eq (sym' {B} p22))
                        main : < δ T > inclusion-subsetoids1-op S T p x ~
                                       inclusion-subsetoids1-op S T p y
-                       main = member-inj-lm {B} T _ _ lm 
+                       main = member-inj-lm {B} T _ _ lm
                    in main }
 
 
 inclusion-lm-1-0 : {B : classoid} -> (S  T : subsetoid B) ->
         inclusion-subsetoids1 S T ->  inclusion-subsetoids S T
-inclusion-lm-1-0 {B} S T p = inclusion-subsetoids1-fun {B} S T p  , 
+inclusion-lm-1-0 {B} S T p = inclusion-subsetoids1-fun {B} S T p  ,
                    (λ x -> let p1 : member (ap1 (ι S) x) T
                                p1 = p (ap1 (ι S) x) (member-inj-lm2 S x)
                                p12 : << B >> ap1 (ι T) (pj1 (p (ap1 (ι S) x) (member-inj-lm2 S x)))  ~ ap1 (ι S) x
@@ -225,8 +225,8 @@ inclusion-lm-1-0 {B} S T p = inclusion-subsetoids1-fun {B} S T p  ,
 
 inclusion-lm-0-1 : {B : classoid} -> (S  T : subsetoid B) ->
         inclusion-subsetoids S T ->  inclusion-subsetoids1 S T
-inclusion-lm-0-1 {B} S T p = λ x q → 
-         ap (pj1 p) (pj1 q) ,  
+inclusion-lm-0-1 {B} S T p = λ x q →
+         ap (pj1 p) (pj1 q) ,
         let lm : << B >>  ap1 (ι S) (pj1 q) ~ x
             lm = pj2 q
             main : << B >> ap1 (ι T) (ap (pj1 p) (pj1 q)) ~ x
@@ -243,33 +243,33 @@ equal-subsetoids {B} S T = and (inclusion-subsetoids S T)  (inclusion-subsetoids
 
 equal-lm-1-0 : {B : classoid} -> (S  T : subsetoid B) ->
         equal-subsetoids1 S T ->  equal-subsetoids S T
-equal-lm-1-0 S T p = pair (inclusion-lm-1-0 S T (λ x q → prj1 (p x) q)) 
+equal-lm-1-0 S T p = pair (inclusion-lm-1-0 S T (λ x q → prj1 (p x) q))
                           (inclusion-lm-1-0 T S (λ x q → prj2 (p x) q))
 
 equal-lm-0-1 : {B : classoid} -> (S  T : subsetoid B) ->
         equal-subsetoids S T ->  equal-subsetoids1 S T
-equal-lm-0-1 {B} S T p = λ x → pair (inclusion-lm-0-1 {B} S T (prj1 p) x) 
+equal-lm-0-1 {B} S T p = λ x → pair (inclusion-lm-0-1 {B} S T (prj1 p) x)
                                     (inclusion-lm-0-1 {B} T S (prj2 p) x)
 
 
 
 
 subsetoids :  classoid -> classoid
-subsetoids B = record { object = subsetoid B 
-                      ; _∼_ = equal-subsetoids 
-                      ; eqrel = record { rf' = λ S → equal-lm-1-0 S S (λ x → pair (λ p → p) (λ p → p)) 
-                                       ; sy' = λ S T p → pair (prj2 p) (prj1 p) 
-                                       ; tr' = λ S T M p q → 
-                                          equal-lm-1-0 S M (λ x → 
+subsetoids B = record { object = subsetoid B
+                      ; _∼_ = equal-subsetoids
+                      ; eqrel = record { rf' = λ S → equal-lm-1-0 S S (λ x → pair (λ p → p) (λ p → p))
+                                       ; sy' = λ S T p → pair (prj2 p) (prj1 p)
+                                       ; tr' = λ S T M p q →
+                                          equal-lm-1-0 S M (λ x →
                                                  pair (λ hy → prj1 (equal-lm-0-1 T M q x) (prj1 (equal-lm-0-1 S T p x) hy))
-                                                      (λ hy → prj2 (equal-lm-0-1 S T p x) (prj2 (equal-lm-0-1 T M q x) hy))) 
+                                                      (λ hy → prj2 (equal-lm-0-1 S T p x) (prj2 (equal-lm-0-1 T M q x) hy)))
                                        }
                       }
 
 
 
-eq-lemma : (B : classoid) -> (S  T : ||| subsetoids B |||) 
-          -> << subsetoids B >> S ~ T -> (x : ||| B |||) 
+eq-lemma : (B : classoid) -> (S  T : ||| subsetoids B |||)
+          -> << subsetoids B >> S ~ T -> (x : ||| B |||)
           ->  member x S -> member x T
 eq-lemma B S T p x =  prj1 (equal-lm-0-1 S T (>><< p) x)
 
@@ -298,68 +298,68 @@ BFam-Fam-std A B S x =  δ (S • x)
 
 
 
-BFam-Fam-trp : (A : setoid) -> (B : classoid) -> (S : BFam A B) -> (a b : || A ||) 
+BFam-Fam-trp : (A : setoid) -> (B : classoid) -> (S : BFam A B) -> (a b : || A ||)
     -> ( p : < A > a ~ b)
     -> || BFam-Fam-std A B S a => BFam-Fam-std A B S b ||
 BFam-Fam-trp A B S a b p =
     let lm : equal-subsetoids (S • a) (S • b)
-        lm = >><< (extensionality1 S _ _ p) 
+        lm = >><< (extensionality1 S _ _ p)
     in  (θ (S • a) (S • b) (prj1 lm))
 
 
 
 
 BFam-Fam : (A : setoid) -> (B : classoid) -> (S : BFam A B) -> Fam A
-BFam-Fam A B S = record { std = λ x → BFam-Fam-std A B S x  
-                        ; trp = λ {a} {b} p → BFam-Fam-trp A B S a b p 
-                        ; id-trp = λ {a} p x → >< (θ-id (ap1 S a) ((prj1 (>><< (extensionality1 S _ _ p))))) x  
-                        ; ir-trp = λ {a} {b} p q x → >< (θ-ir (ap1 S a ) (ap1 S b) 
-                                                          (prj1 (>><< (extensionality1 S _ _ p))) 
-                                                          (prj1 (>><< (extensionality1 S _ _ q)))) x 
+BFam-Fam A B S = record { std = λ x → BFam-Fam-std A B S x
+                        ; trp = λ {a} {b} p → BFam-Fam-trp A B S a b p
+                        ; id-trp = λ {a} p x → >< (θ-id (ap1 S a) ((prj1 (>><< (extensionality1 S _ _ p))))) x
+                        ; ir-trp = λ {a} {b} p q x → >< (θ-ir (ap1 S a ) (ap1 S b)
+                                                          (prj1 (>><< (extensionality1 S _ _ p)))
+                                                          (prj1 (>><< (extensionality1 S _ _ q)))) x
                         ; fn-trp = λ {a} {b} {c} q p r x → >< (θ-fn (ap1 S a) (ap1 S b) (ap1 S c )
-                                                               (prj1 (>><< (extensionality1 S _ _ p))) 
-                                                               (prj1 (>><< (extensionality1 S _ _ q))) 
-                                                               (prj1 (>><<(extensionality1 S _ _ r)))) x 
-                        } 
+                                                               (prj1 (>><< (extensionality1 S _ _ p)))
+                                                               (prj1 (>><< (extensionality1 S _ _ q)))
+                                                               (prj1 (>><<(extensionality1 S _ _ r)))) x
+                        }
 
 {--
-extensionality1 : {A : setoid} -> {B : classoid} -> (f : setoidmap1 A B) -> (x y : || A ||) -> 
+extensionality1 : {A : setoid} -> {B : classoid} -> (f : setoidmap1 A B) -> (x y : || A ||) ->
              (< A > x ~ y) ->  (<< B >> (f • x) ~ (f • y))
 --}
 
 
-global-member-element-op : (A : setoid) -> (B : classoid) -> (S : BFam A B) -> (f : setoidmap1 A B) -> 
+global-member-element-op : (A : setoid) -> (B : classoid) -> (S : BFam A B) -> (f : setoidmap1 A B) ->
   (p : global-member f S) -> (x : || A ||) -> || BFam-Fam A B S § x ||
 global-member-element-op A B S f p x =  pj1 (p x)
 
 
 
-global-member-element : (A : setoid) -> (B : classoid) -> (S : BFam A B) -> (f : setoidmap1 A B) -> 
+global-member-element : (A : setoid) -> (B : classoid) -> (S : BFam A B) -> (f : setoidmap1 A B) ->
   (p : global-member f S) -> || Π-std A (BFam-Fam A B S) ||
-global-member-element A B S f p 
-      = (global-member-element-op A B S f p) , 
-         (λ x y q ->  
+global-member-element A B S f p
+      = (global-member-element-op A B S f p) ,
+         (λ x y q ->
            let lm1 : << B >> ap1 (ι (ap1 S x)) (pj1 (p x)) ~ ap1 f x
                lm1 = pj2 (p x)
                lm2 : << B >> ap1 (ι (ap1 S y)) (pj1 (p y)) ~ ap1 f y
                lm2 = pj2 (p y)
                lm3 : << B >>  ap1 f x ~ ap1 f y
-               lm3 = extensionality1 f x y q 
+               lm3 = extensionality1 f x y q
                lm4 : << B >> ap1 (ι (ap1 S x)) (pj1 (p x)) ~ ap1 (ι (ap1 S y)) (pj1 (p y))
                lm4 = tra' lm1 (tra' lm3 (sym' lm2))
-               lm5 :  exteq1 (ι (ap1 S x)) (comp1 (ι (ap1 S y)) (θ (ap1 S x) (ap1 S y) 
+               lm5 :  exteq1 (ι (ap1 S x)) (comp1 (ι (ap1 S y)) (θ (ap1 S x) (ap1 S y)
                                 (prj1 (>><< (extensionality1 S _ _ q)))))
-               lm5 = θ-prop (ap1 S x) (ap1 S y) (prj1 (>><< (extensionality1 S _ _ q))) 
+               lm5 = θ-prop (ap1 S x) (ap1 S y) (prj1 (>><< (extensionality1 S _ _ q)))
                lm6 : << B >> ap1 (ι (ap1 S x)) (pj1 (p x)) ~
                              ap1 (comp1 (ι (ap1 S y))
                                          (θ (ap1 S x) (ap1 S y) (prj1 (>><< (extensionality1 S x y q)))))
                                  (pj1 (p x))
                lm6 = lm5 (pj1 (p x))
-               main'' :  << B >>   ap1 (ι (ap1 S y)) (ap (θ (ap1 S x) (ap1 S y) 
-                                      (prj1 (>><< (extensionality1 S _ _ q)))) (pj1 (p x)))  
+               main'' :  << B >>   ap1 (ι (ap1 S y)) (ap (θ (ap1 S x) (ap1 S y)
+                                      (prj1 (>><< (extensionality1 S _ _ q)))) (pj1 (p x)))
                               ~  ap1 (ι (ap1 S y)) (pj1 (p y))
                main'' = sym' {B} (tra' {B} (sym' {B} lm4) lm6)
-               main' : < δ (ap1 S y) >  ap (θ (ap1 S x) (ap1 S y) 
+               main' : < δ (ap1 S y) >  ap (θ (ap1 S x) (ap1 S y)
                                          (prj1 (>><< (extensionality1 S _ _ q)))) (pj1 (p x)) ~ (pj1 (p y))
                main' = ι-inj (ap1 S y)  _ _  main''
                main : < δ (ap1 S y) >  ap (BFam-Fam A B S ± q) (pj1 (p x)) ~ (pj1 (p y))
@@ -375,7 +375,7 @@ global-member-element A B S f p
 --        lm = extensionality1 S _ _ p
 --    in  (θ (ap1 S a) (ap1 S b) (prj1 lm))
 
--- θ-prop : {B : classoid} -> (S  T : subsetoid B) -> (p : inclusion-subsetoids S T) -> 
+-- θ-prop : {B : classoid} -> (S  T : subsetoid B) -> (p : inclusion-subsetoids S T) ->
 --    exteq1 (ι S) (comp1 (ι T) (θ S T p))
 -- θ-prop S T p =  pj2 p
 


### PR DESCRIPTION
[ MLTT-and-setoids ] README.agda: executable version of README.txt

According to my experiments, this development checks fine with Agda 2.5.2 and 2.5.3.  Earlier versions do not support the projection overloading, later versions takes ages for type-checking (or loop).
